### PR TITLE
impl(generator/rust)!: prepare to support additional bindings

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -157,6 +157,7 @@ type methodAnnotation struct {
 	SystemParameters    []systemParameter
 	ReturnType          string
 	HasVeneer           bool
+	Attributes          []string
 }
 
 type pathInfoAnnotation struct {
@@ -564,6 +565,11 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		SystemParameters:    c.systemParameters,
 		ReturnType:          returnType,
 		HasVeneer:           c.hasVeneer,
+	}
+	if annotation.Name == "clone" {
+		// Some methods look too similar to standard Rust traits. Clippy makes
+		// a recommendation that is not applicable to generated code.
+		annotation.Attributes = []string{"#[allow(clippy::should_implement_trait)]"}
 	}
 	if m.OperationInfo != nil {
 		metadataType := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, sourceSpecificationPackageName)

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -925,9 +925,33 @@ func derefFieldPath(fieldPath string, message *api.Message, state *api.APIState)
 	return expression.String()
 }
 
+func typezFieldPath(fieldPath string, message *api.Message, state *api.APIState) api.Typez {
+	typez := api.UNDEFINED_TYPE
+	components := strings.Split(fieldPath, ".")
+	msg := message
+	for _, name := range components {
+		if msg == nil {
+			slog.Error("cannot build full expression", "fieldPath", fieldPath, "message", msg)
+			return typez
+		}
+		for _, field := range message.Fields {
+			if name != field.Name {
+				continue
+			}
+			typez = field.Typez
+			if field.Typez == api.MESSAGE_TYPE {
+				msg = state.MessageByID[field.TypezID]
+			}
+			break
+		}
+	}
+	return typez
+}
+
 type pathArg struct {
-	Name     string
-	Accessor string
+	Name          string
+	Accessor      string
+	CheckForEmpty bool
 }
 
 func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pathArg {
@@ -939,9 +963,11 @@ func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pa
 	var params []pathArg
 	for _, arg := range h.Bindings[0].PathTemplate {
 		if arg.FieldPath != nil {
+			leafTypez := typezFieldPath(*arg.FieldPath, message, state)
 			params = append(params, pathArg{
-				Name:     *arg.FieldPath,
-				Accessor: derefFieldPath(*arg.FieldPath, message, state),
+				Name:          *arg.FieldPath,
+				Accessor:      derefFieldPath(*arg.FieldPath, message, state),
+				CheckForEmpty: leafTypez == api.STRING_TYPE,
 			})
 		}
 	}

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -925,16 +925,16 @@ func derefFieldPath(fieldPath string, message *api.Message, state *api.APIState)
 	return expression.String()
 }
 
-func typezFieldPath(fieldPath string, message *api.Message, state *api.APIState) api.Typez {
+func leafFieldTypez(fieldPath string, message *api.Message, state *api.APIState) api.Typez {
 	typez := api.UNDEFINED_TYPE
 	components := strings.Split(fieldPath, ".")
 	msg := message
 	for _, name := range components {
 		if msg == nil {
-			slog.Error("cannot build full expression", "fieldPath", fieldPath, "message", msg)
+			slog.Error("cannot find leaf field type", "fieldPath", fieldPath, "message", msg)
 			return typez
 		}
-		for _, field := range message.Fields {
+		for _, field := range msg.Fields {
 			if name != field.Name {
 				continue
 			}
@@ -963,7 +963,7 @@ func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pa
 	var params []pathArg
 	for _, arg := range h.Bindings[0].PathTemplate {
 		if arg.FieldPath != nil {
-			leafTypez := typezFieldPath(*arg.FieldPath, message, state)
+			leafTypez := leafFieldTypez(*arg.FieldPath, message, state)
 			params = append(params, pathArg{
 				Name:          *arg.FieldPath,
 				Accessor:      derefFieldPath(*arg.FieldPath, message, state),

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -2167,11 +2167,11 @@ func TestPathArgs(t *testing.T) {
 		Name: "CreateResourceRequest",
 		ID:   ".test.CreateResourceRequest",
 		Fields: []*api.Field{
-			{Name: "a", Typez: api.STRING_TYPE},
-			{Name: "b", Typez: api.STRING_TYPE, Optional: true},
-			{Name: "c", Typez: api.ENUM_TYPE},
-			{Name: "d", Typez: api.ENUM_TYPE, Optional: true},
-			{Name: "e", Typez: api.MESSAGE_TYPE, TypezID: ".test.Body", Optional: true},
+			{Name: "v", Typez: api.STRING_TYPE},
+			{Name: "w", Typez: api.STRING_TYPE, Optional: true},
+			{Name: "x", Typez: api.ENUM_TYPE},
+			{Name: "y", Typez: api.ENUM_TYPE, Optional: true},
+			{Name: "z", Typez: api.MESSAGE_TYPE, TypezID: ".test.Body", Optional: true},
 		},
 	}
 	method := &api.Method{
@@ -2198,13 +2198,13 @@ func TestPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]pathArg{{Name: "a", Accessor: ".a", CheckForEmpty: true}},
+			[]pathArg{{Name: "v", Accessor: ".v", CheckForEmpty: true}},
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("a"),
+							api.NewFieldPathPathSegment("v"),
 						},
 					},
 				},
@@ -2213,8 +2213,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:          "b",
-					Accessor:      `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					Name:          "w",
+					Accessor:      `.w.as_ref().ok_or_else(|| gaxi::path_parameter::missing("w"))?`,
 					CheckForEmpty: true,
 				},
 			},
@@ -2223,20 +2223,20 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("b"),
+							api.NewFieldPathPathSegment("w"),
 						},
 					},
 				},
 			},
 		},
 		{
-			[]pathArg{{Name: "c", Accessor: `.c`}},
+			[]pathArg{{Name: "x", Accessor: `.x`}},
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("c"),
+							api.NewFieldPathPathSegment("x"),
 						},
 					},
 				},
@@ -2245,8 +2245,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:     "d",
-					Accessor: `.d.as_ref().ok_or_else(|| gaxi::path_parameter::missing("d"))?`,
+					Name:     "y",
+					Accessor: `.y.as_ref().ok_or_else(|| gaxi::path_parameter::missing("y"))?`,
 				},
 			},
 			&api.PathInfo{
@@ -2254,7 +2254,7 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("d"),
+							api.NewFieldPathPathSegment("y"),
 						},
 					},
 				},
@@ -2263,8 +2263,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:          "e.a",
-					Accessor:      `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?.a`,
+					Name:          "z.a",
+					Accessor:      `.z.as_ref().ok_or_else(|| gaxi::path_parameter::missing("z"))?.a`,
 					CheckForEmpty: true,
 				},
 			},
@@ -2273,7 +2273,7 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("e.a"),
+							api.NewFieldPathPathSegment("z.a"),
 						},
 					},
 				},
@@ -2282,8 +2282,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name: "e.b",
-					Accessor: `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?` +
+					Name: "z.b",
+					Accessor: `.z.as_ref().ok_or_else(|| gaxi::path_parameter::missing("z"))?` +
 						`.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
 					CheckForEmpty: true,
 				},
@@ -2293,7 +2293,7 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("e.b"),
+							api.NewFieldPathPathSegment("z.b"),
 						},
 					},
 				},
@@ -2302,8 +2302,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:     "e.c",
-					Accessor: `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?.c`,
+					Name:     "z.c",
+					Accessor: `.z.as_ref().ok_or_else(|| gaxi::path_parameter::missing("z"))?.c`,
 				},
 			},
 			&api.PathInfo{
@@ -2311,7 +2311,7 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("e.c"),
+							api.NewFieldPathPathSegment("z.c"),
 						},
 					},
 				},
@@ -2320,8 +2320,8 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name: "e.d",
-					Accessor: `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?` +
+					Name: "z.d",
+					Accessor: `.z.as_ref().ok_or_else(|| gaxi::path_parameter::missing("z"))?` +
 						`.d.as_ref().ok_or_else(|| gaxi::path_parameter::missing("d"))?`,
 				},
 			},
@@ -2330,7 +2330,7 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("e.d"),
+							api.NewFieldPathPathSegment("z.d"),
 						},
 					},
 				},
@@ -2339,13 +2339,13 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:          "a",
-					Accessor:      ".a",
+					Name:          "v",
+					Accessor:      ".v",
 					CheckForEmpty: true,
 				},
 				{
-					Name:          "b",
-					Accessor:      `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					Name:          "w",
+					Accessor:      `.w.as_ref().ok_or_else(|| gaxi::path_parameter::missing("w"))?`,
 					CheckForEmpty: true,
 				},
 			},
@@ -2354,8 +2354,8 @@ func TestPathArgs(t *testing.T) {
 					{
 						PathTemplate: []api.PathSegment{
 							api.NewLiteralPathSegment("v1"),
-							api.NewFieldPathPathSegment("a"),
-							api.NewFieldPathPathSegment("b"),
+							api.NewFieldPathPathSegment("v"),
+							api.NewFieldPathPathSegment("w"),
 						},
 					},
 				},

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -2198,7 +2198,7 @@ func TestPathArgs(t *testing.T) {
 			},
 		},
 		{
-			[]pathArg{{Name: "a", Accessor: ".a"}},
+			[]pathArg{{Name: "a", Accessor: ".a", CheckForEmpty: true}},
 			&api.PathInfo{
 				Bindings: []*api.PathBinding{
 					{
@@ -2213,8 +2213,9 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:     "b",
-					Accessor: `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					Name:          "b",
+					Accessor:      `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					CheckForEmpty: true,
 				},
 			},
 			&api.PathInfo{
@@ -2262,8 +2263,9 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:     "e.a",
-					Accessor: `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?.a`,
+					Name:          "e.a",
+					Accessor:      `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?.a`,
+					CheckForEmpty: true,
 				},
 			},
 			&api.PathInfo{
@@ -2283,6 +2285,7 @@ func TestPathArgs(t *testing.T) {
 					Name: "e.b",
 					Accessor: `.e.as_ref().ok_or_else(|| gaxi::path_parameter::missing("e"))?` +
 						`.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					CheckForEmpty: true,
 				},
 			},
 			&api.PathInfo{
@@ -2336,12 +2339,14 @@ func TestPathArgs(t *testing.T) {
 		{
 			[]pathArg{
 				{
-					Name:     "a",
-					Accessor: ".a",
+					Name:          "a",
+					Accessor:      ".a",
+					CheckForEmpty: true,
 				},
 				{
-					Name:     "b",
-					Accessor: `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					Name:          "b",
+					Accessor:      `.b.as_ref().ok_or_else(|| gaxi::path_parameter::missing("b"))?`,
+					CheckForEmpty: true,
 				},
 			},
 			&api.PathInfo{

--- a/generator/internal/rust/templates/crate/src/client.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/client.rs.mustache
@@ -153,17 +153,12 @@ impl {{Codec.Name}} {
     {{#Deprecated}}
     #[deprecated]
     {{/Deprecated}}
-    pub fn {{Codec.Name}}(
-        &self,
-        {{#Codec.PathParams}}
-        {{{Codec.FieldName}}}: impl Into<{{{Codec.PrimitiveFieldType}}}>,
-        {{/Codec.PathParams}}
-    ) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
+    {{#Codec.Attributes}}
+    {{{.}}}
+    {{/Codec.Attributes}}
+    pub fn {{Codec.Name}}(&self) -> super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}
     {
         super::builder::{{Codec.ServiceNameToSnake}}::{{Codec.BuilderName}}::new(self.inner.clone())
-        {{#Codec.PathParams}}
-            .set_{{Codec.SetterName}} ( {{Codec.FieldName}}.into() )
-        {{/Codec.PathParams}}
     }
     {{/Codec.Methods}}
 }

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -72,22 +72,32 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             options,
             {{PathInfo.Codec.IsIdempotent}},
         );
+        let path =
+            {{^PathInfo.Codec.HasPathArgs}}
+            {{! Sometimes there are no path args and `format!()` produces warnings }}
+            "{{PathInfo.Codec.PathFmt}}".to_string();
+            {{/PathInfo.Codec.HasPathArgs}}
+            {{#PathInfo.Codec.HasPathArgs}}
+            format!("{{PathInfo.Codec.PathFmt}}",
+                {{#PathInfo.Codec.PathArgs}}
+                    {
+                        {{#CheckForEmpty}}
+                        let arg = &req{{{Accessor}}};
+                        if arg.is_empty() {
+                            return Err(gaxi::path_parameter::missing("{{Name}}"));
+                        }
+                        arg
+                        {{/CheckForEmpty}}
+                        {{^CheckForEmpty}}
+                        &req{{{Accessor}}}
+                        {{/CheckForEmpty}}
+                    },
+                {{/PathInfo.Codec.PathArgs}}
+            );
+            {{/PathInfo.Codec.HasPathArgs}};
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::{{PathInfo.Codec.Method}},
-                {{^PathInfo.Codec.HasPathArgs}}
-                {{! Sometimes there are no path args and `format!()` produces warnings }}
-                "{{PathInfo.Codec.PathFmt}}".to_string()
-                {{/PathInfo.Codec.HasPathArgs}}
-                {{#PathInfo.Codec.HasPathArgs}}
-                format!("{{PathInfo.Codec.PathFmt}}"
-                    {{#PathInfo.Codec.PathArgs}}
-                        , req{{{Accessor}}}
-                    {{/PathInfo.Codec.PathArgs}}
-                )
-                {{/PathInfo.Codec.HasPathArgs}}
-            )
+            .builder(reqwest::Method::{{PathInfo.Codec.Method}}, path)
             {{#Codec.SystemParameters}}
             .query(&[("{{Name}}", "{{Value}}")])
             {{/Codec.SystemParameters}}

--- a/guide/samples/src/bin/getting_started.rs
+++ b/guide/samples/src/bin/getting_started.rs
@@ -21,7 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = SecretManagerService::builder().build().await?;
 
     let mut items = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_item();
     while let Some(item) = items.next().await {
         println!("{}", item?.name);

--- a/guide/samples/src/error_handling.rs
+++ b/guide/samples/src/error_handling.rs
@@ -74,7 +74,8 @@ async fn update_attempt(
 ) -> gax::Result<sm::model::SecretVersion> {
     let checksum = crc32c::crc32c(&data) as i64;
     client
-        .add_secret_version(format!("projects/{project_id}/secrets/{secret_id}"))
+        .add_secret_version()
+        .set_parent(format!("projects/{project_id}/secrets/{secret_id}"))
         .set_payload(
             sm::model::SecretPayload::new()
                 .set_data(data)
@@ -97,7 +98,8 @@ pub async fn create_secret(
     use std::time::Duration;
 
     client
-        .create_secret(format!("projects/{project_id}"))
+        .create_secret()
+        .set_parent(format!("projects/{project_id}"))
         .with_retry_policy(
             AlwaysRetry
                 .with_attempt_limit(5)

--- a/guide/samples/src/gemini.rs
+++ b/guide/samples/src/gemini.rs
@@ -30,7 +30,7 @@ pub async fn text_prompt(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: text-prompt-request
     let response = client
-        .generate_content(&model)
+        .generate_content().set_model(&model)
         .set_contents([vertexai::model::Content::new().set_role("user").set_parts([
             vertexai::model::Part::new().set_text("What's a good name for a flower shop that specializes in selling bouquets of dried flowers?"),
         ])])
@@ -61,7 +61,8 @@ pub async fn prompt_and_image(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: prompt-and-image-request
     let response = client
-        .generate_content(&model)
+        .generate_content()
+        .set_model(&model)
         .set_contents(
             [vertexai::model::Content::new().set_role("user").set_parts([
                 // ANCHOR: prompt-and-image-image-part

--- a/guide/samples/src/lro.rs
+++ b/guide/samples/src/lro.rs
@@ -25,7 +25,8 @@ pub async fn start(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: request-builder
     let operation = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         // ANCHOR_END: request-builder
@@ -74,7 +75,8 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
     let client = speech::client::Speech::builder().build().await?;
 
     let response = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         .set_files([speech::model::BatchRecognizeFileMetadata::new()
@@ -116,7 +118,8 @@ pub async fn polling(project_id: &str) -> crate::Result<()> {
     let client = speech::client::Speech::builder().build().await?;
 
     let mut poller = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         .set_files([speech::model::BatchRecognizeFileMetadata::new()
@@ -207,7 +210,12 @@ pub async fn manually_poll_lro(
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         // ANCHOR_END: manual-backoff
         // ANCHOR: manual-poll-again
-        if let Ok(attempt) = client.get_operation(operation.name.clone()).send().await {
+        if let Ok(attempt) = client
+            .get_operation()
+            .set_name(&operation.name)
+            .send()
+            .await
+        {
             operation = attempt;
         }
         // ANCHOR_END: manual-poll-again

--- a/guide/samples/src/pagination.rs
+++ b/guide/samples/src/pagination.rs
@@ -26,7 +26,8 @@ pub async fn paginator_iterate_pages(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: paginator-iterate-pages
     let mut list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_page();
     while let Some(page) = list.next().await {
         let page = page?;
@@ -51,7 +52,8 @@ pub async fn paginator_stream_pages(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: paginator-stream-pages
     let list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_page()
         .into_stream();
     list.enumerate()
@@ -80,7 +82,8 @@ pub async fn paginator_iterate_items(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: paginator-iterate-items
     let mut list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_item();
     while let Some(secret) = list.next().await {
         let secret = secret?;
@@ -102,7 +105,8 @@ pub async fn paginator_stream_items(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: paginator-stream-items
     let list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_item()
         .into_stream();
     list.map(|secret| -> gax::Result<()> {
@@ -127,7 +131,8 @@ pub async fn pagination_page_token(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: paginator-page-token
     let page = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .send()
         .await;
     let page = page?;
@@ -140,7 +145,8 @@ pub async fn pagination_page_token(project_id: &str) -> crate::Result<()> {
         println!("  next_page_token={}", next_page_token);
 
         let page = client
-            .list_secrets(format!("projects/{project_id}"))
+            .list_secrets()
+            .set_parent(format!("projects/{project_id}"))
             .set_page_token(next_page_token)
             .send()
             .await;

--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -40,7 +40,8 @@ pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: client-backoff-builder
     let response = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         // ANCHOR_END: client-backoff-builder
@@ -90,7 +91,8 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: rpc-backoff-builder
     let response = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         // ANCHOR_END: rpc-backoff-builder
@@ -153,7 +155,8 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: client-errors-builder
     let response = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         // ANCHOR_END: client-errors-builder
@@ -204,7 +207,8 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: rpc-errors-builder
     let response = client
-        .batch_recognize(format!(
+        .batch_recognize()
+        .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
         // ANCHOR_END: rpc-errors-builder

--- a/guide/samples/src/retry_policies.rs
+++ b/guide/samples/src/retry_policies.rs
@@ -29,7 +29,8 @@ pub async fn client_retry(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: client-retry-request
     let mut list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_item();
     while let Some(secret) = list.next().await {
         let secret = secret?;
@@ -62,7 +63,8 @@ pub async fn client_retry_full(project_id: &str) -> crate::Result<()> {
 
     // ANCHOR: client-retry-full-request
     let mut list = client
-        .list_secrets(format!("projects/{project_id}"))
+        .list_secrets()
+        .set_parent(format!("projects/{project_id}"))
         .by_item();
     while let Some(secret) = list.next().await {
         let secret = secret?;
@@ -88,7 +90,8 @@ pub async fn request_retry(
 
     // ANCHOR: request-retry-request
     client
-        .delete_secret(format!("projects/{project_id}/secrets/{secret_id}"))
+        .delete_secret()
+        .set_name(format!("projects/{project_id}/secrets/{secret_id}"))
         .with_retry_policy(
             AlwaysRetry
                 .with_attempt_limit(5)

--- a/guide/samples/tests/driver.rs
+++ b/guide/samples/tests/driver.rs
@@ -167,9 +167,14 @@ mod driver {
             "The quick brown fox jumps over the lazy dog".into(),
         )
         .await?;
-        let _ = client.destroy_secret_version(&version.name).send().await?;
         let _ = client
-            .delete_secret(format!("projects/{project_id}/secrets/{secret_id}"))
+            .destroy_secret_version()
+            .set_name(&version.name)
+            .send()
+            .await?;
+        let _ = client
+            .delete_secret()
+            .set_name(format!("projects/{project_id}/secrets/{secret_id}"))
             .send()
             .await?;
         Ok(())
@@ -204,9 +209,14 @@ mod driver {
             )
             .build()
             .await?;
-        let _ = client.destroy_secret_version(&version.name).send().await?;
         let _ = client
-            .delete_secret(format!("projects/{project_id}/secrets/{secret_id}"))
+            .destroy_secret_version()
+            .set_name(&version.name)
+            .send()
+            .await?;
+        let _ = client
+            .delete_secret()
+            .set_name(format!("projects/{project_id}/secrets/{secret_id}"))
             .send()
             .await?;
         Ok(())

--- a/guide/samples/tests/initialize_client.rs
+++ b/guide/samples/tests/initialize_client.rs
@@ -31,7 +31,8 @@ pub async fn initialize_client(project_id: &str) -> Result {
     // ANCHOR: make-rpc
     use google_cloud_gax::paginator::Paginator as _;
     let mut items = client
-        .list_locations(format!("projects/{project_id}"))
+        .list_locations()
+        .set_name(format!("projects/{project_id}"))
         .by_page();
     while let Some(page) = items.next().await {
         let page = page?;

--- a/guide/samples/tests/mocking.rs
+++ b/guide/samples/tests/mocking.rs
@@ -33,7 +33,8 @@ mod test {
     // display name of the recognizer.
     async fn my_application_function(client: &speech::client::Speech) -> gax::Result<String> {
         client
-            .get_recognizer("invalid-test-recognizer")
+            .get_recognizer()
+            .set_name("invalid-test-recognizer")
             .send()
             .await
             .map(|r| r.display_name)

--- a/guide/samples/tests/mocking_lros_auto.rs
+++ b/guide/samples/tests/mocking_lros_auto.rs
@@ -40,7 +40,8 @@ mod my_application {
     ) -> Result<Option<wkt::Duration>> {
         use speech::Poller;
         client
-            .batch_recognize(format!(
+            .batch_recognize()
+            .set_recognizer(format!(
                 "projects/{project_id}/locations/global/recognizers/_"
             ))
             .poller()

--- a/guide/samples/tests/mocking_lros_error.rs
+++ b/guide/samples/tests/mocking_lros_error.rs
@@ -51,7 +51,8 @@ mod my_application {
         use speech::Poller;
         let mut progress_updates = Vec::new();
         let mut poller = client
-            .batch_recognize(format!(
+            .batch_recognize()
+            .set_recognizer(format!(
                 "projects/{project_id}/locations/global/recognizers/_"
             ))
             .poller();

--- a/guide/samples/tests/mocking_lros_manual.rs
+++ b/guide/samples/tests/mocking_lros_manual.rs
@@ -51,7 +51,8 @@ mod my_application {
         use speech::Poller;
         let mut progress_updates = Vec::new();
         let mut poller = client
-            .batch_recognize(format!(
+            .batch_recognize()
+            .set_recognizer(format!(
                 "projects/{project_id}/locations/global/recognizers/_"
             ))
             .poller();

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -34,7 +34,8 @@ pub async fn service_account() -> Result<()> {
     // Load the ADC json for the principal under test, in this case, a
     // service account.
     let response = client
-        .access_secret_version(format!(
+        .access_secret_version()
+        .set_name(format!(
             "projects/{}/secrets/test-sa-creds-json/versions/latest",
             project
         ))
@@ -64,7 +65,8 @@ pub async fn service_account() -> Result<()> {
 
     // Access a secret, which only this principal has permissions to do.
     let response = client
-        .access_secret_version(format!(
+        .access_secret_version()
+        .set_name(format!(
             "projects/{}/secrets/test-sa-creds-secret/versions/latest",
             project
         ))
@@ -88,7 +90,8 @@ pub async fn api_key() -> Result<()> {
 
     // Load the API key under test.
     let response = client
-        .access_secret_version(format!(
+        .access_secret_version()
+        .set_name(format!(
             "projects/{}/secrets/test-api-key/versions/latest",
             project
         ))

--- a/src/firestore/src/generated/gapic/client.rs
+++ b/src/firestore/src/generated/gapic/client.rs
@@ -126,83 +126,50 @@ impl Firestore {
     }
 
     /// Gets a single document.
-    pub fn get_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore::GetDocument {
-        super::builder::firestore::GetDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn get_document(&self) -> super::builder::firestore::GetDocument {
+        super::builder::firestore::GetDocument::new(self.inner.clone())
     }
 
     /// Lists documents.
-    pub fn list_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-        collection_id: impl Into<std::string::String>,
-    ) -> super::builder::firestore::ListDocuments {
+    pub fn list_documents(&self) -> super::builder::firestore::ListDocuments {
         super::builder::firestore::ListDocuments::new(self.inner.clone())
-            .set_parent(parent.into())
-            .set_collection_id(collection_id.into())
     }
 
     /// Updates or inserts a document.
-    pub fn update_document(
-        &self,
-        document: impl Into<crate::model::Document>,
-    ) -> super::builder::firestore::UpdateDocument {
+    pub fn update_document(&self) -> super::builder::firestore::UpdateDocument {
         super::builder::firestore::UpdateDocument::new(self.inner.clone())
-            .set_document(document.into())
     }
 
     /// Deletes a document.
-    pub fn delete_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore::DeleteDocument {
-        super::builder::firestore::DeleteDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_document(&self) -> super::builder::firestore::DeleteDocument {
+        super::builder::firestore::DeleteDocument::new(self.inner.clone())
     }
 
     /// Starts a new transaction.
-    pub fn begin_transaction(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::firestore::BeginTransaction {
+    pub fn begin_transaction(&self) -> super::builder::firestore::BeginTransaction {
         super::builder::firestore::BeginTransaction::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Commits a transaction, while optionally updating documents.
-    pub fn commit(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::firestore::Commit {
-        super::builder::firestore::Commit::new(self.inner.clone()).set_database(database.into())
+    pub fn commit(&self) -> super::builder::firestore::Commit {
+        super::builder::firestore::Commit::new(self.inner.clone())
     }
 
     /// Rolls back a transaction.
-    pub fn rollback(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::firestore::Rollback {
-        super::builder::firestore::Rollback::new(self.inner.clone()).set_database(database.into())
+    pub fn rollback(&self) -> super::builder::firestore::Rollback {
+        super::builder::firestore::Rollback::new(self.inner.clone())
     }
 
     /// Partitions a query by returning partition cursors that can be used to run
     /// the query in parallel. The returned partition cursors are split points that
     /// can be used by RunQuery as starting/end points for the query results.
-    pub fn partition_query(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore::PartitionQuery {
-        super::builder::firestore::PartitionQuery::new(self.inner.clone()).set_parent(parent.into())
+    pub fn partition_query(&self) -> super::builder::firestore::PartitionQuery {
+        super::builder::firestore::PartitionQuery::new(self.inner.clone())
     }
 
     /// Lists all the collection IDs underneath a document.
-    pub fn list_collection_ids(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore::ListCollectionIds {
+    pub fn list_collection_ids(&self) -> super::builder::firestore::ListCollectionIds {
         super::builder::firestore::ListCollectionIds::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Applies a batch of write operations.
@@ -218,21 +185,12 @@ impl Firestore {
     ///
     /// [google.firestore.v1.BatchWriteResponse]: crate::model::BatchWriteResponse
     /// [google.firestore.v1.Firestore.Commit]: crate::client::Firestore::commit
-    pub fn batch_write(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::firestore::BatchWrite {
-        super::builder::firestore::BatchWrite::new(self.inner.clone()).set_database(database.into())
+    pub fn batch_write(&self) -> super::builder::firestore::BatchWrite {
+        super::builder::firestore::BatchWrite::new(self.inner.clone())
     }
 
     /// Creates a new document.
-    pub fn create_document(
-        &self,
-        parent: impl Into<std::string::String>,
-        collection_id: impl Into<std::string::String>,
-    ) -> super::builder::firestore::CreateDocument {
+    pub fn create_document(&self) -> super::builder::firestore::CreateDocument {
         super::builder::firestore::CreateDocument::new(self.inner.clone())
-            .set_parent(parent.into())
-            .set_collection_id(collection_id.into())
     }
 }

--- a/src/generated/api/apikeys/v2/src/client.rs
+++ b/src/generated/api/apikeys/v2/src/client.rs
@@ -132,11 +132,8 @@ impl ApiKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::CreateKey {
-        super::builder::api_keys::CreateKey::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_key(&self) -> super::builder::api_keys::CreateKey {
+        super::builder::api_keys::CreateKey::new(self.inner.clone())
     }
 
     /// Lists the API keys owned by a project. The key string of the API key
@@ -144,11 +141,8 @@ impl ApiKeys {
     ///
     /// NOTE: Key is a global resource; hence the only supported value for
     /// location is `global`.
-    pub fn list_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::ListKeys {
-        super::builder::api_keys::ListKeys::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_keys(&self) -> super::builder::api_keys::ListKeys {
+        super::builder::api_keys::ListKeys::new(self.inner.clone())
     }
 
     /// Gets the metadata for an API key. The key string of the API key
@@ -156,22 +150,16 @@ impl ApiKeys {
     ///
     /// NOTE: Key is a global resource; hence the only supported value for
     /// location is `global`.
-    pub fn get_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::GetKey {
-        super::builder::api_keys::GetKey::new(self.inner.clone()).set_name(name.into())
+    pub fn get_key(&self) -> super::builder::api_keys::GetKey {
+        super::builder::api_keys::GetKey::new(self.inner.clone())
     }
 
     /// Get the key string for an API key.
     ///
     /// NOTE: Key is a global resource; hence the only supported value for
     /// location is `global`.
-    pub fn get_key_string(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::GetKeyString {
-        super::builder::api_keys::GetKeyString::new(self.inner.clone()).set_name(name.into())
+    pub fn get_key_string(&self) -> super::builder::api_keys::GetKeyString {
+        super::builder::api_keys::GetKeyString::new(self.inner.clone())
     }
 
     /// Patches the modifiable fields of an API key.
@@ -189,11 +177,8 @@ impl ApiKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_key(
-        &self,
-        key: impl Into<crate::model::Key>,
-    ) -> super::builder::api_keys::UpdateKey {
-        super::builder::api_keys::UpdateKey::new(self.inner.clone()).set_key(key.into())
+    pub fn update_key(&self) -> super::builder::api_keys::UpdateKey {
+        super::builder::api_keys::UpdateKey::new(self.inner.clone())
     }
 
     /// Deletes an API key. Deleted key can be retrieved within 30 days of
@@ -211,11 +196,8 @@ impl ApiKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::DeleteKey {
-        super::builder::api_keys::DeleteKey::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_key(&self) -> super::builder::api_keys::DeleteKey {
+        super::builder::api_keys::DeleteKey::new(self.inner.clone())
     }
 
     /// Undeletes an API key which was deleted within 30 days.
@@ -232,11 +214,8 @@ impl ApiKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::UndeleteKey {
-        super::builder::api_keys::UndeleteKey::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_key(&self) -> super::builder::api_keys::UndeleteKey {
+        super::builder::api_keys::UndeleteKey::new(self.inner.clone())
     }
 
     /// Find the parent project and resource name of the API
@@ -251,10 +230,7 @@ impl ApiKeys {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_keys::GetOperation {
-        super::builder::api_keys::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::api_keys::GetOperation {
+        super::builder::api_keys::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -153,10 +153,15 @@ impl super::stub::ApiKeys for ApiKeys {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.key
+            let arg = &req
+                .key
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("key"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("key.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/keys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/keys", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -64,9 +71,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/keys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/keys", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +100,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,9 +126,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetKeyStringResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/keyString", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/keyString", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,18 +152,15 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.key
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("key"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.key
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("key"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -156,9 +181,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,9 +208,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +232,10 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupKeyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v2/keys:lookupKey".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v2/keys:lookupKey".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,9 +253,16 @@ impl super::stub::ApiKeys for ApiKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/api/servicecontrol/v1/src/client.rs
+++ b/src/generated/api/servicecontrol/v1/src/client.rs
@@ -134,12 +134,8 @@ impl QuotaController {
     /// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
     /// reliability, the server may inject these errors to prohibit any hard
     /// dependency on the quota functionality.
-    pub fn allocate_quota(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::quota_controller::AllocateQuota {
+    pub fn allocate_quota(&self) -> super::builder::quota_controller::AllocateQuota {
         super::builder::quota_controller::AllocateQuota::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 }
 
@@ -267,12 +263,8 @@ impl ServiceController {
     /// [Cloud IAM](https://cloud.google.com/iam).
     ///
     /// [google.api.servicecontrol.v1.CheckRequest]: crate::model::CheckRequest
-    pub fn check(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_controller::Check {
+    pub fn check(&self) -> super::builder::service_controller::Check {
         super::builder::service_controller::Check::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Reports operation results to Google Service Control, such as logs and
@@ -292,11 +284,7 @@ impl ServiceController {
     /// [Google Cloud IAM](https://cloud.google.com/iam).
     ///
     /// [google.api.servicecontrol.v1.ReportRequest]: crate::model::ReportRequest
-    pub fn report(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_controller::Report {
+    pub fn report(&self) -> super::builder::service_controller::Report {
         super::builder::service_controller::Report::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 }

--- a/src/generated/api/servicecontrol/v1/src/transport.rs
+++ b/src/generated/api/servicecontrol/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::QuotaController for QuotaController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AllocateQuotaResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}:allocateQuota", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}:allocateQuota", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +93,16 @@ impl super::stub::ServiceController for ServiceController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}:check", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}:check", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -109,12 +117,16 @@ impl super::stub::ServiceController for ServiceController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}:report", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}:report", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/api/servicecontrol/v2/src/client.rs
+++ b/src/generated/api/servicecontrol/v2/src/client.rs
@@ -149,12 +149,8 @@ impl ServiceController {
     /// on the specified service. For more information, see
     /// [Service Control API Access
     /// Control](https://cloud.google.com/service-infrastructure/docs/service-control/access-control).
-    pub fn check(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_controller::Check {
+    pub fn check(&self) -> super::builder::service_controller::Check {
         super::builder::service_controller::Check::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Private Preview. This feature is only available for approved services.
@@ -175,11 +171,7 @@ impl ServiceController {
     /// on the specified service. For more information, see
     /// [Service Control API Access
     /// Control](https://cloud.google.com/service-infrastructure/docs/service-control/access-control).
-    pub fn report(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_controller::Report {
+    pub fn report(&self) -> super::builder::service_controller::Report {
         super::builder::service_controller::Report::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 }

--- a/src/generated/api/servicecontrol/v2/src/transport.rs
+++ b/src/generated/api/servicecontrol/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ServiceController for ServiceController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/services/{}:check", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/services/{}:check", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::ServiceController for ServiceController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/services/{}:report", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/services/{}:report", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/api/servicemanagement/v1/src/client.rs
+++ b/src/generated/api/servicemanagement/v1/src/client.rs
@@ -130,12 +130,8 @@ impl ServiceManager {
 
     /// Gets a managed service. Authentication is required unless the service is
     /// public.
-    pub fn get_service(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::GetService {
+    pub fn get_service(&self) -> super::builder::service_manager::GetService {
         super::builder::service_manager::GetService::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Creates a new managed service.
@@ -183,12 +179,8 @@ impl ServiceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::DeleteService {
+    pub fn delete_service(&self) -> super::builder::service_manager::DeleteService {
         super::builder::service_manager::DeleteService::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Revives a previously deleted managed service. The method restores the
@@ -207,33 +199,19 @@ impl ServiceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_service(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::UndeleteService {
+    pub fn undelete_service(&self) -> super::builder::service_manager::UndeleteService {
         super::builder::service_manager::UndeleteService::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Lists the history of the service configuration for a managed service,
     /// from the newest to the oldest.
-    pub fn list_service_configs(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::ListServiceConfigs {
+    pub fn list_service_configs(&self) -> super::builder::service_manager::ListServiceConfigs {
         super::builder::service_manager::ListServiceConfigs::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Gets a service configuration (version) for a managed service.
-    pub fn get_service_config(
-        &self,
-        service_name: impl Into<std::string::String>,
-        config_id: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::GetServiceConfig {
+    pub fn get_service_config(&self) -> super::builder::service_manager::GetServiceConfig {
         super::builder::service_manager::GetServiceConfig::new(self.inner.clone())
-            .set_service_name(service_name.into())
-            .set_config_id(config_id.into())
     }
 
     /// Creates a new service configuration (version) for a managed service.
@@ -246,12 +224,8 @@ impl ServiceManager {
     /// eventually.
     ///
     /// [google.api.servicemanagement.v1.ServiceManager.CreateServiceRollout]: crate::client::ServiceManager::create_service_rollout
-    pub fn create_service_config(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::CreateServiceConfig {
+    pub fn create_service_config(&self) -> super::builder::service_manager::CreateServiceConfig {
         super::builder::service_manager::CreateServiceConfig::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Creates a new service configuration (version) for a managed service based
@@ -280,36 +254,22 @@ impl ServiceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn submit_config_source(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::SubmitConfigSource {
+    pub fn submit_config_source(&self) -> super::builder::service_manager::SubmitConfigSource {
         super::builder::service_manager::SubmitConfigSource::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Lists the history of the service configuration rollouts for a managed
     /// service, from the newest to the oldest.
-    pub fn list_service_rollouts(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::ListServiceRollouts {
+    pub fn list_service_rollouts(&self) -> super::builder::service_manager::ListServiceRollouts {
         super::builder::service_manager::ListServiceRollouts::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Gets a service configuration
     /// [rollout][google.api.servicemanagement.v1.Rollout].
     ///
     /// [google.api.servicemanagement.v1.Rollout]: crate::model::Rollout
-    pub fn get_service_rollout(
-        &self,
-        service_name: impl Into<std::string::String>,
-        rollout_id: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::GetServiceRollout {
+    pub fn get_service_rollout(&self) -> super::builder::service_manager::GetServiceRollout {
         super::builder::service_manager::GetServiceRollout::new(self.inner.clone())
-            .set_service_name(service_name.into())
-            .set_rollout_id(rollout_id.into())
     }
 
     /// Creates a new service configuration rollout. Based on rollout, the
@@ -336,12 +296,8 @@ impl ServiceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_service_rollout(
-        &self,
-        service_name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::CreateServiceRollout {
+    pub fn create_service_rollout(&self) -> super::builder::service_manager::CreateServiceRollout {
         super::builder::service_manager::CreateServiceRollout::new(self.inner.clone())
-            .set_service_name(service_name.into())
     }
 
     /// Generates and returns a report (errors, warnings and changes from
@@ -364,22 +320,14 @@ impl ServiceManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::service_manager::SetIamPolicy {
         super::builder::service_manager::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::service_manager::GetIamPolicy {
         super::builder::service_manager::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -389,12 +337,8 @@ impl ServiceManager {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::service_manager::TestIamPermissions {
         super::builder::service_manager::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists service operations that match the specified filter in the request.
@@ -405,10 +349,7 @@ impl ServiceManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_manager::GetOperation {
-        super::builder::service_manager::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::service_manager::GetOperation {
+        super::builder::service_manager::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/services".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/services".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +70,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ManagedService>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/services/{}", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/services/{}", req.service_name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +96,10 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/services".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/services".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,12 +116,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/services/{}", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v1/services/{}", req.service_name),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -132,12 +142,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}:undelete", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}:undelete", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -154,12 +168,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/services/{}/configs", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/services/{}/configs", req.service_name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,15 +196,26 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/services/{}/configs/{}",
+            {
+                let arg = &req.service_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("service_name"));
+                }
+                arg
+            },
+            {
+                let arg = &req.config_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("config_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/services/{}/configs/{}",
-                    req.service_name, req.config_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,12 +233,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}/configs", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}/configs", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,12 +259,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}/configs:submit", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}/configs:submit", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,12 +283,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceRolloutsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/services/{}/rollouts", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/services/{}/rollouts", req.service_name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,15 +312,26 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rollout>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/services/{}/rollouts/{}",
+            {
+                let arg = &req.service_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("service_name"));
+                }
+                arg
+            },
+            {
+                let arg = &req.rollout_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("rollout_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/services/{}/rollouts/{}",
-                    req.service_name, req.rollout_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -296,12 +348,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/services/{}/rollouts", {
+            let arg = &req.service_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/services/{}/rollouts", req.service_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,12 +374,10 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateConfigReportResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/services:generateConfigReport".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/services:generateConfigReport".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,12 +392,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,12 +416,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -378,12 +440,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -398,9 +464,10 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,9 +488,16 @@ impl super::stub::ServiceManager for ServiceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/api/serviceusage/v1/src/client.rs
+++ b/src/generated/api/serviceusage/v1/src/client.rs
@@ -133,11 +133,8 @@ impl ServiceUsage {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn enable_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::EnableService {
-        super::builder::service_usage::EnableService::new(self.inner.clone()).set_name(name.into())
+    pub fn enable_service(&self) -> super::builder::service_usage::EnableService {
+        super::builder::service_usage::EnableService::new(self.inner.clone())
     }
 
     /// Disable a service so that it can no longer be used with a project.
@@ -157,19 +154,13 @@ impl ServiceUsage {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn disable_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::DisableService {
-        super::builder::service_usage::DisableService::new(self.inner.clone()).set_name(name.into())
+    pub fn disable_service(&self) -> super::builder::service_usage::DisableService {
+        super::builder::service_usage::DisableService::new(self.inner.clone())
     }
 
     /// Returns the service configuration and enabled state for a given service.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::GetService {
-        super::builder::service_usage::GetService::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service(&self) -> super::builder::service_usage::GetService {
+        super::builder::service_usage::GetService::new(self.inner.clone())
     }
 
     /// List all services available to the specified project, and the current
@@ -185,12 +176,8 @@ impl ServiceUsage {
     /// [Cloud Asset Inventory
     /// API](https://cloud.google.com/asset-inventory/docs/apis), which provides
     /// higher throughput and richer filtering capability.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::ListServices {
+    pub fn list_services(&self) -> super::builder::service_usage::ListServices {
         super::builder::service_usage::ListServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Enable multiple services on a project. The operation is atomic: if enabling
@@ -206,22 +193,14 @@ impl ServiceUsage {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_enable_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::BatchEnableServices {
+    pub fn batch_enable_services(&self) -> super::builder::service_usage::BatchEnableServices {
         super::builder::service_usage::BatchEnableServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the service configurations and enabled states for a given list of
     /// services.
-    pub fn batch_get_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::BatchGetServices {
+    pub fn batch_get_services(&self) -> super::builder::service_usage::BatchGetServices {
         super::builder::service_usage::BatchGetServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -234,10 +213,7 @@ impl ServiceUsage {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_usage::GetOperation {
-        super::builder::service_usage::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::service_usage::GetOperation {
+        super::builder::service_usage::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/api/serviceusage/v1/src/transport.rs
+++ b/src/generated/api/serviceusage/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +70,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -80,9 +94,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -99,9 +120,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,12 +149,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/services:batchEnable", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/services:batchEnable", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -141,12 +173,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchGetServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services:batchGet", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/services:batchGet", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,9 +203,10 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,9 +227,16 @@ impl super::stub::ServiceUsage for ServiceUsage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/appengine/v1/src/client.rs
+++ b/src/generated/appengine/v1/src/client.rs
@@ -119,11 +119,8 @@ impl Applications {
     }
 
     /// Gets information about an application.
-    pub fn get_application(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::applications::GetApplication {
-        super::builder::applications::GetApplication::new(self.inner.clone()).set_name(name.into())
+    pub fn get_application(&self) -> super::builder::applications::GetApplication {
+        super::builder::applications::GetApplication::new(self.inner.clone())
     }
 
     /// Creates an App Engine application for a Google Cloud Platform project.
@@ -163,12 +160,8 @@ impl Applications {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_application(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::applications::UpdateApplication {
+    pub fn update_application(&self) -> super::builder::applications::UpdateApplication {
         super::builder::applications::UpdateApplication::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Recreates the required App Engine features for the specified App Engine
@@ -191,32 +184,22 @@ impl Applications {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn repair_application(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::applications::RepairApplication {
+    pub fn repair_application(&self) -> super::builder::applications::RepairApplication {
         super::builder::applications::RepairApplication::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::applications::ListOperations {
-        super::builder::applications::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::applications::ListOperations {
+        super::builder::applications::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::applications::GetOperation {
-        super::builder::applications::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::applications::GetOperation {
+        super::builder::applications::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -321,19 +304,13 @@ impl Services {
     }
 
     /// Lists all the services in the application.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::services::ListServices {
-        super::builder::services::ListServices::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_services(&self) -> super::builder::services::ListServices {
+        super::builder::services::ListServices::new(self.inner.clone())
     }
 
     /// Gets the current configuration of the specified service.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::GetService {
-        super::builder::services::GetService::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service(&self) -> super::builder::services::GetService {
+        super::builder::services::GetService::new(self.inner.clone())
     }
 
     /// Updates the configuration of the specified service.
@@ -347,11 +324,8 @@ impl Services {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::UpdateService {
-        super::builder::services::UpdateService::new(self.inner.clone()).set_name(name.into())
+    pub fn update_service(&self) -> super::builder::services::UpdateService {
+        super::builder::services::UpdateService::new(self.inner.clone())
     }
 
     /// Deletes the specified service and all enclosed versions.
@@ -365,31 +339,22 @@ impl Services {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::DeleteService {
-        super::builder::services::DeleteService::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_service(&self) -> super::builder::services::DeleteService {
+        super::builder::services::DeleteService::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::ListOperations {
-        super::builder::services::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::services::ListOperations {
+        super::builder::services::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::GetOperation {
-        super::builder::services::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::services::GetOperation {
+        super::builder::services::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -494,21 +459,15 @@ impl Versions {
     }
 
     /// Lists the versions of a service.
-    pub fn list_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListVersions {
-        super::builder::versions::ListVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_versions(&self) -> super::builder::versions::ListVersions {
+        super::builder::versions::ListVersions::new(self.inner.clone())
     }
 
     /// Gets the specified Version resource.
     /// By default, only a `BASIC_VIEW` will be returned.
     /// Specify the `FULL_VIEW` parameter to get the full resource.
-    pub fn get_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetVersion {
-        super::builder::versions::GetVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_version(&self) -> super::builder::versions::GetVersion {
+        super::builder::versions::GetVersion::new(self.inner.clone())
     }
 
     /// Deploys code and resource files to a new version.
@@ -522,11 +481,8 @@ impl Versions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::CreateVersion {
-        super::builder::versions::CreateVersion::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_version(&self) -> super::builder::versions::CreateVersion {
+        super::builder::versions::CreateVersion::new(self.inner.clone())
     }
 
     /// Updates the specified Version resource.
@@ -575,11 +531,8 @@ impl Versions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::UpdateVersion {
-        super::builder::versions::UpdateVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn update_version(&self) -> super::builder::versions::UpdateVersion {
+        super::builder::versions::UpdateVersion::new(self.inner.clone())
     }
 
     /// Deletes an existing Version resource.
@@ -593,31 +546,22 @@ impl Versions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::DeleteVersion {
-        super::builder::versions::DeleteVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_version(&self) -> super::builder::versions::DeleteVersion {
+        super::builder::versions::DeleteVersion::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListOperations {
-        super::builder::versions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::versions::ListOperations {
+        super::builder::versions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetOperation {
-        super::builder::versions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::versions::GetOperation {
+        super::builder::versions::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -725,19 +669,13 @@ impl Instances {
     ///
     /// Tip: To aggregate details about instances over time, see the
     /// [Stackdriver Monitoring API](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::instances::ListInstances {
-        super::builder::instances::ListInstances::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_instances(&self) -> super::builder::instances::ListInstances {
+        super::builder::instances::ListInstances::new(self.inner.clone())
     }
 
     /// Gets instance information.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instances::GetInstance {
-        super::builder::instances::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::instances::GetInstance {
+        super::builder::instances::GetInstance::new(self.inner.clone())
     }
 
     /// Stops a running instance.
@@ -762,11 +700,8 @@ impl Instances {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instances::DeleteInstance {
-        super::builder::instances::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::instances::DeleteInstance {
+        super::builder::instances::DeleteInstance::new(self.inner.clone())
     }
 
     /// Enables debugging on a VM instance. This allows you to use the SSH
@@ -787,31 +722,22 @@ impl Instances {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn debug_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instances::DebugInstance {
-        super::builder::instances::DebugInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn debug_instance(&self) -> super::builder::instances::DebugInstance {
+        super::builder::instances::DebugInstance::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instances::ListOperations {
-        super::builder::instances::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::instances::ListOperations {
+        super::builder::instances::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instances::GetOperation {
-        super::builder::instances::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::instances::GetOperation {
+        super::builder::instances::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -925,12 +851,8 @@ impl Firewall {
     }
 
     /// Lists the firewall rules of an application.
-    pub fn list_ingress_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firewall::ListIngressRules {
+    pub fn list_ingress_rules(&self) -> super::builder::firewall::ListIngressRules {
         super::builder::firewall::ListIngressRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Replaces the entire firewall ruleset in one bulk operation. This overrides
@@ -938,65 +860,42 @@ impl Firewall {
     ///
     /// If the final rule does not match traffic with the '*' wildcard IP range,
     /// then an "allow all" rule is explicitly added to the end of the list.
-    pub fn batch_update_ingress_rules(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::BatchUpdateIngressRules {
+    pub fn batch_update_ingress_rules(&self) -> super::builder::firewall::BatchUpdateIngressRules {
         super::builder::firewall::BatchUpdateIngressRules::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a firewall rule for the application.
-    pub fn create_ingress_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firewall::CreateIngressRule {
+    pub fn create_ingress_rule(&self) -> super::builder::firewall::CreateIngressRule {
         super::builder::firewall::CreateIngressRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the specified firewall rule.
-    pub fn get_ingress_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::GetIngressRule {
-        super::builder::firewall::GetIngressRule::new(self.inner.clone()).set_name(name.into())
+    pub fn get_ingress_rule(&self) -> super::builder::firewall::GetIngressRule {
+        super::builder::firewall::GetIngressRule::new(self.inner.clone())
     }
 
     /// Updates the specified firewall rule.
-    pub fn update_ingress_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::UpdateIngressRule {
-        super::builder::firewall::UpdateIngressRule::new(self.inner.clone()).set_name(name.into())
+    pub fn update_ingress_rule(&self) -> super::builder::firewall::UpdateIngressRule {
+        super::builder::firewall::UpdateIngressRule::new(self.inner.clone())
     }
 
     /// Deletes the specified firewall rule.
-    pub fn delete_ingress_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::DeleteIngressRule {
-        super::builder::firewall::DeleteIngressRule::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_ingress_rule(&self) -> super::builder::firewall::DeleteIngressRule {
+        super::builder::firewall::DeleteIngressRule::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::ListOperations {
-        super::builder::firewall::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::firewall::ListOperations {
+        super::builder::firewall::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firewall::GetOperation {
-        super::builder::firewall::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::firewall::GetOperation {
+        super::builder::firewall::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1107,32 +1006,22 @@ impl AuthorizedDomains {
     /// Lists all domains the user is authorized to administer.
     pub fn list_authorized_domains(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::authorized_domains::ListAuthorizedDomains {
         super::builder::authorized_domains::ListAuthorizedDomains::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::authorized_domains::ListOperations {
+    pub fn list_operations(&self) -> super::builder::authorized_domains::ListOperations {
         super::builder::authorized_domains::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::authorized_domains::GetOperation {
+    pub fn get_operation(&self) -> super::builder::authorized_domains::GetOperation {
         super::builder::authorized_domains::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1242,30 +1131,24 @@ impl AuthorizedCertificates {
     /// Lists all SSL certificates the user is authorized to administer.
     pub fn list_authorized_certificates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::authorized_certificates::ListAuthorizedCertificates {
         super::builder::authorized_certificates::ListAuthorizedCertificates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the specified SSL certificate.
     pub fn get_authorized_certificate(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::authorized_certificates::GetAuthorizedCertificate {
         super::builder::authorized_certificates::GetAuthorizedCertificate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Uploads the specified SSL certificate.
     pub fn create_authorized_certificate(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::authorized_certificates::CreateAuthorizedCertificate {
         super::builder::authorized_certificates::CreateAuthorizedCertificate::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the specified SSL certificate. To renew a certificate and maintain
@@ -1275,45 +1158,33 @@ impl AuthorizedCertificates {
     /// updated.
     pub fn update_authorized_certificate(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::authorized_certificates::UpdateAuthorizedCertificate {
         super::builder::authorized_certificates::UpdateAuthorizedCertificate::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Deletes the specified SSL certificate.
     pub fn delete_authorized_certificate(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::authorized_certificates::DeleteAuthorizedCertificate {
         super::builder::authorized_certificates::DeleteAuthorizedCertificate::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::authorized_certificates::ListOperations {
+    pub fn list_operations(&self) -> super::builder::authorized_certificates::ListOperations {
         super::builder::authorized_certificates::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::authorized_certificates::GetOperation {
+    pub fn get_operation(&self) -> super::builder::authorized_certificates::GetOperation {
         super::builder::authorized_certificates::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1418,21 +1289,13 @@ impl DomainMappings {
     }
 
     /// Lists the domain mappings on an application.
-    pub fn list_domain_mappings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::ListDomainMappings {
+    pub fn list_domain_mappings(&self) -> super::builder::domain_mappings::ListDomainMappings {
         super::builder::domain_mappings::ListDomainMappings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the specified domain mapping.
-    pub fn get_domain_mapping(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::GetDomainMapping {
+    pub fn get_domain_mapping(&self) -> super::builder::domain_mappings::GetDomainMapping {
         super::builder::domain_mappings::GetDomainMapping::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Maps a domain to an application. A user must be authorized to administer a
@@ -1448,12 +1311,8 @@ impl DomainMappings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_domain_mapping(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::CreateDomainMapping {
+    pub fn create_domain_mapping(&self) -> super::builder::domain_mappings::CreateDomainMapping {
         super::builder::domain_mappings::CreateDomainMapping::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified domain mapping. To map an SSL certificate to a
@@ -1470,12 +1329,8 @@ impl DomainMappings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_domain_mapping(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::UpdateDomainMapping {
+    pub fn update_domain_mapping(&self) -> super::builder::domain_mappings::UpdateDomainMapping {
         super::builder::domain_mappings::UpdateDomainMapping::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified domain mapping. A user must be authorized to
@@ -1491,32 +1346,21 @@ impl DomainMappings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_domain_mapping(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::DeleteDomainMapping {
+    pub fn delete_domain_mapping(&self) -> super::builder::domain_mappings::DeleteDomainMapping {
         super::builder::domain_mappings::DeleteDomainMapping::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::ListOperations {
+    pub fn list_operations(&self) -> super::builder::domain_mappings::ListOperations {
         super::builder::domain_mappings::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domain_mappings::GetOperation {
-        super::builder::domain_mappings::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::domain_mappings::GetOperation {
+        super::builder::domain_mappings::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Application>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,10 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/apps".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/apps".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -84,9 +92,16 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -109,9 +124,16 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:repair", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:repair", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -126,9 +148,16 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +177,16 @@ impl super::stub::Applications for Applications {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,9 +240,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,9 +268,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -244,9 +294,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +327,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -289,9 +353,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -311,9 +382,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -367,9 +445,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,9 +474,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,12 +501,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/versions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -431,9 +527,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -456,9 +559,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -475,9 +585,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -497,9 +614,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -553,12 +677,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -577,9 +705,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,9 +731,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -615,9 +757,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:debug", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:debug", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -632,9 +781,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -654,9 +810,16 @@ impl super::stub::Instances for Instances {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -710,12 +873,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIngressRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/firewall/ingressRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/firewall/ingressRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -735,12 +902,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchUpdateIngressRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchUpdate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchUpdate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -755,12 +926,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/firewall/ingressRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/firewall/ingressRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -775,9 +950,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -794,9 +976,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -817,9 +1006,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -840,9 +1036,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -862,9 +1065,16 @@ impl super::stub::Firewall for Firewall {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -904,12 +1114,16 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAuthorizedDomainsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/authorizedDomains", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/authorizedDomains", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -928,9 +1142,16 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -950,9 +1171,16 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -992,12 +1220,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAuthorizedCertificatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/authorizedCertificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/authorizedCertificates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1017,9 +1249,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizedCertificate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1037,12 +1276,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizedCertificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/authorizedCertificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/authorizedCertificates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1059,9 +1302,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizedCertificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1084,9 +1334,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1107,9 +1364,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1129,9 +1393,16 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1171,12 +1442,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDomainMappingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/domainMappings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/domainMappings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1195,9 +1470,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DomainMapping>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1214,12 +1496,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/domainMappings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/domainMappings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1237,9 +1523,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1262,9 +1555,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1281,9 +1581,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1303,9 +1610,16 @@ impl super::stub::DomainMappings for DomainMappings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/bigtable/admin/v2/src/client.rs
+++ b/src/generated/bigtable/admin/v2/src/client.rs
@@ -139,41 +139,25 @@ impl BigtableInstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::bigtable_instance_admin::CreateInstance {
         super::builder::bigtable_instance_admin::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about an instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetInstance {
+    pub fn get_instance(&self) -> super::builder::bigtable_instance_admin::GetInstance {
         super::builder::bigtable_instance_admin::GetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about instances in a project.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListInstances {
+    pub fn list_instances(&self) -> super::builder::bigtable_instance_admin::ListInstances {
         super::builder::bigtable_instance_admin::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an instance within a project. This method updates only the display
     /// name and type for an Instance. To update other Instance properties, such as
     /// labels, use PartialUpdateInstance.
-    pub fn update_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::bigtable_instance_admin::UpdateInstance {
         super::builder::bigtable_instance_admin::UpdateInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Partially updates an instance within a project. This method can modify all
@@ -190,19 +174,13 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn partial_update_instance(
         &self,
-        instance: impl Into<crate::model::Instance>,
     ) -> super::builder::bigtable_instance_admin::PartialUpdateInstance {
         super::builder::bigtable_instance_admin::PartialUpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Delete an instance from a project.
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::bigtable_instance_admin::DeleteInstance {
         super::builder::bigtable_instance_admin::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a cluster within an instance.
@@ -222,30 +200,18 @@ impl BigtableInstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::bigtable_instance_admin::CreateCluster {
         super::builder::bigtable_instance_admin::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a cluster.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetCluster {
+    pub fn get_cluster(&self) -> super::builder::bigtable_instance_admin::GetCluster {
         super::builder::bigtable_instance_admin::GetCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about clusters in an instance.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::bigtable_instance_admin::ListClusters {
         super::builder::bigtable_instance_admin::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a cluster within an instance.
@@ -263,12 +229,8 @@ impl BigtableInstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::bigtable_instance_admin::UpdateCluster {
         super::builder::bigtable_instance_admin::UpdateCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Partially updates a cluster within a project. This method is the preferred
@@ -295,46 +257,28 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn partial_update_cluster(
         &self,
-        cluster: impl Into<crate::model::Cluster>,
     ) -> super::builder::bigtable_instance_admin::PartialUpdateCluster {
         super::builder::bigtable_instance_admin::PartialUpdateCluster::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Deletes a cluster from an instance.
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::DeleteCluster {
+    pub fn delete_cluster(&self) -> super::builder::bigtable_instance_admin::DeleteCluster {
         super::builder::bigtable_instance_admin::DeleteCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an app profile within an instance.
-    pub fn create_app_profile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::CreateAppProfile {
+    pub fn create_app_profile(&self) -> super::builder::bigtable_instance_admin::CreateAppProfile {
         super::builder::bigtable_instance_admin::CreateAppProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about an app profile.
-    pub fn get_app_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetAppProfile {
+    pub fn get_app_profile(&self) -> super::builder::bigtable_instance_admin::GetAppProfile {
         super::builder::bigtable_instance_admin::GetAppProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about app profiles in an instance.
-    pub fn list_app_profiles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListAppProfiles {
+    pub fn list_app_profiles(&self) -> super::builder::bigtable_instance_admin::ListAppProfiles {
         super::builder::bigtable_instance_admin::ListAppProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an app profile within an instance.
@@ -348,60 +292,38 @@ impl BigtableInstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_app_profile(
-        &self,
-        app_profile: impl Into<crate::model::AppProfile>,
-    ) -> super::builder::bigtable_instance_admin::UpdateAppProfile {
+    pub fn update_app_profile(&self) -> super::builder::bigtable_instance_admin::UpdateAppProfile {
         super::builder::bigtable_instance_admin::UpdateAppProfile::new(self.inner.clone())
-            .set_app_profile(app_profile.into())
     }
 
     /// Deletes an app profile from an instance.
-    pub fn delete_app_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::DeleteAppProfile {
+    pub fn delete_app_profile(&self) -> super::builder::bigtable_instance_admin::DeleteAppProfile {
         super::builder::bigtable_instance_admin::DeleteAppProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the access control policy for an instance resource. Returns an empty
     /// policy if an instance exists but does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::bigtable_instance_admin::GetIamPolicy {
         super::builder::bigtable_instance_admin::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on an instance resource. Replaces any
     /// existing policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::bigtable_instance_admin::SetIamPolicy {
         super::builder::bigtable_instance_admin::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that the caller has on the specified instance resource.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::TestIamPermissions {
         super::builder::bigtable_instance_admin::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists hot tablets in a cluster, within the time range provided. Hot
     /// tablets are ordered based on CPU usage.
-    pub fn list_hot_tablets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListHotTablets {
+    pub fn list_hot_tablets(&self) -> super::builder::bigtable_instance_admin::ListHotTablets {
         super::builder::bigtable_instance_admin::ListHotTablets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a logical view within an instance.
@@ -417,28 +339,18 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_logical_view(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::CreateLogicalView {
         super::builder::bigtable_instance_admin::CreateLogicalView::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a logical view.
-    pub fn get_logical_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetLogicalView {
+    pub fn get_logical_view(&self) -> super::builder::bigtable_instance_admin::GetLogicalView {
         super::builder::bigtable_instance_admin::GetLogicalView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about logical views in an instance.
-    pub fn list_logical_views(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListLogicalViews {
+    pub fn list_logical_views(&self) -> super::builder::bigtable_instance_admin::ListLogicalViews {
         super::builder::bigtable_instance_admin::ListLogicalViews::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a logical view within an instance.
@@ -454,19 +366,15 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_logical_view(
         &self,
-        logical_view: impl Into<crate::model::LogicalView>,
     ) -> super::builder::bigtable_instance_admin::UpdateLogicalView {
         super::builder::bigtable_instance_admin::UpdateLogicalView::new(self.inner.clone())
-            .set_logical_view(logical_view.into())
     }
 
     /// Deletes a logical view from an instance.
     pub fn delete_logical_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::DeleteLogicalView {
         super::builder::bigtable_instance_admin::DeleteLogicalView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a materialized view within an instance.
@@ -482,28 +390,22 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_materialized_view(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::CreateMaterializedView {
         super::builder::bigtable_instance_admin::CreateMaterializedView::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a materialized view.
     pub fn get_materialized_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::GetMaterializedView {
         super::builder::bigtable_instance_admin::GetMaterializedView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about materialized views in an instance.
     pub fn list_materialized_views(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::ListMaterializedViews {
         super::builder::bigtable_instance_admin::ListMaterializedViews::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a materialized view within an instance.
@@ -519,63 +421,43 @@ impl BigtableInstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_materialized_view(
         &self,
-        materialized_view: impl Into<crate::model::MaterializedView>,
     ) -> super::builder::bigtable_instance_admin::UpdateMaterializedView {
         super::builder::bigtable_instance_admin::UpdateMaterializedView::new(self.inner.clone())
-            .set_materialized_view(materialized_view.into())
     }
 
     /// Deletes a materialized view from an instance.
     pub fn delete_materialized_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_instance_admin::DeleteMaterializedView {
         super::builder::bigtable_instance_admin::DeleteMaterializedView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::bigtable_instance_admin::ListOperations {
         super::builder::bigtable_instance_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::GetOperation {
+    pub fn get_operation(&self) -> super::builder::bigtable_instance_admin::GetOperation {
         super::builder::bigtable_instance_admin::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::bigtable_instance_admin::DeleteOperation {
         super::builder::bigtable_instance_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_instance_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::bigtable_instance_admin::CancelOperation {
         super::builder::bigtable_instance_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -687,12 +569,8 @@ impl BigtableTableAdmin {
     /// Creates a new table in the specified instance.
     /// The table can be created with a full set of initial column families,
     /// specified in the request.
-    pub fn create_table(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::CreateTable {
+    pub fn create_table(&self) -> super::builder::bigtable_table_admin::CreateTable {
         super::builder::bigtable_table_admin::CreateTable::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new table from the specified snapshot. The target table must
@@ -715,28 +593,18 @@ impl BigtableTableAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_table_from_snapshot(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::CreateTableFromSnapshot {
         super::builder::bigtable_table_admin::CreateTableFromSnapshot::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all tables served from a specified instance.
-    pub fn list_tables(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::ListTables {
+    pub fn list_tables(&self) -> super::builder::bigtable_table_admin::ListTables {
         super::builder::bigtable_table_admin::ListTables::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata information about the specified table.
-    pub fn get_table(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetTable {
+    pub fn get_table(&self) -> super::builder::bigtable_table_admin::GetTable {
         super::builder::bigtable_table_admin::GetTable::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a specified table.
@@ -750,21 +618,13 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_table(
-        &self,
-        table: impl Into<crate::model::Table>,
-    ) -> super::builder::bigtable_table_admin::UpdateTable {
+    pub fn update_table(&self) -> super::builder::bigtable_table_admin::UpdateTable {
         super::builder::bigtable_table_admin::UpdateTable::new(self.inner.clone())
-            .set_table(table.into())
     }
 
     /// Permanently deletes a specified table and all of its data.
-    pub fn delete_table(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::DeleteTable {
+    pub fn delete_table(&self) -> super::builder::bigtable_table_admin::DeleteTable {
         super::builder::bigtable_table_admin::DeleteTable::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restores a specified table which was accidentally deleted.
@@ -778,12 +638,8 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_table(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::UndeleteTable {
+    pub fn undelete_table(&self) -> super::builder::bigtable_table_admin::UndeleteTable {
         super::builder::bigtable_table_admin::UndeleteTable::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new AuthorizedView in a table.
@@ -799,28 +655,20 @@ impl BigtableTableAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_authorized_view(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::CreateAuthorizedView {
         super::builder::bigtable_table_admin::CreateAuthorizedView::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all AuthorizedViews from a specific table.
     pub fn list_authorized_views(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::ListAuthorizedViews {
         super::builder::bigtable_table_admin::ListAuthorizedViews::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information from a specified AuthorizedView.
-    pub fn get_authorized_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetAuthorizedView {
+    pub fn get_authorized_view(&self) -> super::builder::bigtable_table_admin::GetAuthorizedView {
         super::builder::bigtable_table_admin::GetAuthorizedView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an AuthorizedView in a table.
@@ -836,19 +684,15 @@ impl BigtableTableAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_authorized_view(
         &self,
-        authorized_view: impl Into<crate::model::AuthorizedView>,
     ) -> super::builder::bigtable_table_admin::UpdateAuthorizedView {
         super::builder::bigtable_table_admin::UpdateAuthorizedView::new(self.inner.clone())
-            .set_authorized_view(authorized_view.into())
     }
 
     /// Permanently deletes a specified AuthorizedView.
     pub fn delete_authorized_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::DeleteAuthorizedView {
         super::builder::bigtable_table_admin::DeleteAuthorizedView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Performs a series of column family modifications on the specified table.
@@ -857,21 +701,15 @@ impl BigtableTableAdmin {
     /// where only some modifications have taken effect.
     pub fn modify_column_families(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::ModifyColumnFamilies {
         super::builder::bigtable_table_admin::ModifyColumnFamilies::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Permanently drop/delete a row range from a specified table. The request can
     /// specify whether to delete all rows in a table, or only those that match a
     /// particular prefix.
-    pub fn drop_row_range(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::DropRowRange {
+    pub fn drop_row_range(&self) -> super::builder::bigtable_table_admin::DropRowRange {
         super::builder::bigtable_table_admin::DropRowRange::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates a consistency token for a Table, which can be used in
@@ -880,21 +718,15 @@ impl BigtableTableAdmin {
     /// for 90 days.
     pub fn generate_consistency_token(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bigtable_table_admin::GenerateConsistencyToken {
         super::builder::bigtable_table_admin::GenerateConsistencyToken::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Checks replication consistency based on a consistency token, that is, if
     /// replication has caught up based on the conditions specified in the token
     /// and the check request.
-    pub fn check_consistency(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::CheckConsistency {
+    pub fn check_consistency(&self) -> super::builder::bigtable_table_admin::CheckConsistency {
         super::builder::bigtable_table_admin::CheckConsistency::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new snapshot in the specified cluster from the specified
@@ -915,12 +747,8 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn snapshot_table(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::SnapshotTable {
+    pub fn snapshot_table(&self) -> super::builder::bigtable_table_admin::SnapshotTable {
         super::builder::bigtable_table_admin::SnapshotTable::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets metadata information about the specified snapshot.
@@ -930,12 +758,8 @@ impl BigtableTableAdmin {
     /// feature might be changed in backward-incompatible ways and is not
     /// recommended for production use. It is not subject to any SLA or deprecation
     /// policy.
-    pub fn get_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetSnapshot {
+    pub fn get_snapshot(&self) -> super::builder::bigtable_table_admin::GetSnapshot {
         super::builder::bigtable_table_admin::GetSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all snapshots associated with the specified cluster.
@@ -945,12 +769,8 @@ impl BigtableTableAdmin {
     /// feature might be changed in backward-incompatible ways and is not
     /// recommended for production use. It is not subject to any SLA or deprecation
     /// policy.
-    pub fn list_snapshots(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::ListSnapshots {
+    pub fn list_snapshots(&self) -> super::builder::bigtable_table_admin::ListSnapshots {
         super::builder::bigtable_table_admin::ListSnapshots::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Permanently deletes the specified snapshot.
@@ -960,12 +780,8 @@ impl BigtableTableAdmin {
     /// feature might be changed in backward-incompatible ways and is not
     /// recommended for production use. It is not subject to any SLA or deprecation
     /// policy.
-    pub fn delete_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::DeleteSnapshot {
+    pub fn delete_snapshot(&self) -> super::builder::bigtable_table_admin::DeleteSnapshot {
         super::builder::bigtable_table_admin::DeleteSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts creating a new Cloud Bigtable Backup.  The returned backup
@@ -992,49 +808,29 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::bigtable_table_admin::CreateBackup {
         super::builder::bigtable_table_admin::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata on a pending or completed Cloud Bigtable Backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetBackup {
+    pub fn get_backup(&self) -> super::builder::bigtable_table_admin::GetBackup {
         super::builder::bigtable_table_admin::GetBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a pending or completed Cloud Bigtable Backup.
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::bigtable_table_admin::UpdateBackup {
+    pub fn update_backup(&self) -> super::builder::bigtable_table_admin::UpdateBackup {
         super::builder::bigtable_table_admin::UpdateBackup::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Deletes a pending or completed Cloud Bigtable backup.
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::DeleteBackup {
+    pub fn delete_backup(&self) -> super::builder::bigtable_table_admin::DeleteBackup {
         super::builder::bigtable_table_admin::DeleteBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Cloud Bigtable backups. Returns both completed and pending
     /// backups.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::ListBackups {
+    pub fn list_backups(&self) -> super::builder::bigtable_table_admin::ListBackups {
         super::builder::bigtable_table_admin::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new table by restoring from a completed backup.  The
@@ -1060,12 +856,8 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_table(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::RestoreTable {
+    pub fn restore_table(&self) -> super::builder::bigtable_table_admin::RestoreTable {
         super::builder::bigtable_table_admin::RestoreTable::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Copy a Cloud Bigtable backup to a new backup in the destination cluster
@@ -1080,86 +872,54 @@ impl BigtableTableAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn copy_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::CopyBackup {
+    pub fn copy_backup(&self) -> super::builder::bigtable_table_admin::CopyBackup {
         super::builder::bigtable_table_admin::CopyBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the access control policy for a Table or Backup resource.
     /// Returns an empty policy if the resource exists but does not have a policy
     /// set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::bigtable_table_admin::GetIamPolicy {
         super::builder::bigtable_table_admin::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on a Table or Backup resource.
     /// Replaces any existing policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::bigtable_table_admin::SetIamPolicy {
         super::builder::bigtable_table_admin::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that the caller has on the specified Table or Backup
     /// resource.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::bigtable_table_admin::TestIamPermissions {
         super::builder::bigtable_table_admin::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::bigtable_table_admin::ListOperations {
         super::builder::bigtable_table_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::GetOperation {
+    pub fn get_operation(&self) -> super::builder::bigtable_table_admin::GetOperation {
         super::builder::bigtable_table_admin::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::bigtable_table_admin::DeleteOperation {
         super::builder::bigtable_table_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bigtable_table_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::bigtable_table_admin::CancelOperation {
         super::builder::bigtable_table_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -148,10 +148,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -313,10 +318,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.cluster
+            let arg = &req
+                .cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -456,10 +466,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.app_profile
+            let arg = &req
+                .app_profile
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("app_profile"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("app_profile.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -720,10 +735,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.logical_view
+            let arg = &req
+                .logical_view
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("logical_view"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("logical_view.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -863,10 +883,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.materialized_view
+            let arg = &req
+                .materialized_view
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("materialized_view"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("materialized_view.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1181,10 +1206,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.table
+            let arg = &req
+                .table
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("table"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("table.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1348,10 +1378,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.authorized_view
+            let arg = &req
+                .authorized_view
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("authorized_view"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("authorized_view.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1671,10 +1706,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,12 +96,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -108,9 +123,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -125,18 +147,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +178,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -182,12 +208,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -205,9 +235,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -224,9 +261,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -244,9 +288,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -261,18 +312,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,9 +343,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,12 +373,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/appProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/appProfiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -342,9 +401,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,12 +427,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAppProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/appProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/appProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -385,18 +455,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.app_profile
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("app_profile"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.app_profile
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("app_profile"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -420,9 +487,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -444,12 +518,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -464,12 +542,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -484,12 +566,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,12 +590,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHotTabletsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/hotTablets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/hotTablets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -548,12 +638,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/logicalViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/logicalViews", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -571,9 +665,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogicalView>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -590,12 +691,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLogicalViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/logicalViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/logicalViews", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -614,18 +719,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.logical_view
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("logical_view"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.logical_view
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("logical_view"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -648,9 +750,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -672,12 +781,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/materializedViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/materializedViews", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -695,9 +808,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MaterializedView>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -714,12 +834,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMaterializedViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/materializedViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/materializedViews", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -738,18 +862,15 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.materialized_view
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("materialized_view"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.materialized_view
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("materialized_view"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -772,9 +893,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -796,9 +924,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -818,9 +953,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -837,9 +979,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -860,9 +1009,16 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -920,9 +1076,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/tables", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/tables", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -937,12 +1100,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/tables:createFromSnapshot", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/tables:createFromSnapshot", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -957,9 +1124,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTablesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/tables", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/tables", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -979,9 +1153,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -999,18 +1180,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.table
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("table"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.table
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("table"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1032,9 +1210,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1055,9 +1240,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1072,12 +1264,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/authorizedViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/authorizedViews", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1095,12 +1291,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAuthorizedViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/authorizedViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/authorizedViews", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1120,9 +1320,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizedView>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1140,18 +1347,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.authorized_view
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("authorized_view"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.authorized_view
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("authorized_view"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1175,9 +1379,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1199,12 +1410,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:modifyColumnFamilies", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:modifyColumnFamilies", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1219,12 +1434,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:dropRowRange", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:dropRowRange", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1244,12 +1463,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateConsistencyTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:generateConsistencyToken", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:generateConsistencyToken", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1264,12 +1487,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckConsistencyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:checkConsistency", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:checkConsistency", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1284,9 +1511,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:snapshot", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:snapshot", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1301,9 +1535,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snapshot>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1320,12 +1561,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSnapshotsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1344,9 +1589,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1367,9 +1619,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1385,9 +1644,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1404,18 +1670,15 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1436,9 +1699,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1459,9 +1729,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1482,12 +1759,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/tables:restore", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/tables:restore", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1502,12 +1783,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/backups:copy", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/backups:copy", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1522,12 +1807,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1542,12 +1831,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1562,12 +1855,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1582,9 +1879,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1604,9 +1908,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1623,9 +1934,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1646,9 +1964,16 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/accessapproval/v1/src/client.rs
+++ b/src/generated/cloud/accessapproval/v1/src/client.rs
@@ -155,21 +155,13 @@ impl AccessApproval {
     /// Lists approval requests associated with a project, folder, or organization.
     /// Approval requests can be filtered by state (pending, active, dismissed).
     /// The order is reverse chronological.
-    pub fn list_approval_requests(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::access_approval::ListApprovalRequests {
+    pub fn list_approval_requests(&self) -> super::builder::access_approval::ListApprovalRequests {
         super::builder::access_approval::ListApprovalRequests::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an approval request. Returns NOT_FOUND if the request does not exist.
-    pub fn get_approval_request(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::access_approval::GetApprovalRequest {
+    pub fn get_approval_request(&self) -> super::builder::access_approval::GetApprovalRequest {
         super::builder::access_approval::GetApprovalRequest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Approves a request and returns the updated ApprovalRequest.
@@ -178,10 +170,8 @@ impl AccessApproval {
     /// FAILED_PRECONDITION if the request exists but is not in a pending state.
     pub fn approve_approval_request(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::ApproveApprovalRequest {
         super::builder::access_approval::ApproveApprovalRequest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Dismisses a request. Returns the updated ApprovalRequest.
@@ -196,10 +186,8 @@ impl AccessApproval {
     /// state.
     pub fn dismiss_approval_request(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::DismissApprovalRequest {
         super::builder::access_approval::DismissApprovalRequest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Invalidates an existing ApprovalRequest. Returns the updated
@@ -212,29 +200,23 @@ impl AccessApproval {
     /// state.
     pub fn invalidate_approval_request(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::InvalidateApprovalRequest {
         super::builder::access_approval::InvalidateApprovalRequest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the settings associated with a project, folder, or organization.
     pub fn get_access_approval_settings(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::GetAccessApprovalSettings {
         super::builder::access_approval::GetAccessApprovalSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the settings associated with a project, folder, or organization.
     /// Settings to update are determined by the value of field_mask.
     pub fn update_access_approval_settings(
         &self,
-        settings: impl Into<crate::model::AccessApprovalSettings>,
     ) -> super::builder::access_approval::UpdateAccessApprovalSettings {
         super::builder::access_approval::UpdateAccessApprovalSettings::new(self.inner.clone())
-            .set_settings(settings.into())
     }
 
     /// Deletes the settings associated with a project, folder, or organization.
@@ -245,19 +227,15 @@ impl AccessApproval {
     /// the settings are inherited.
     pub fn delete_access_approval_settings(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::DeleteAccessApprovalSettings {
         super::builder::access_approval::DeleteAccessApprovalSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves the service account that is used by Access Approval to access KMS
     /// keys for signing approved approval requests.
     pub fn get_access_approval_service_account(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_approval::GetAccessApprovalServiceAccount {
         super::builder::access_approval::GetAccessApprovalServiceAccount::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -200,10 +200,15 @@ impl super::stub::AccessApproval for AccessApproval {
     ) -> Result<gax::response::Response<crate::model::AccessApprovalSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.settings
+            let arg = &req
+                .settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApprovalRequestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/approvalRequests", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/approvalRequests", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,9 +75,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApprovalRequest>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,9 +101,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApprovalRequest>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:approve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,9 +125,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApprovalRequest>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:dismiss", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:dismiss", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,12 +149,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApprovalRequest>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:invalidate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:invalidate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -144,9 +173,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessApprovalSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -163,18 +199,15 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessApprovalSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +230,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -220,9 +260,16 @@ impl super::stub::AccessApproval for AccessApproval {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessApprovalServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/advisorynotifications/v1/src/client.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/client.rs
@@ -123,36 +123,26 @@ impl AdvisoryNotificationsService {
     /// Lists notifications under a given parent.
     pub fn list_notifications(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::advisory_notifications_service::ListNotifications {
         super::builder::advisory_notifications_service::ListNotifications::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a notification.
     pub fn get_notification(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::advisory_notifications_service::GetNotification {
         super::builder::advisory_notifications_service::GetNotification::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get notification settings.
-    pub fn get_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::advisory_notifications_service::GetSettings {
+    pub fn get_settings(&self) -> super::builder::advisory_notifications_service::GetSettings {
         super::builder::advisory_notifications_service::GetSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update notification settings.
     pub fn update_settings(
         &self,
-        settings: impl Into<crate::model::Settings>,
     ) -> super::builder::advisory_notifications_service::UpdateSettings {
         super::builder::advisory_notifications_service::UpdateSettings::new(self.inner.clone())
-            .set_settings(settings.into())
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.settings
+            let arg = &req
+                .settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotificationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notifications", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/notifications", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Notification>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,9 +103,16 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,18 +129,15 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/aiplatform/v1/src/client.rs
+++ b/src/generated/cloud/aiplatform/v1/src/client.rs
@@ -167,38 +167,23 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_dataset(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::CreateDataset {
+    pub fn create_dataset(&self) -> super::builder::dataset_service::CreateDataset {
         super::builder::dataset_service::CreateDataset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Dataset.
-    pub fn get_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetDataset {
-        super::builder::dataset_service::GetDataset::new(self.inner.clone()).set_name(name.into())
+    pub fn get_dataset(&self) -> super::builder::dataset_service::GetDataset {
+        super::builder::dataset_service::GetDataset::new(self.inner.clone())
     }
 
     /// Updates a Dataset.
-    pub fn update_dataset(
-        &self,
-        dataset: impl Into<crate::model::Dataset>,
-    ) -> super::builder::dataset_service::UpdateDataset {
+    pub fn update_dataset(&self) -> super::builder::dataset_service::UpdateDataset {
         super::builder::dataset_service::UpdateDataset::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Lists Datasets in a Location.
-    pub fn list_datasets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListDatasets {
+    pub fn list_datasets(&self) -> super::builder::dataset_service::ListDatasets {
         super::builder::dataset_service::ListDatasets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Dataset.
@@ -212,12 +197,8 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::DeleteDataset {
+    pub fn delete_dataset(&self) -> super::builder::dataset_service::DeleteDataset {
         super::builder::dataset_service::DeleteDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports data into a Dataset.
@@ -231,11 +212,8 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ImportData {
-        super::builder::dataset_service::ImportData::new(self.inner.clone()).set_name(name.into())
+    pub fn import_data(&self) -> super::builder::dataset_service::ImportData {
+        super::builder::dataset_service::ImportData::new(self.inner.clone())
     }
 
     /// Exports data from a Dataset.
@@ -249,11 +227,8 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ExportData {
-        super::builder::dataset_service::ExportData::new(self.inner.clone()).set_name(name.into())
+    pub fn export_data(&self) -> super::builder::dataset_service::ExportData {
+        super::builder::dataset_service::ExportData::new(self.inner.clone())
     }
 
     /// Create a version from a Dataset.
@@ -267,21 +242,13 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_dataset_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::CreateDatasetVersion {
+    pub fn create_dataset_version(&self) -> super::builder::dataset_service::CreateDatasetVersion {
         super::builder::dataset_service::CreateDatasetVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DatasetVersion.
-    pub fn update_dataset_version(
-        &self,
-        dataset_version: impl Into<crate::model::DatasetVersion>,
-    ) -> super::builder::dataset_service::UpdateDatasetVersion {
+    pub fn update_dataset_version(&self) -> super::builder::dataset_service::UpdateDatasetVersion {
         super::builder::dataset_service::UpdateDatasetVersion::new(self.inner.clone())
-            .set_dataset_version(dataset_version.into())
     }
 
     /// Deletes a Dataset version.
@@ -295,30 +262,18 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_dataset_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::DeleteDatasetVersion {
+    pub fn delete_dataset_version(&self) -> super::builder::dataset_service::DeleteDatasetVersion {
         super::builder::dataset_service::DeleteDatasetVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a Dataset version.
-    pub fn get_dataset_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetDatasetVersion {
+    pub fn get_dataset_version(&self) -> super::builder::dataset_service::GetDatasetVersion {
         super::builder::dataset_service::GetDatasetVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DatasetVersions in a Dataset.
-    pub fn list_dataset_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListDatasetVersions {
+    pub fn list_dataset_versions(&self) -> super::builder::dataset_service::ListDatasetVersions {
         super::builder::dataset_service::ListDatasetVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Restores a dataset version.
@@ -334,37 +289,23 @@ impl DatasetService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn restore_dataset_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dataset_service::RestoreDatasetVersion {
         super::builder::dataset_service::RestoreDatasetVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataItems in a Dataset.
-    pub fn list_data_items(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListDataItems {
+    pub fn list_data_items(&self) -> super::builder::dataset_service::ListDataItems {
         super::builder::dataset_service::ListDataItems::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Searches DataItems in a Dataset.
-    pub fn search_data_items(
-        &self,
-        dataset: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::SearchDataItems {
+    pub fn search_data_items(&self) -> super::builder::dataset_service::SearchDataItems {
         super::builder::dataset_service::SearchDataItems::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Lists SavedQueries in a Dataset.
-    pub fn list_saved_queries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListSavedQueries {
+    pub fn list_saved_queries(&self) -> super::builder::dataset_service::ListSavedQueries {
         super::builder::dataset_service::ListSavedQueries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a SavedQuery.
@@ -378,49 +319,30 @@ impl DatasetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_saved_query(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::DeleteSavedQuery {
+    pub fn delete_saved_query(&self) -> super::builder::dataset_service::DeleteSavedQuery {
         super::builder::dataset_service::DeleteSavedQuery::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets an AnnotationSpec.
-    pub fn get_annotation_spec(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetAnnotationSpec {
+    pub fn get_annotation_spec(&self) -> super::builder::dataset_service::GetAnnotationSpec {
         super::builder::dataset_service::GetAnnotationSpec::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Annotations belongs to a dataitem
     /// This RPC is only available in InternalDatasetService. It is only used for
     /// exporting conversation data to CCAI Insights.
-    pub fn list_annotations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListAnnotations {
+    pub fn list_annotations(&self) -> super::builder::dataset_service::ListAnnotations {
         super::builder::dataset_service::ListAnnotations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::dataset_service::ListLocations {
         super::builder::dataset_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetLocation {
-        super::builder::dataset_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::dataset_service::GetLocation {
+        super::builder::dataset_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -428,22 +350,14 @@ impl DatasetService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::dataset_service::SetIamPolicy {
         super::builder::dataset_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::dataset_service::GetIamPolicy {
         super::builder::dataset_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -453,66 +367,43 @@ impl DatasetService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::dataset_service::TestIamPermissions {
         super::builder::dataset_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::dataset_service::ListOperations {
         super::builder::dataset_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetOperation {
-        super::builder::dataset_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::dataset_service::GetOperation {
+        super::builder::dataset_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::dataset_service::DeleteOperation {
         super::builder::dataset_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::dataset_service::CancelOperation {
         super::builder::dataset_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::dataset_service::WaitOperation {
         super::builder::dataset_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -634,34 +525,28 @@ impl DeploymentResourcePoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_deployment_resource_pool(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::CreateDeploymentResourcePool {
         super::builder::deployment_resource_pool_service::CreateDeploymentResourcePool::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get a DeploymentResourcePool.
     pub fn get_deployment_resource_pool(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::GetDeploymentResourcePool {
         super::builder::deployment_resource_pool_service::GetDeploymentResourcePool::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// List DeploymentResourcePools in a location.
     pub fn list_deployment_resource_pools(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::ListDeploymentResourcePools {
         super::builder::deployment_resource_pool_service::ListDeploymentResourcePools::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Update a DeploymentResourcePool.
@@ -677,12 +562,10 @@ impl DeploymentResourcePoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_deployment_resource_pool(
         &self,
-        deployment_resource_pool: impl Into<crate::model::DeploymentResourcePool>,
     ) -> super::builder::deployment_resource_pool_service::UpdateDeploymentResourcePool {
         super::builder::deployment_resource_pool_service::UpdateDeploymentResourcePool::new(
             self.inner.clone(),
         )
-        .set_deployment_resource_pool(deployment_resource_pool.into())
     }
 
     /// Delete a DeploymentResourcePool.
@@ -698,41 +581,31 @@ impl DeploymentResourcePoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_deployment_resource_pool(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::DeleteDeploymentResourcePool {
         super::builder::deployment_resource_pool_service::DeleteDeploymentResourcePool::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// List DeployedModels that have been deployed on this DeploymentResourcePool.
     pub fn query_deployed_models(
         &self,
-        deployment_resource_pool: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::QueryDeployedModels {
         super::builder::deployment_resource_pool_service::QueryDeployedModels::new(
             self.inner.clone(),
         )
-        .set_deployment_resource_pool(deployment_resource_pool.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::ListLocations {
         super::builder::deployment_resource_pool_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployment_resource_pool_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::deployment_resource_pool_service::GetLocation {
         super::builder::deployment_resource_pool_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -740,22 +613,14 @@ impl DeploymentResourcePoolService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::deployment_resource_pool_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::deployment_resource_pool_service::SetIamPolicy {
         super::builder::deployment_resource_pool_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::deployment_resource_pool_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::deployment_resource_pool_service::GetIamPolicy {
         super::builder::deployment_resource_pool_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -767,12 +632,10 @@ impl DeploymentResourcePoolService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::TestIamPermissions {
         super::builder::deployment_resource_pool_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -780,21 +643,15 @@ impl DeploymentResourcePoolService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::ListOperations {
         super::builder::deployment_resource_pool_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployment_resource_pool_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::deployment_resource_pool_service::GetOperation {
         super::builder::deployment_resource_pool_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -802,10 +659,8 @@ impl DeploymentResourcePoolService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::DeleteOperation {
         super::builder::deployment_resource_pool_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -813,10 +668,8 @@ impl DeploymentResourcePoolService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::CancelOperation {
         super::builder::deployment_resource_pool_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -824,10 +677,8 @@ impl DeploymentResourcePoolService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::deployment_resource_pool_service::WaitOperation {
         super::builder::deployment_resource_pool_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -947,38 +798,23 @@ impl EndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_endpoint(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::CreateEndpoint {
+    pub fn create_endpoint(&self) -> super::builder::endpoint_service::CreateEndpoint {
         super::builder::endpoint_service::CreateEndpoint::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an Endpoint.
-    pub fn get_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::GetEndpoint {
-        super::builder::endpoint_service::GetEndpoint::new(self.inner.clone()).set_name(name.into())
+    pub fn get_endpoint(&self) -> super::builder::endpoint_service::GetEndpoint {
+        super::builder::endpoint_service::GetEndpoint::new(self.inner.clone())
     }
 
     /// Lists Endpoints in a Location.
-    pub fn list_endpoints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::ListEndpoints {
+    pub fn list_endpoints(&self) -> super::builder::endpoint_service::ListEndpoints {
         super::builder::endpoint_service::ListEndpoints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an Endpoint.
-    pub fn update_endpoint(
-        &self,
-        endpoint: impl Into<crate::model::Endpoint>,
-    ) -> super::builder::endpoint_service::UpdateEndpoint {
+    pub fn update_endpoint(&self) -> super::builder::endpoint_service::UpdateEndpoint {
         super::builder::endpoint_service::UpdateEndpoint::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Updates an Endpoint with a long running operation.
@@ -994,10 +830,8 @@ impl EndpointService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_endpoint_long_running(
         &self,
-        endpoint: impl Into<crate::model::Endpoint>,
     ) -> super::builder::endpoint_service::UpdateEndpointLongRunning {
         super::builder::endpoint_service::UpdateEndpointLongRunning::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Deletes an Endpoint.
@@ -1011,12 +845,8 @@ impl EndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::DeleteEndpoint {
+    pub fn delete_endpoint(&self) -> super::builder::endpoint_service::DeleteEndpoint {
         super::builder::endpoint_service::DeleteEndpoint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deploys a Model into this Endpoint, creating a DeployedModel within it.
@@ -1030,12 +860,8 @@ impl EndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn deploy_model(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::DeployModel {
+    pub fn deploy_model(&self) -> super::builder::endpoint_service::DeployModel {
         super::builder::endpoint_service::DeployModel::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Undeploys a Model from an Endpoint, removing a DeployedModel from it, and
@@ -1050,12 +876,8 @@ impl EndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undeploy_model(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::UndeployModel {
+    pub fn undeploy_model(&self) -> super::builder::endpoint_service::UndeployModel {
         super::builder::endpoint_service::UndeployModel::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Updates an existing deployed model. Updatable fields include
@@ -1072,29 +894,18 @@ impl EndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn mutate_deployed_model(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::MutateDeployedModel {
+    pub fn mutate_deployed_model(&self) -> super::builder::endpoint_service::MutateDeployedModel {
         super::builder::endpoint_service::MutateDeployedModel::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::endpoint_service::ListLocations {
         super::builder::endpoint_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::GetLocation {
-        super::builder::endpoint_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::endpoint_service::GetLocation {
+        super::builder::endpoint_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1102,22 +913,14 @@ impl EndpointService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::endpoint_service::SetIamPolicy {
         super::builder::endpoint_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::endpoint_service::GetIamPolicy {
         super::builder::endpoint_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1127,67 +930,43 @@ impl EndpointService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::endpoint_service::TestIamPermissions {
         super::builder::endpoint_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::endpoint_service::ListOperations {
         super::builder::endpoint_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::endpoint_service::GetOperation {
         super::builder::endpoint_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::endpoint_service::DeleteOperation {
         super::builder::endpoint_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::endpoint_service::CancelOperation {
         super::builder::endpoint_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::endpoint_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::endpoint_service::WaitOperation {
         super::builder::endpoint_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1297,30 +1076,18 @@ impl EvaluationService {
     }
 
     /// Evaluates instances based on a given metric.
-    pub fn evaluate_instances(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::EvaluateInstances {
+    pub fn evaluate_instances(&self) -> super::builder::evaluation_service::EvaluateInstances {
         super::builder::evaluation_service::EvaluateInstances::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::evaluation_service::ListLocations {
         super::builder::evaluation_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::evaluation_service::GetLocation {
         super::builder::evaluation_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1328,22 +1095,14 @@ impl EvaluationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::evaluation_service::SetIamPolicy {
         super::builder::evaluation_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::evaluation_service::GetIamPolicy {
         super::builder::evaluation_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1353,67 +1112,43 @@ impl EvaluationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::evaluation_service::TestIamPermissions {
         super::builder::evaluation_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::evaluation_service::ListOperations {
         super::builder::evaluation_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::evaluation_service::GetOperation {
         super::builder::evaluation_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::evaluation_service::DeleteOperation {
         super::builder::evaluation_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::evaluation_service::CancelOperation {
         super::builder::evaluation_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::evaluation_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::evaluation_service::WaitOperation {
         super::builder::evaluation_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1536,34 +1271,28 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_feature_online_store(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::CreateFeatureOnlineStore {
         super::builder::feature_online_store_admin_service::CreateFeatureOnlineStore::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single FeatureOnlineStore.
     pub fn get_feature_online_store(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureOnlineStore {
         super::builder::feature_online_store_admin_service::GetFeatureOnlineStore::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists FeatureOnlineStores in a given project and location.
     pub fn list_feature_online_stores(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::ListFeatureOnlineStores {
         super::builder::feature_online_store_admin_service::ListFeatureOnlineStores::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single FeatureOnlineStore.
@@ -1579,12 +1308,10 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_feature_online_store(
         &self,
-        feature_online_store: impl Into<crate::model::FeatureOnlineStore>,
     ) -> super::builder::feature_online_store_admin_service::UpdateFeatureOnlineStore {
         super::builder::feature_online_store_admin_service::UpdateFeatureOnlineStore::new(
             self.inner.clone(),
         )
-        .set_feature_online_store(feature_online_store.into())
     }
 
     /// Deletes a single FeatureOnlineStore. The FeatureOnlineStore must not
@@ -1601,12 +1328,10 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_feature_online_store(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::DeleteFeatureOnlineStore {
         super::builder::feature_online_store_admin_service::DeleteFeatureOnlineStore::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a new FeatureView in a given FeatureOnlineStore.
@@ -1622,32 +1347,26 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_feature_view(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::CreateFeatureView {
         super::builder::feature_online_store_admin_service::CreateFeatureView::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single FeatureView.
     pub fn get_feature_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureView {
         super::builder::feature_online_store_admin_service::GetFeatureView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists FeatureViews in a given FeatureOnlineStore.
     pub fn list_feature_views(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::ListFeatureViews {
         super::builder::feature_online_store_admin_service::ListFeatureViews::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single FeatureView.
@@ -1663,12 +1382,10 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_feature_view(
         &self,
-        feature_view: impl Into<crate::model::FeatureView>,
     ) -> super::builder::feature_online_store_admin_service::UpdateFeatureView {
         super::builder::feature_online_store_admin_service::UpdateFeatureView::new(
             self.inner.clone(),
         )
-        .set_feature_view(feature_view.into())
     }
 
     /// Deletes a single FeatureView.
@@ -1684,61 +1401,47 @@ impl FeatureOnlineStoreAdminService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_feature_view(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::DeleteFeatureView {
         super::builder::feature_online_store_admin_service::DeleteFeatureView::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Triggers on-demand sync for the FeatureView.
     pub fn sync_feature_view(
         &self,
-        feature_view: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::SyncFeatureView {
         super::builder::feature_online_store_admin_service::SyncFeatureView::new(self.inner.clone())
-            .set_feature_view(feature_view.into())
     }
 
     /// Gets details of a single FeatureViewSync.
     pub fn get_feature_view_sync(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureViewSync {
         super::builder::feature_online_store_admin_service::GetFeatureViewSync::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists FeatureViewSyncs in a given FeatureView.
     pub fn list_feature_view_syncs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::ListFeatureViewSyncs {
         super::builder::feature_online_store_admin_service::ListFeatureViewSyncs::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::ListLocations {
         super::builder::feature_online_store_admin_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_admin_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::feature_online_store_admin_service::GetLocation {
         super::builder::feature_online_store_admin_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1748,20 +1451,16 @@ impl FeatureOnlineStoreAdminService {
     /// errors.
     pub fn set_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::SetIamPolicy {
         super::builder::feature_online_store_admin_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
     pub fn get_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::GetIamPolicy {
         super::builder::feature_online_store_admin_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1773,12 +1472,10 @@ impl FeatureOnlineStoreAdminService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::TestIamPermissions {
         super::builder::feature_online_store_admin_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1786,10 +1483,8 @@ impl FeatureOnlineStoreAdminService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::ListOperations {
         super::builder::feature_online_store_admin_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1797,10 +1492,8 @@ impl FeatureOnlineStoreAdminService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::GetOperation {
         super::builder::feature_online_store_admin_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1808,10 +1501,8 @@ impl FeatureOnlineStoreAdminService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::DeleteOperation {
         super::builder::feature_online_store_admin_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1819,10 +1510,8 @@ impl FeatureOnlineStoreAdminService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::CancelOperation {
         super::builder::feature_online_store_admin_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1830,10 +1519,8 @@ impl FeatureOnlineStoreAdminService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_admin_service::WaitOperation {
         super::builder::feature_online_store_admin_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1945,10 +1632,8 @@ impl FeatureOnlineStoreService {
     /// Fetch feature values under a FeatureView.
     pub fn fetch_feature_values(
         &self,
-        feature_view: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_service::FetchFeatureValues {
         super::builder::feature_online_store_service::FetchFeatureValues::new(self.inner.clone())
-            .set_feature_view(feature_view.into())
     }
 
     /// Search the nearest entities under a FeatureView.
@@ -1956,28 +1641,18 @@ impl FeatureOnlineStoreService {
     /// indexable, returns Invalid argument response.
     pub fn search_nearest_entities(
         &self,
-        feature_view: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_service::SearchNearestEntities {
         super::builder::feature_online_store_service::SearchNearestEntities::new(self.inner.clone())
-            .set_feature_view(feature_view.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::feature_online_store_service::ListLocations {
         super::builder::feature_online_store_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::feature_online_store_service::GetLocation {
         super::builder::feature_online_store_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1985,22 +1660,14 @@ impl FeatureOnlineStoreService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::feature_online_store_service::SetIamPolicy {
         super::builder::feature_online_store_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::feature_online_store_service::GetIamPolicy {
         super::builder::feature_online_store_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2012,32 +1679,22 @@ impl FeatureOnlineStoreService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_service::TestIamPermissions {
         super::builder::feature_online_store_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::feature_online_store_service::ListOperations {
         super::builder::feature_online_store_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::feature_online_store_service::GetOperation {
         super::builder::feature_online_store_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2045,10 +1702,8 @@ impl FeatureOnlineStoreService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_service::DeleteOperation {
         super::builder::feature_online_store_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2056,21 +1711,15 @@ impl FeatureOnlineStoreService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_online_store_service::CancelOperation {
         super::builder::feature_online_store_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_online_store_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::feature_online_store_service::WaitOperation {
         super::builder::feature_online_store_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2193,28 +1842,20 @@ impl FeatureRegistryService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_feature_group(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_registry_service::CreateFeatureGroup {
         super::builder::feature_registry_service::CreateFeatureGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single FeatureGroup.
-    pub fn get_feature_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::GetFeatureGroup {
+    pub fn get_feature_group(&self) -> super::builder::feature_registry_service::GetFeatureGroup {
         super::builder::feature_registry_service::GetFeatureGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists FeatureGroups in a given project and location.
     pub fn list_feature_groups(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_registry_service::ListFeatureGroups {
         super::builder::feature_registry_service::ListFeatureGroups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single FeatureGroup.
@@ -2230,10 +1871,8 @@ impl FeatureRegistryService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_feature_group(
         &self,
-        feature_group: impl Into<crate::model::FeatureGroup>,
     ) -> super::builder::feature_registry_service::UpdateFeatureGroup {
         super::builder::feature_registry_service::UpdateFeatureGroup::new(self.inner.clone())
-            .set_feature_group(feature_group.into())
     }
 
     /// Deletes a single FeatureGroup.
@@ -2249,10 +1888,8 @@ impl FeatureRegistryService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_feature_group(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::feature_registry_service::DeleteFeatureGroup {
         super::builder::feature_registry_service::DeleteFeatureGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Feature in a given FeatureGroup.
@@ -2266,12 +1903,8 @@ impl FeatureRegistryService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_feature(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::CreateFeature {
+    pub fn create_feature(&self) -> super::builder::feature_registry_service::CreateFeature {
         super::builder::feature_registry_service::CreateFeature::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a batch of Features in a given FeatureGroup.
@@ -2287,28 +1920,18 @@ impl FeatureRegistryService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_create_features(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::feature_registry_service::BatchCreateFeatures {
         super::builder::feature_registry_service::BatchCreateFeatures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Feature.
-    pub fn get_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::GetFeature {
+    pub fn get_feature(&self) -> super::builder::feature_registry_service::GetFeature {
         super::builder::feature_registry_service::GetFeature::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Features in a given FeatureGroup.
-    pub fn list_features(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::ListFeatures {
+    pub fn list_features(&self) -> super::builder::feature_registry_service::ListFeatures {
         super::builder::feature_registry_service::ListFeatures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Feature.
@@ -2322,12 +1945,8 @@ impl FeatureRegistryService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_feature(
-        &self,
-        feature: impl Into<crate::model::Feature>,
-    ) -> super::builder::feature_registry_service::UpdateFeature {
+    pub fn update_feature(&self) -> super::builder::feature_registry_service::UpdateFeature {
         super::builder::feature_registry_service::UpdateFeature::new(self.inner.clone())
-            .set_feature(feature.into())
     }
 
     /// Deletes a single Feature.
@@ -2341,30 +1960,18 @@ impl FeatureRegistryService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::DeleteFeature {
+    pub fn delete_feature(&self) -> super::builder::feature_registry_service::DeleteFeature {
         super::builder::feature_registry_service::DeleteFeature::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::feature_registry_service::ListLocations {
         super::builder::feature_registry_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::feature_registry_service::GetLocation {
         super::builder::feature_registry_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -2372,22 +1979,14 @@ impl FeatureRegistryService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::feature_registry_service::SetIamPolicy {
         super::builder::feature_registry_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::feature_registry_service::GetIamPolicy {
         super::builder::feature_registry_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2399,65 +1998,43 @@ impl FeatureRegistryService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::feature_registry_service::TestIamPermissions {
         super::builder::feature_registry_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::feature_registry_service::ListOperations {
         super::builder::feature_registry_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::feature_registry_service::GetOperation {
         super::builder::feature_registry_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::feature_registry_service::DeleteOperation {
         super::builder::feature_registry_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::feature_registry_service::CancelOperation {
         super::builder::feature_registry_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::feature_registry_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::feature_registry_service::WaitOperation {
         super::builder::feature_registry_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2571,12 +2148,10 @@ impl FeaturestoreOnlineServingService {
     /// StreamingReadFeatureValues.
     pub fn read_feature_values(
         &self,
-        entity_type: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::ReadFeatureValues {
         super::builder::featurestore_online_serving_service::ReadFeatureValues::new(
             self.inner.clone(),
         )
-        .set_entity_type(entity_type.into())
     }
 
     /// Writes Feature values of one or more entities of an EntityType.
@@ -2586,30 +2161,22 @@ impl FeaturestoreOnlineServingService {
     /// retention.
     pub fn write_feature_values(
         &self,
-        entity_type: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::WriteFeatureValues {
         super::builder::featurestore_online_serving_service::WriteFeatureValues::new(
             self.inner.clone(),
         )
-        .set_entity_type(entity_type.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::ListLocations {
         super::builder::featurestore_online_serving_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_online_serving_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::featurestore_online_serving_service::GetLocation {
         super::builder::featurestore_online_serving_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -2619,20 +2186,16 @@ impl FeaturestoreOnlineServingService {
     /// errors.
     pub fn set_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::SetIamPolicy {
         super::builder::featurestore_online_serving_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
     pub fn get_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::GetIamPolicy {
         super::builder::featurestore_online_serving_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2644,12 +2207,10 @@ impl FeaturestoreOnlineServingService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::TestIamPermissions {
         super::builder::featurestore_online_serving_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2657,10 +2218,8 @@ impl FeaturestoreOnlineServingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::ListOperations {
         super::builder::featurestore_online_serving_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2668,10 +2227,8 @@ impl FeaturestoreOnlineServingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::GetOperation {
         super::builder::featurestore_online_serving_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2679,12 +2236,10 @@ impl FeaturestoreOnlineServingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::DeleteOperation {
         super::builder::featurestore_online_serving_service::DeleteOperation::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2692,12 +2247,10 @@ impl FeaturestoreOnlineServingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::CancelOperation {
         super::builder::featurestore_online_serving_service::CancelOperation::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -2705,10 +2258,8 @@ impl FeaturestoreOnlineServingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::featurestore_online_serving_service::WaitOperation {
         super::builder::featurestore_online_serving_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2828,30 +2379,18 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_featurestore(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::CreateFeaturestore {
+    pub fn create_featurestore(&self) -> super::builder::featurestore_service::CreateFeaturestore {
         super::builder::featurestore_service::CreateFeaturestore::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Featurestore.
-    pub fn get_featurestore(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetFeaturestore {
+    pub fn get_featurestore(&self) -> super::builder::featurestore_service::GetFeaturestore {
         super::builder::featurestore_service::GetFeaturestore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Featurestores in a given project and location.
-    pub fn list_featurestores(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::ListFeaturestores {
+    pub fn list_featurestores(&self) -> super::builder::featurestore_service::ListFeaturestores {
         super::builder::featurestore_service::ListFeaturestores::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Featurestore.
@@ -2865,12 +2404,8 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_featurestore(
-        &self,
-        featurestore: impl Into<crate::model::Featurestore>,
-    ) -> super::builder::featurestore_service::UpdateFeaturestore {
+    pub fn update_featurestore(&self) -> super::builder::featurestore_service::UpdateFeaturestore {
         super::builder::featurestore_service::UpdateFeaturestore::new(self.inner.clone())
-            .set_featurestore(featurestore.into())
     }
 
     /// Deletes a single Featurestore. The Featurestore must not contain any
@@ -2885,12 +2420,8 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_featurestore(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::DeleteFeaturestore {
+    pub fn delete_featurestore(&self) -> super::builder::featurestore_service::DeleteFeaturestore {
         super::builder::featurestore_service::DeleteFeaturestore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new EntityType in a given Featurestore.
@@ -2904,39 +2435,23 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_entity_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::CreateEntityType {
+    pub fn create_entity_type(&self) -> super::builder::featurestore_service::CreateEntityType {
         super::builder::featurestore_service::CreateEntityType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single EntityType.
-    pub fn get_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetEntityType {
+    pub fn get_entity_type(&self) -> super::builder::featurestore_service::GetEntityType {
         super::builder::featurestore_service::GetEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists EntityTypes in a given Featurestore.
-    pub fn list_entity_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::ListEntityTypes {
+    pub fn list_entity_types(&self) -> super::builder::featurestore_service::ListEntityTypes {
         super::builder::featurestore_service::ListEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single EntityType.
-    pub fn update_entity_type(
-        &self,
-        entity_type: impl Into<crate::model::EntityType>,
-    ) -> super::builder::featurestore_service::UpdateEntityType {
+    pub fn update_entity_type(&self) -> super::builder::featurestore_service::UpdateEntityType {
         super::builder::featurestore_service::UpdateEntityType::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Deletes a single EntityType. The EntityType must not have any Features
@@ -2951,12 +2466,8 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::DeleteEntityType {
+    pub fn delete_entity_type(&self) -> super::builder::featurestore_service::DeleteEntityType {
         super::builder::featurestore_service::DeleteEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Feature in a given EntityType.
@@ -2970,12 +2481,8 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_feature(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::CreateFeature {
+    pub fn create_feature(&self) -> super::builder::featurestore_service::CreateFeature {
         super::builder::featurestore_service::CreateFeature::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a batch of Features in a given EntityType.
@@ -2991,37 +2498,23 @@ impl FeaturestoreService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_create_features(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::featurestore_service::BatchCreateFeatures {
         super::builder::featurestore_service::BatchCreateFeatures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Feature.
-    pub fn get_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetFeature {
+    pub fn get_feature(&self) -> super::builder::featurestore_service::GetFeature {
         super::builder::featurestore_service::GetFeature::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Features in a given EntityType.
-    pub fn list_features(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::ListFeatures {
+    pub fn list_features(&self) -> super::builder::featurestore_service::ListFeatures {
         super::builder::featurestore_service::ListFeatures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Feature.
-    pub fn update_feature(
-        &self,
-        feature: impl Into<crate::model::Feature>,
-    ) -> super::builder::featurestore_service::UpdateFeature {
+    pub fn update_feature(&self) -> super::builder::featurestore_service::UpdateFeature {
         super::builder::featurestore_service::UpdateFeature::new(self.inner.clone())
-            .set_feature(feature.into())
     }
 
     /// Deletes a single Feature.
@@ -3035,12 +2528,8 @@ impl FeaturestoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::DeleteFeature {
+    pub fn delete_feature(&self) -> super::builder::featurestore_service::DeleteFeature {
         super::builder::featurestore_service::DeleteFeature::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports Feature values into the Featurestore from a source storage.
@@ -3075,10 +2564,8 @@ impl FeaturestoreService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_feature_values(
         &self,
-        entity_type: impl Into<std::string::String>,
     ) -> super::builder::featurestore_service::ImportFeatureValues {
         super::builder::featurestore_service::ImportFeatureValues::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Batch reads Feature values from a Featurestore.
@@ -3099,10 +2586,8 @@ impl FeaturestoreService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_read_feature_values(
         &self,
-        featurestore: impl Into<std::string::String>,
     ) -> super::builder::featurestore_service::BatchReadFeatureValues {
         super::builder::featurestore_service::BatchReadFeatureValues::new(self.inner.clone())
-            .set_featurestore(featurestore.into())
     }
 
     /// Exports Feature values from all the entities of a target EntityType.
@@ -3118,10 +2603,8 @@ impl FeaturestoreService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn export_feature_values(
         &self,
-        entity_type: impl Into<std::string::String>,
     ) -> super::builder::featurestore_service::ExportFeatureValues {
         super::builder::featurestore_service::ExportFeatureValues::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Delete Feature values from Featurestore.
@@ -3146,37 +2629,23 @@ impl FeaturestoreService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_feature_values(
         &self,
-        entity_type: impl Into<std::string::String>,
     ) -> super::builder::featurestore_service::DeleteFeatureValues {
         super::builder::featurestore_service::DeleteFeatureValues::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Searches Features matching a query in a given project.
-    pub fn search_features(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::SearchFeatures {
+    pub fn search_features(&self) -> super::builder::featurestore_service::SearchFeatures {
         super::builder::featurestore_service::SearchFeatures::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::featurestore_service::ListLocations {
         super::builder::featurestore_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::featurestore_service::GetLocation {
         super::builder::featurestore_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -3184,22 +2653,14 @@ impl FeaturestoreService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::featurestore_service::SetIamPolicy {
         super::builder::featurestore_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::featurestore_service::GetIamPolicy {
         super::builder::featurestore_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -3209,67 +2670,43 @@ impl FeaturestoreService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::featurestore_service::TestIamPermissions {
         super::builder::featurestore_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::featurestore_service::ListOperations {
         super::builder::featurestore_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::featurestore_service::GetOperation {
         super::builder::featurestore_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::featurestore_service::DeleteOperation {
         super::builder::featurestore_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::featurestore_service::CancelOperation {
         super::builder::featurestore_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::featurestore_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::featurestore_service::WaitOperation {
         super::builder::featurestore_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3382,64 +2819,42 @@ impl GenAiCacheService {
     /// data storage, and users need to pay for the cache data storage.
     pub fn create_cached_content(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::gen_ai_cache_service::CreateCachedContent {
         super::builder::gen_ai_cache_service::CreateCachedContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets cached content configurations
-    pub fn get_cached_content(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::GetCachedContent {
+    pub fn get_cached_content(&self) -> super::builder::gen_ai_cache_service::GetCachedContent {
         super::builder::gen_ai_cache_service::GetCachedContent::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates cached content configurations
     pub fn update_cached_content(
         &self,
-        cached_content: impl Into<crate::model::CachedContent>,
     ) -> super::builder::gen_ai_cache_service::UpdateCachedContent {
         super::builder::gen_ai_cache_service::UpdateCachedContent::new(self.inner.clone())
-            .set_cached_content(cached_content.into())
     }
 
     /// Deletes cached content
     pub fn delete_cached_content(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::gen_ai_cache_service::DeleteCachedContent {
         super::builder::gen_ai_cache_service::DeleteCachedContent::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists cached contents in a project
-    pub fn list_cached_contents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::ListCachedContents {
+    pub fn list_cached_contents(&self) -> super::builder::gen_ai_cache_service::ListCachedContents {
         super::builder::gen_ai_cache_service::ListCachedContents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::gen_ai_cache_service::ListLocations {
         super::builder::gen_ai_cache_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::gen_ai_cache_service::GetLocation {
         super::builder::gen_ai_cache_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -3447,22 +2862,14 @@ impl GenAiCacheService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::gen_ai_cache_service::SetIamPolicy {
         super::builder::gen_ai_cache_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::gen_ai_cache_service::GetIamPolicy {
         super::builder::gen_ai_cache_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -3472,67 +2879,43 @@ impl GenAiCacheService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::gen_ai_cache_service::TestIamPermissions {
         super::builder::gen_ai_cache_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::gen_ai_cache_service::ListOperations {
         super::builder::gen_ai_cache_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::gen_ai_cache_service::GetOperation {
         super::builder::gen_ai_cache_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::gen_ai_cache_service::DeleteOperation {
         super::builder::gen_ai_cache_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::gen_ai_cache_service::CancelOperation {
         super::builder::gen_ai_cache_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_cache_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::gen_ai_cache_service::WaitOperation {
         super::builder::gen_ai_cache_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3643,30 +3026,18 @@ impl GenAiTuningService {
 
     /// Creates a TuningJob. A created TuningJob right away will be attempted to
     /// be run.
-    pub fn create_tuning_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::CreateTuningJob {
+    pub fn create_tuning_job(&self) -> super::builder::gen_ai_tuning_service::CreateTuningJob {
         super::builder::gen_ai_tuning_service::CreateTuningJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a TuningJob.
-    pub fn get_tuning_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::GetTuningJob {
+    pub fn get_tuning_job(&self) -> super::builder::gen_ai_tuning_service::GetTuningJob {
         super::builder::gen_ai_tuning_service::GetTuningJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists TuningJobs in a Location.
-    pub fn list_tuning_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::ListTuningJobs {
+    pub fn list_tuning_jobs(&self) -> super::builder::gen_ai_tuning_service::ListTuningJobs {
         super::builder::gen_ai_tuning_service::ListTuningJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Cancels a TuningJob.
@@ -3686,12 +3057,8 @@ impl GenAiTuningService {
     /// [google.cloud.aiplatform.v1.TuningJob.error]: crate::model::TuningJob::error
     /// [google.cloud.aiplatform.v1.TuningJob.state]: crate::model::TuningJob::state
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_tuning_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::CancelTuningJob {
+    pub fn cancel_tuning_job(&self) -> super::builder::gen_ai_tuning_service::CancelTuningJob {
         super::builder::gen_ai_tuning_service::CancelTuningJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rebase a TunedModel.
@@ -3705,30 +3072,18 @@ impl GenAiTuningService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn rebase_tuned_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::RebaseTunedModel {
+    pub fn rebase_tuned_model(&self) -> super::builder::gen_ai_tuning_service::RebaseTunedModel {
         super::builder::gen_ai_tuning_service::RebaseTunedModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::gen_ai_tuning_service::ListLocations {
         super::builder::gen_ai_tuning_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::gen_ai_tuning_service::GetLocation {
         super::builder::gen_ai_tuning_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -3736,22 +3091,14 @@ impl GenAiTuningService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::gen_ai_tuning_service::SetIamPolicy {
         super::builder::gen_ai_tuning_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::gen_ai_tuning_service::GetIamPolicy {
         super::builder::gen_ai_tuning_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -3763,65 +3110,43 @@ impl GenAiTuningService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::gen_ai_tuning_service::TestIamPermissions {
         super::builder::gen_ai_tuning_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::gen_ai_tuning_service::ListOperations {
         super::builder::gen_ai_tuning_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::gen_ai_tuning_service::GetOperation {
         super::builder::gen_ai_tuning_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::gen_ai_tuning_service::DeleteOperation {
         super::builder::gen_ai_tuning_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::gen_ai_tuning_service::CancelOperation {
         super::builder::gen_ai_tuning_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gen_ai_tuning_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::gen_ai_tuning_service::WaitOperation {
         super::builder::gen_ai_tuning_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3943,37 +3268,27 @@ impl IndexEndpointService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_index_endpoint(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::index_endpoint_service::CreateIndexEndpoint {
         super::builder::index_endpoint_service::CreateIndexEndpoint::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an IndexEndpoint.
-    pub fn get_index_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::GetIndexEndpoint {
+    pub fn get_index_endpoint(&self) -> super::builder::index_endpoint_service::GetIndexEndpoint {
         super::builder::index_endpoint_service::GetIndexEndpoint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists IndexEndpoints in a Location.
     pub fn list_index_endpoints(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::index_endpoint_service::ListIndexEndpoints {
         super::builder::index_endpoint_service::ListIndexEndpoints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an IndexEndpoint.
     pub fn update_index_endpoint(
         &self,
-        index_endpoint: impl Into<crate::model::IndexEndpoint>,
     ) -> super::builder::index_endpoint_service::UpdateIndexEndpoint {
         super::builder::index_endpoint_service::UpdateIndexEndpoint::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Deletes an IndexEndpoint.
@@ -3989,10 +3304,8 @@ impl IndexEndpointService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_index_endpoint(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::index_endpoint_service::DeleteIndexEndpoint {
         super::builder::index_endpoint_service::DeleteIndexEndpoint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deploys an Index into this IndexEndpoint, creating a DeployedIndex within
@@ -4008,12 +3321,8 @@ impl IndexEndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn deploy_index(
-        &self,
-        index_endpoint: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::DeployIndex {
+    pub fn deploy_index(&self) -> super::builder::index_endpoint_service::DeployIndex {
         super::builder::index_endpoint_service::DeployIndex::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Undeploys an Index from an IndexEndpoint, removing a DeployedIndex from it,
@@ -4028,12 +3337,8 @@ impl IndexEndpointService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undeploy_index(
-        &self,
-        index_endpoint: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::UndeployIndex {
+    pub fn undeploy_index(&self) -> super::builder::index_endpoint_service::UndeployIndex {
         super::builder::index_endpoint_service::UndeployIndex::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Update an existing DeployedIndex under an IndexEndpoint.
@@ -4049,28 +3354,18 @@ impl IndexEndpointService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn mutate_deployed_index(
         &self,
-        index_endpoint: impl Into<std::string::String>,
     ) -> super::builder::index_endpoint_service::MutateDeployedIndex {
         super::builder::index_endpoint_service::MutateDeployedIndex::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::index_endpoint_service::ListLocations {
         super::builder::index_endpoint_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::index_endpoint_service::GetLocation {
         super::builder::index_endpoint_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -4078,22 +3373,14 @@ impl IndexEndpointService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::index_endpoint_service::SetIamPolicy {
         super::builder::index_endpoint_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::index_endpoint_service::GetIamPolicy {
         super::builder::index_endpoint_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -4105,65 +3392,43 @@ impl IndexEndpointService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::index_endpoint_service::TestIamPermissions {
         super::builder::index_endpoint_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::index_endpoint_service::ListOperations {
         super::builder::index_endpoint_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::index_endpoint_service::GetOperation {
         super::builder::index_endpoint_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::index_endpoint_service::DeleteOperation {
         super::builder::index_endpoint_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::index_endpoint_service::CancelOperation {
         super::builder::index_endpoint_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_endpoint_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::index_endpoint_service::WaitOperation {
         super::builder::index_endpoint_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -4281,29 +3546,18 @@ impl IndexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_index(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::index_service::CreateIndex {
+    pub fn create_index(&self) -> super::builder::index_service::CreateIndex {
         super::builder::index_service::CreateIndex::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an Index.
-    pub fn get_index(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::GetIndex {
-        super::builder::index_service::GetIndex::new(self.inner.clone()).set_name(name.into())
+    pub fn get_index(&self) -> super::builder::index_service::GetIndex {
+        super::builder::index_service::GetIndex::new(self.inner.clone())
     }
 
     /// Lists Indexes in a Location.
-    pub fn list_indexes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::index_service::ListIndexes {
+    pub fn list_indexes(&self) -> super::builder::index_service::ListIndexes {
         super::builder::index_service::ListIndexes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an Index.
@@ -4317,11 +3571,8 @@ impl IndexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_index(
-        &self,
-        index: impl Into<crate::model::Index>,
-    ) -> super::builder::index_service::UpdateIndex {
-        super::builder::index_service::UpdateIndex::new(self.inner.clone()).set_index(index.into())
+    pub fn update_index(&self) -> super::builder::index_service::UpdateIndex {
+        super::builder::index_service::UpdateIndex::new(self.inner.clone())
     }
 
     /// Deletes an Index.
@@ -4340,45 +3591,28 @@ impl IndexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_index(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::DeleteIndex {
-        super::builder::index_service::DeleteIndex::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_index(&self) -> super::builder::index_service::DeleteIndex {
+        super::builder::index_service::DeleteIndex::new(self.inner.clone())
     }
 
     /// Add/update Datapoints into an Index.
-    pub fn upsert_datapoints(
-        &self,
-        index: impl Into<std::string::String>,
-    ) -> super::builder::index_service::UpsertDatapoints {
+    pub fn upsert_datapoints(&self) -> super::builder::index_service::UpsertDatapoints {
         super::builder::index_service::UpsertDatapoints::new(self.inner.clone())
-            .set_index(index.into())
     }
 
     /// Remove Datapoints from an Index.
-    pub fn remove_datapoints(
-        &self,
-        index: impl Into<std::string::String>,
-    ) -> super::builder::index_service::RemoveDatapoints {
+    pub fn remove_datapoints(&self) -> super::builder::index_service::RemoveDatapoints {
         super::builder::index_service::RemoveDatapoints::new(self.inner.clone())
-            .set_index(index.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::ListLocations {
-        super::builder::index_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::index_service::ListLocations {
+        super::builder::index_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::GetLocation {
-        super::builder::index_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::index_service::GetLocation {
+        super::builder::index_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -4386,22 +3620,14 @@ impl IndexService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::index_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::index_service::SetIamPolicy {
         super::builder::index_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::index_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::index_service::GetIamPolicy {
         super::builder::index_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -4411,64 +3637,43 @@ impl IndexService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::index_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::index_service::TestIamPermissions {
         super::builder::index_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::ListOperations {
-        super::builder::index_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::index_service::ListOperations {
+        super::builder::index_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::GetOperation {
-        super::builder::index_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::index_service::GetOperation {
+        super::builder::index_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::index_service::DeleteOperation {
         super::builder::index_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::index_service::CancelOperation {
         super::builder::index_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::index_service::WaitOperation {
-        super::builder::index_service::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::index_service::WaitOperation {
+        super::builder::index_service::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -4577,29 +3782,18 @@ impl JobService {
 
     /// Creates a CustomJob. A created CustomJob right away
     /// will be attempted to be run.
-    pub fn create_custom_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CreateCustomJob {
+    pub fn create_custom_job(&self) -> super::builder::job_service::CreateCustomJob {
         super::builder::job_service::CreateCustomJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a CustomJob.
-    pub fn get_custom_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetCustomJob {
-        super::builder::job_service::GetCustomJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_custom_job(&self) -> super::builder::job_service::GetCustomJob {
+        super::builder::job_service::GetCustomJob::new(self.inner.clone())
     }
 
     /// Lists CustomJobs in a Location.
-    pub fn list_custom_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListCustomJobs {
+    pub fn list_custom_jobs(&self) -> super::builder::job_service::ListCustomJobs {
         super::builder::job_service::ListCustomJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a CustomJob.
@@ -4613,11 +3807,8 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_custom_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::DeleteCustomJob {
-        super::builder::job_service::DeleteCustomJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_custom_job(&self) -> super::builder::job_service::DeleteCustomJob {
+        super::builder::job_service::DeleteCustomJob::new(self.inner.clone())
     }
 
     /// Cancels a CustomJob.
@@ -4638,38 +3829,23 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.CustomJob.state]: crate::model::CustomJob::state
     /// [google.cloud.aiplatform.v1.JobService.GetCustomJob]: crate::client::JobService::get_custom_job
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_custom_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CancelCustomJob {
-        super::builder::job_service::CancelCustomJob::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_custom_job(&self) -> super::builder::job_service::CancelCustomJob {
+        super::builder::job_service::CancelCustomJob::new(self.inner.clone())
     }
 
     /// Creates a DataLabelingJob.
-    pub fn create_data_labeling_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CreateDataLabelingJob {
+    pub fn create_data_labeling_job(&self) -> super::builder::job_service::CreateDataLabelingJob {
         super::builder::job_service::CreateDataLabelingJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a DataLabelingJob.
-    pub fn get_data_labeling_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetDataLabelingJob {
+    pub fn get_data_labeling_job(&self) -> super::builder::job_service::GetDataLabelingJob {
         super::builder::job_service::GetDataLabelingJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataLabelingJobs in a Location.
-    pub fn list_data_labeling_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListDataLabelingJobs {
+    pub fn list_data_labeling_jobs(&self) -> super::builder::job_service::ListDataLabelingJobs {
         super::builder::job_service::ListDataLabelingJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a DataLabelingJob.
@@ -4683,48 +3859,34 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_data_labeling_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::DeleteDataLabelingJob {
+    pub fn delete_data_labeling_job(&self) -> super::builder::job_service::DeleteDataLabelingJob {
         super::builder::job_service::DeleteDataLabelingJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a DataLabelingJob. Success of cancellation is not guaranteed.
-    pub fn cancel_data_labeling_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CancelDataLabelingJob {
+    pub fn cancel_data_labeling_job(&self) -> super::builder::job_service::CancelDataLabelingJob {
         super::builder::job_service::CancelDataLabelingJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a HyperparameterTuningJob
     pub fn create_hyperparameter_tuning_job(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::CreateHyperparameterTuningJob {
         super::builder::job_service::CreateHyperparameterTuningJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a HyperparameterTuningJob
     pub fn get_hyperparameter_tuning_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::GetHyperparameterTuningJob {
         super::builder::job_service::GetHyperparameterTuningJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists HyperparameterTuningJobs in a Location.
     pub fn list_hyperparameter_tuning_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::ListHyperparameterTuningJobs {
         super::builder::job_service::ListHyperparameterTuningJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a HyperparameterTuningJob.
@@ -4740,10 +3902,8 @@ impl JobService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_hyperparameter_tuning_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::DeleteHyperparameterTuningJob {
         super::builder::job_service::DeleteHyperparameterTuningJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a HyperparameterTuningJob.
@@ -4767,34 +3927,23 @@ impl JobService {
     /// [google.rpc.Status.code]: rpc::model::Status::code
     pub fn cancel_hyperparameter_tuning_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::CancelHyperparameterTuningJob {
         super::builder::job_service::CancelHyperparameterTuningJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a NasJob
-    pub fn create_nas_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CreateNasJob {
-        super::builder::job_service::CreateNasJob::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_nas_job(&self) -> super::builder::job_service::CreateNasJob {
+        super::builder::job_service::CreateNasJob::new(self.inner.clone())
     }
 
     /// Gets a NasJob
-    pub fn get_nas_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetNasJob {
-        super::builder::job_service::GetNasJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_nas_job(&self) -> super::builder::job_service::GetNasJob {
+        super::builder::job_service::GetNasJob::new(self.inner.clone())
     }
 
     /// Lists NasJobs in a Location.
-    pub fn list_nas_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListNasJobs {
-        super::builder::job_service::ListNasJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_nas_jobs(&self) -> super::builder::job_service::ListNasJobs {
+        super::builder::job_service::ListNasJobs::new(self.inner.clone())
     }
 
     /// Deletes a NasJob.
@@ -4808,11 +3957,8 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_nas_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::DeleteNasJob {
-        super::builder::job_service::DeleteNasJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_nas_job(&self) -> super::builder::job_service::DeleteNasJob {
+        super::builder::job_service::DeleteNasJob::new(self.inner.clone())
     }
 
     /// Cancels a NasJob.
@@ -4833,57 +3979,38 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.NasJob.error]: crate::model::NasJob::error
     /// [google.cloud.aiplatform.v1.NasJob.state]: crate::model::NasJob::state
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_nas_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CancelNasJob {
-        super::builder::job_service::CancelNasJob::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_nas_job(&self) -> super::builder::job_service::CancelNasJob {
+        super::builder::job_service::CancelNasJob::new(self.inner.clone())
     }
 
     /// Gets a NasTrialDetail.
-    pub fn get_nas_trial_detail(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetNasTrialDetail {
+    pub fn get_nas_trial_detail(&self) -> super::builder::job_service::GetNasTrialDetail {
         super::builder::job_service::GetNasTrialDetail::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List top NasTrialDetails of a NasJob.
-    pub fn list_nas_trial_details(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListNasTrialDetails {
+    pub fn list_nas_trial_details(&self) -> super::builder::job_service::ListNasTrialDetails {
         super::builder::job_service::ListNasTrialDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a BatchPredictionJob. A BatchPredictionJob once created will
     /// right away be attempted to start.
     pub fn create_batch_prediction_job(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::CreateBatchPredictionJob {
         super::builder::job_service::CreateBatchPredictionJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a BatchPredictionJob
-    pub fn get_batch_prediction_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetBatchPredictionJob {
+    pub fn get_batch_prediction_job(&self) -> super::builder::job_service::GetBatchPredictionJob {
         super::builder::job_service::GetBatchPredictionJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists BatchPredictionJobs in a Location.
     pub fn list_batch_prediction_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::ListBatchPredictionJobs {
         super::builder::job_service::ListBatchPredictionJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a BatchPredictionJob. Can only be called on jobs that already
@@ -4900,10 +4027,8 @@ impl JobService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_batch_prediction_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::DeleteBatchPredictionJob {
         super::builder::job_service::DeleteBatchPredictionJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a BatchPredictionJob.
@@ -4923,49 +4048,39 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.JobService.GetBatchPredictionJob]: crate::client::JobService::get_batch_prediction_job
     pub fn cancel_batch_prediction_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::CancelBatchPredictionJob {
         super::builder::job_service::CancelBatchPredictionJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a ModelDeploymentMonitoringJob. It will run periodically on a
     /// configured interval.
     pub fn create_model_deployment_monitoring_job(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::CreateModelDeploymentMonitoringJob {
         super::builder::job_service::CreateModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Searches Model Monitoring Statistics generated within a given time window.
     pub fn search_model_deployment_monitoring_stats_anomalies(
         &self,
-        model_deployment_monitoring_job: impl Into<std::string::String>,
     ) -> super::builder::job_service::SearchModelDeploymentMonitoringStatsAnomalies {
         super::builder::job_service::SearchModelDeploymentMonitoringStatsAnomalies::new(
             self.inner.clone(),
         )
-        .set_model_deployment_monitoring_job(model_deployment_monitoring_job.into())
     }
 
     /// Gets a ModelDeploymentMonitoringJob.
     pub fn get_model_deployment_monitoring_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::GetModelDeploymentMonitoringJob {
         super::builder::job_service::GetModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ModelDeploymentMonitoringJobs in a Location.
     pub fn list_model_deployment_monitoring_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::job_service::ListModelDeploymentMonitoringJobs {
         super::builder::job_service::ListModelDeploymentMonitoringJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a ModelDeploymentMonitoringJob.
@@ -4981,10 +4096,8 @@ impl JobService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_model_deployment_monitoring_job(
         &self,
-        model_deployment_monitoring_job: impl Into<crate::model::ModelDeploymentMonitoringJob>,
     ) -> super::builder::job_service::UpdateModelDeploymentMonitoringJob {
         super::builder::job_service::UpdateModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_model_deployment_monitoring_job(model_deployment_monitoring_job.into())
     }
 
     /// Deletes a ModelDeploymentMonitoringJob.
@@ -5000,10 +4113,8 @@ impl JobService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_model_deployment_monitoring_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::DeleteModelDeploymentMonitoringJob {
         super::builder::job_service::DeleteModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Pauses a ModelDeploymentMonitoringJob. If the job is running, the server
@@ -5014,10 +4125,8 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringJob.state]: crate::model::ModelDeploymentMonitoringJob::state
     pub fn pause_model_deployment_monitoring_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::PauseModelDeploymentMonitoringJob {
         super::builder::job_service::PauseModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resumes a paused ModelDeploymentMonitoringJob. It will start to run from
@@ -5025,26 +4134,18 @@ impl JobService {
     /// resumed.
     pub fn resume_model_deployment_monitoring_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::job_service::ResumeModelDeploymentMonitoringJob {
         super::builder::job_service::ResumeModelDeploymentMonitoringJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListLocations {
-        super::builder::job_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::job_service::ListLocations {
+        super::builder::job_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetLocation {
-        super::builder::job_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::job_service::GetLocation {
+        super::builder::job_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -5052,22 +4153,14 @@ impl JobService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::job_service::SetIamPolicy {
         super::builder::job_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::job_service::GetIamPolicy {
         super::builder::job_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -5077,62 +4170,43 @@ impl JobService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::job_service::TestIamPermissions {
         super::builder::job_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListOperations {
-        super::builder::job_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::job_service::ListOperations {
+        super::builder::job_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetOperation {
-        super::builder::job_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::job_service::GetOperation {
+        super::builder::job_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::DeleteOperation {
-        super::builder::job_service::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::job_service::DeleteOperation {
+        super::builder::job_service::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CancelOperation {
-        super::builder::job_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::job_service::CancelOperation {
+        super::builder::job_service::CancelOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::WaitOperation {
-        super::builder::job_service::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::job_service::WaitOperation {
+        super::builder::job_service::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -5242,39 +4316,23 @@ impl LlmUtilityService {
     }
 
     /// Perform a token counting.
-    pub fn count_tokens(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::CountTokens {
+    pub fn count_tokens(&self) -> super::builder::llm_utility_service::CountTokens {
         super::builder::llm_utility_service::CountTokens::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Return a list of tokens based on the input text.
-    pub fn compute_tokens(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::ComputeTokens {
+    pub fn compute_tokens(&self) -> super::builder::llm_utility_service::ComputeTokens {
         super::builder::llm_utility_service::ComputeTokens::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::llm_utility_service::ListLocations {
         super::builder::llm_utility_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::llm_utility_service::GetLocation {
         super::builder::llm_utility_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -5282,22 +4340,14 @@ impl LlmUtilityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::llm_utility_service::SetIamPolicy {
         super::builder::llm_utility_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::llm_utility_service::GetIamPolicy {
         super::builder::llm_utility_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -5307,67 +4357,43 @@ impl LlmUtilityService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::llm_utility_service::TestIamPermissions {
         super::builder::llm_utility_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::llm_utility_service::ListOperations {
         super::builder::llm_utility_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::llm_utility_service::GetOperation {
         super::builder::llm_utility_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::llm_utility_service::DeleteOperation {
         super::builder::llm_utility_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::llm_utility_service::CancelOperation {
         super::builder::llm_utility_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::llm_utility_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::llm_utility_service::WaitOperation {
         super::builder::llm_utility_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -5476,38 +4502,24 @@ impl MatchService {
     }
 
     /// Finds the nearest neighbors of each vector within the request.
-    pub fn find_neighbors(
-        &self,
-        index_endpoint: impl Into<std::string::String>,
-    ) -> super::builder::match_service::FindNeighbors {
+    pub fn find_neighbors(&self) -> super::builder::match_service::FindNeighbors {
         super::builder::match_service::FindNeighbors::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Reads the datapoints/vectors of the given IDs.
     /// A maximum of 1000 datapoints can be retrieved in a batch.
-    pub fn read_index_datapoints(
-        &self,
-        index_endpoint: impl Into<std::string::String>,
-    ) -> super::builder::match_service::ReadIndexDatapoints {
+    pub fn read_index_datapoints(&self) -> super::builder::match_service::ReadIndexDatapoints {
         super::builder::match_service::ReadIndexDatapoints::new(self.inner.clone())
-            .set_index_endpoint(index_endpoint.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::ListLocations {
-        super::builder::match_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::match_service::ListLocations {
+        super::builder::match_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::GetLocation {
-        super::builder::match_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::match_service::GetLocation {
+        super::builder::match_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -5515,22 +4527,14 @@ impl MatchService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::match_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::match_service::SetIamPolicy {
         super::builder::match_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::match_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::match_service::GetIamPolicy {
         super::builder::match_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -5540,64 +4544,43 @@ impl MatchService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::match_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::match_service::TestIamPermissions {
         super::builder::match_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::ListOperations {
-        super::builder::match_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::match_service::ListOperations {
+        super::builder::match_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::GetOperation {
-        super::builder::match_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::match_service::GetOperation {
+        super::builder::match_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::match_service::DeleteOperation {
         super::builder::match_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::match_service::CancelOperation {
         super::builder::match_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::match_service::WaitOperation {
-        super::builder::match_service::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::match_service::WaitOperation {
+        super::builder::match_service::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -5717,30 +4700,18 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_metadata_store(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateMetadataStore {
+    pub fn create_metadata_store(&self) -> super::builder::metadata_service::CreateMetadataStore {
         super::builder::metadata_service::CreateMetadataStore::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a specific MetadataStore.
-    pub fn get_metadata_store(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetMetadataStore {
+    pub fn get_metadata_store(&self) -> super::builder::metadata_service::GetMetadataStore {
         super::builder::metadata_service::GetMetadataStore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists MetadataStores for a Location.
-    pub fn list_metadata_stores(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListMetadataStores {
+    pub fn list_metadata_stores(&self) -> super::builder::metadata_service::ListMetadataStores {
         super::builder::metadata_service::ListMetadataStores::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single MetadataStore and all its child resources (Artifacts,
@@ -5755,47 +4726,28 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_metadata_store(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteMetadataStore {
+    pub fn delete_metadata_store(&self) -> super::builder::metadata_service::DeleteMetadataStore {
         super::builder::metadata_service::DeleteMetadataStore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an Artifact associated with a MetadataStore.
-    pub fn create_artifact(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateArtifact {
+    pub fn create_artifact(&self) -> super::builder::metadata_service::CreateArtifact {
         super::builder::metadata_service::CreateArtifact::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a specific Artifact.
-    pub fn get_artifact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetArtifact {
-        super::builder::metadata_service::GetArtifact::new(self.inner.clone()).set_name(name.into())
+    pub fn get_artifact(&self) -> super::builder::metadata_service::GetArtifact {
+        super::builder::metadata_service::GetArtifact::new(self.inner.clone())
     }
 
     /// Lists Artifacts in the MetadataStore.
-    pub fn list_artifacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListArtifacts {
+    pub fn list_artifacts(&self) -> super::builder::metadata_service::ListArtifacts {
         super::builder::metadata_service::ListArtifacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a stored Artifact.
-    pub fn update_artifact(
-        &self,
-        artifact: impl Into<crate::model::Artifact>,
-    ) -> super::builder::metadata_service::UpdateArtifact {
+    pub fn update_artifact(&self) -> super::builder::metadata_service::UpdateArtifact {
         super::builder::metadata_service::UpdateArtifact::new(self.inner.clone())
-            .set_artifact(artifact.into())
     }
 
     /// Deletes an Artifact.
@@ -5809,12 +4761,8 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_artifact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteArtifact {
+    pub fn delete_artifact(&self) -> super::builder::metadata_service::DeleteArtifact {
         super::builder::metadata_service::DeleteArtifact::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Purges Artifacts.
@@ -5828,47 +4776,28 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_artifacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::PurgeArtifacts {
+    pub fn purge_artifacts(&self) -> super::builder::metadata_service::PurgeArtifacts {
         super::builder::metadata_service::PurgeArtifacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a Context associated with a MetadataStore.
-    pub fn create_context(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateContext {
+    pub fn create_context(&self) -> super::builder::metadata_service::CreateContext {
         super::builder::metadata_service::CreateContext::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a specific Context.
-    pub fn get_context(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetContext {
-        super::builder::metadata_service::GetContext::new(self.inner.clone()).set_name(name.into())
+    pub fn get_context(&self) -> super::builder::metadata_service::GetContext {
+        super::builder::metadata_service::GetContext::new(self.inner.clone())
     }
 
     /// Lists Contexts on the MetadataStore.
-    pub fn list_contexts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListContexts {
+    pub fn list_contexts(&self) -> super::builder::metadata_service::ListContexts {
         super::builder::metadata_service::ListContexts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a stored Context.
-    pub fn update_context(
-        &self,
-        context: impl Into<crate::model::Context>,
-    ) -> super::builder::metadata_service::UpdateContext {
+    pub fn update_context(&self) -> super::builder::metadata_service::UpdateContext {
         super::builder::metadata_service::UpdateContext::new(self.inner.clone())
-            .set_context(context.into())
     }
 
     /// Deletes a stored Context.
@@ -5882,12 +4811,8 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_context(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteContext {
+    pub fn delete_context(&self) -> super::builder::metadata_service::DeleteContext {
         super::builder::metadata_service::DeleteContext::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Purges Contexts.
@@ -5901,12 +4826,8 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_contexts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::PurgeContexts {
+    pub fn purge_contexts(&self) -> super::builder::metadata_service::PurgeContexts {
         super::builder::metadata_service::PurgeContexts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds a set of Artifacts and Executions to a Context. If any of the
@@ -5914,10 +4835,8 @@ impl MetadataService {
     /// simply skipped.
     pub fn add_context_artifacts_and_executions(
         &self,
-        context: impl Into<std::string::String>,
     ) -> super::builder::metadata_service::AddContextArtifactsAndExecutions {
         super::builder::metadata_service::AddContextArtifactsAndExecutions::new(self.inner.clone())
-            .set_context(context.into())
     }
 
     /// Adds a set of Contexts as children to a parent Context. If any of the
@@ -5925,12 +4844,8 @@ impl MetadataService {
     /// simply skipped. If this call would create a cycle or cause any Context to
     /// have more than 10 parents, the request will fail with an INVALID_ARGUMENT
     /// error.
-    pub fn add_context_children(
-        &self,
-        context: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::AddContextChildren {
+    pub fn add_context_children(&self) -> super::builder::metadata_service::AddContextChildren {
         super::builder::metadata_service::AddContextChildren::new(self.inner.clone())
-            .set_context(context.into())
     }
 
     /// Remove a set of children contexts from a parent Context. If any of the
@@ -5938,56 +4853,36 @@ impl MetadataService {
     /// simply skipped.
     pub fn remove_context_children(
         &self,
-        context: impl Into<std::string::String>,
     ) -> super::builder::metadata_service::RemoveContextChildren {
         super::builder::metadata_service::RemoveContextChildren::new(self.inner.clone())
-            .set_context(context.into())
     }
 
     /// Retrieves Artifacts and Executions within the specified Context, connected
     /// by Event edges and returned as a LineageSubgraph.
     pub fn query_context_lineage_subgraph(
         &self,
-        context: impl Into<std::string::String>,
     ) -> super::builder::metadata_service::QueryContextLineageSubgraph {
         super::builder::metadata_service::QueryContextLineageSubgraph::new(self.inner.clone())
-            .set_context(context.into())
     }
 
     /// Creates an Execution associated with a MetadataStore.
-    pub fn create_execution(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateExecution {
+    pub fn create_execution(&self) -> super::builder::metadata_service::CreateExecution {
         super::builder::metadata_service::CreateExecution::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a specific Execution.
-    pub fn get_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetExecution {
+    pub fn get_execution(&self) -> super::builder::metadata_service::GetExecution {
         super::builder::metadata_service::GetExecution::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Executions in the MetadataStore.
-    pub fn list_executions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListExecutions {
+    pub fn list_executions(&self) -> super::builder::metadata_service::ListExecutions {
         super::builder::metadata_service::ListExecutions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a stored Execution.
-    pub fn update_execution(
-        &self,
-        execution: impl Into<crate::model::Execution>,
-    ) -> super::builder::metadata_service::UpdateExecution {
+    pub fn update_execution(&self) -> super::builder::metadata_service::UpdateExecution {
         super::builder::metadata_service::UpdateExecution::new(self.inner.clone())
-            .set_execution(execution.into())
     }
 
     /// Deletes an Execution.
@@ -6001,12 +4896,8 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteExecution {
+    pub fn delete_execution(&self) -> super::builder::metadata_service::DeleteExecution {
         super::builder::metadata_service::DeleteExecution::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Purges Executions.
@@ -6020,24 +4911,16 @@ impl MetadataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_executions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::PurgeExecutions {
+    pub fn purge_executions(&self) -> super::builder::metadata_service::PurgeExecutions {
         super::builder::metadata_service::PurgeExecutions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds Events to the specified Execution. An Event indicates whether an
     /// Artifact was used as an input or output for an Execution. If an Event
     /// already exists between the Execution and the Artifact, the Event is
     /// skipped.
-    pub fn add_execution_events(
-        &self,
-        execution: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::AddExecutionEvents {
+    pub fn add_execution_events(&self) -> super::builder::metadata_service::AddExecutionEvents {
         super::builder::metadata_service::AddExecutionEvents::new(self.inner.clone())
-            .set_execution(execution.into())
     }
 
     /// Obtains the set of input and output Artifacts for this Execution, in the
@@ -6045,64 +4928,41 @@ impl MetadataService {
     /// Events.
     pub fn query_execution_inputs_and_outputs(
         &self,
-        execution: impl Into<std::string::String>,
     ) -> super::builder::metadata_service::QueryExecutionInputsAndOutputs {
         super::builder::metadata_service::QueryExecutionInputsAndOutputs::new(self.inner.clone())
-            .set_execution(execution.into())
     }
 
     /// Creates a MetadataSchema.
-    pub fn create_metadata_schema(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateMetadataSchema {
+    pub fn create_metadata_schema(&self) -> super::builder::metadata_service::CreateMetadataSchema {
         super::builder::metadata_service::CreateMetadataSchema::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a specific MetadataSchema.
-    pub fn get_metadata_schema(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetMetadataSchema {
+    pub fn get_metadata_schema(&self) -> super::builder::metadata_service::GetMetadataSchema {
         super::builder::metadata_service::GetMetadataSchema::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists MetadataSchemas.
-    pub fn list_metadata_schemas(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListMetadataSchemas {
+    pub fn list_metadata_schemas(&self) -> super::builder::metadata_service::ListMetadataSchemas {
         super::builder::metadata_service::ListMetadataSchemas::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves lineage of an Artifact represented through Artifacts and
     /// Executions connected by Event edges and returned as a LineageSubgraph.
     pub fn query_artifact_lineage_subgraph(
         &self,
-        artifact: impl Into<std::string::String>,
     ) -> super::builder::metadata_service::QueryArtifactLineageSubgraph {
         super::builder::metadata_service::QueryArtifactLineageSubgraph::new(self.inner.clone())
-            .set_artifact(artifact.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::metadata_service::ListLocations {
         super::builder::metadata_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetLocation {
-        super::builder::metadata_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::metadata_service::GetLocation {
+        super::builder::metadata_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -6110,22 +4970,14 @@ impl MetadataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::metadata_service::SetIamPolicy {
         super::builder::metadata_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::metadata_service::GetIamPolicy {
         super::builder::metadata_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -6135,67 +4987,43 @@ impl MetadataService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::metadata_service::TestIamPermissions {
         super::builder::metadata_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::metadata_service::ListOperations {
         super::builder::metadata_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::metadata_service::GetOperation {
         super::builder::metadata_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::metadata_service::DeleteOperation {
         super::builder::metadata_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::metadata_service::CancelOperation {
         super::builder::metadata_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::metadata_service::WaitOperation {
         super::builder::metadata_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -6310,10 +5138,8 @@ impl MigrationService {
     /// Vertex AI's given location.
     pub fn search_migratable_resources(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_service::SearchMigratableResources {
         super::builder::migration_service::SearchMigratableResources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Batch migrates resources from ml.googleapis.com, automl.googleapis.com,
@@ -6330,28 +5156,18 @@ impl MigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_migrate_resources(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_service::BatchMigrateResources {
         super::builder::migration_service::BatchMigrateResources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::migration_service::ListLocations {
         super::builder::migration_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::migration_service::GetLocation {
         super::builder::migration_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -6359,22 +5175,14 @@ impl MigrationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::migration_service::SetIamPolicy {
         super::builder::migration_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::migration_service::GetIamPolicy {
         super::builder::migration_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -6384,67 +5192,43 @@ impl MigrationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::migration_service::TestIamPermissions {
         super::builder::migration_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::migration_service::ListOperations {
         super::builder::migration_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::migration_service::GetOperation {
         super::builder::migration_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::migration_service::DeleteOperation {
         super::builder::migration_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::migration_service::CancelOperation {
         super::builder::migration_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::migration_service::WaitOperation {
         super::builder::migration_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -6554,30 +5338,18 @@ impl ModelGardenService {
     }
 
     /// Gets a Model Garden publisher model.
-    pub fn get_publisher_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::GetPublisherModel {
+    pub fn get_publisher_model(&self) -> super::builder::model_garden_service::GetPublisherModel {
         super::builder::model_garden_service::GetPublisherModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::model_garden_service::ListLocations {
         super::builder::model_garden_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::model_garden_service::GetLocation {
         super::builder::model_garden_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -6585,22 +5357,14 @@ impl ModelGardenService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::model_garden_service::SetIamPolicy {
         super::builder::model_garden_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::model_garden_service::GetIamPolicy {
         super::builder::model_garden_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -6610,67 +5374,43 @@ impl ModelGardenService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::model_garden_service::TestIamPermissions {
         super::builder::model_garden_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::model_garden_service::ListOperations {
         super::builder::model_garden_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::model_garden_service::GetOperation {
         super::builder::model_garden_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::model_garden_service::DeleteOperation {
         super::builder::model_garden_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::model_garden_service::CancelOperation {
         super::builder::model_garden_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_garden_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::model_garden_service::WaitOperation {
         super::builder::model_garden_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -6788,54 +5528,35 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn upload_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::UploadModel {
+    pub fn upload_model(&self) -> super::builder::model_service::UploadModel {
         super::builder::model_service::UploadModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Model.
-    pub fn get_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetModel {
-        super::builder::model_service::GetModel::new(self.inner.clone()).set_name(name.into())
+    pub fn get_model(&self) -> super::builder::model_service::GetModel {
+        super::builder::model_service::GetModel::new(self.inner.clone())
     }
 
     /// Lists Models in a Location.
-    pub fn list_models(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListModels {
-        super::builder::model_service::ListModels::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_models(&self) -> super::builder::model_service::ListModels {
+        super::builder::model_service::ListModels::new(self.inner.clone())
     }
 
     /// Lists versions of the specified model.
-    pub fn list_model_versions(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListModelVersions {
+    pub fn list_model_versions(&self) -> super::builder::model_service::ListModelVersions {
         super::builder::model_service::ListModelVersions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists checkpoints of the specified model version.
     pub fn list_model_version_checkpoints(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::model_service::ListModelVersionCheckpoints {
         super::builder::model_service::ListModelVersionCheckpoints::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Model.
-    pub fn update_model(
-        &self,
-        model: impl Into<crate::model::Model>,
-    ) -> super::builder::model_service::UpdateModel {
-        super::builder::model_service::UpdateModel::new(self.inner.clone()).set_model(model.into())
+    pub fn update_model(&self) -> super::builder::model_service::UpdateModel {
+        super::builder::model_service::UpdateModel::new(self.inner.clone())
     }
 
     /// Incrementally update the dataset used for an examples model.
@@ -6851,10 +5572,8 @@ impl ModelService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_explanation_dataset(
         &self,
-        model: impl Into<std::string::String>,
     ) -> super::builder::model_service::UpdateExplanationDataset {
         super::builder::model_service::UpdateExplanationDataset::new(self.inner.clone())
-            .set_model(model.into())
     }
 
     /// Deletes a Model.
@@ -6879,11 +5598,8 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::DeleteModel {
-        super::builder::model_service::DeleteModel::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_model(&self) -> super::builder::model_service::DeleteModel {
+        super::builder::model_service::DeleteModel::new(self.inner.clone())
     }
 
     /// Deletes a Model version.
@@ -6906,21 +5622,13 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_model_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::DeleteModelVersion {
+    pub fn delete_model_version(&self) -> super::builder::model_service::DeleteModelVersion {
         super::builder::model_service::DeleteModelVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Merges a set of aliases for a Model version.
-    pub fn merge_version_aliases(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::MergeVersionAliases {
+    pub fn merge_version_aliases(&self) -> super::builder::model_service::MergeVersionAliases {
         super::builder::model_service::MergeVersionAliases::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Exports a trained, exportable Model to a location specified by the
@@ -6939,11 +5647,8 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ExportModel {
-        super::builder::model_service::ExportModel::new(self.inner.clone()).set_name(name.into())
+    pub fn export_model(&self) -> super::builder::model_service::ExportModel {
+        super::builder::model_service::ExportModel::new(self.inner.clone())
     }
 
     /// Copies an already existing Vertex AI Model into the specified Location.
@@ -6964,90 +5669,61 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn copy_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::CopyModel {
-        super::builder::model_service::CopyModel::new(self.inner.clone()).set_parent(parent.into())
+    pub fn copy_model(&self) -> super::builder::model_service::CopyModel {
+        super::builder::model_service::CopyModel::new(self.inner.clone())
     }
 
     /// Imports an externally generated ModelEvaluation.
-    pub fn import_model_evaluation(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ImportModelEvaluation {
+    pub fn import_model_evaluation(&self) -> super::builder::model_service::ImportModelEvaluation {
         super::builder::model_service::ImportModelEvaluation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports a list of externally generated ModelEvaluationSlice.
     pub fn batch_import_model_evaluation_slices(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::model_service::BatchImportModelEvaluationSlices {
         super::builder::model_service::BatchImportModelEvaluationSlices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports a list of externally generated EvaluatedAnnotations.
     pub fn batch_import_evaluated_annotations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::model_service::BatchImportEvaluatedAnnotations {
         super::builder::model_service::BatchImportEvaluatedAnnotations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a ModelEvaluation.
-    pub fn get_model_evaluation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetModelEvaluation {
+    pub fn get_model_evaluation(&self) -> super::builder::model_service::GetModelEvaluation {
         super::builder::model_service::GetModelEvaluation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ModelEvaluations in a Model.
-    pub fn list_model_evaluations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListModelEvaluations {
+    pub fn list_model_evaluations(&self) -> super::builder::model_service::ListModelEvaluations {
         super::builder::model_service::ListModelEvaluations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a ModelEvaluationSlice.
     pub fn get_model_evaluation_slice(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::model_service::GetModelEvaluationSlice {
         super::builder::model_service::GetModelEvaluationSlice::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ModelEvaluationSlices in a ModelEvaluation.
     pub fn list_model_evaluation_slices(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::model_service::ListModelEvaluationSlices {
         super::builder::model_service::ListModelEvaluationSlices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListLocations {
-        super::builder::model_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::model_service::ListLocations {
+        super::builder::model_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetLocation {
-        super::builder::model_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::model_service::GetLocation {
+        super::builder::model_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -7055,22 +5731,14 @@ impl ModelService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::model_service::SetIamPolicy {
         super::builder::model_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::model_service::GetIamPolicy {
         super::builder::model_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -7080,64 +5748,43 @@ impl ModelService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::model_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::model_service::TestIamPermissions {
         super::builder::model_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListOperations {
-        super::builder::model_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::model_service::ListOperations {
+        super::builder::model_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetOperation {
-        super::builder::model_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::model_service::GetOperation {
+        super::builder::model_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::model_service::DeleteOperation {
         super::builder::model_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::model_service::CancelOperation {
         super::builder::model_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::WaitOperation {
-        super::builder::model_service::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::model_service::WaitOperation {
+        super::builder::model_service::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -7259,28 +5906,22 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_notebook_runtime_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::CreateNotebookRuntimeTemplate {
         super::builder::notebook_service::CreateNotebookRuntimeTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a NotebookRuntimeTemplate.
     pub fn get_notebook_runtime_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::GetNotebookRuntimeTemplate {
         super::builder::notebook_service::GetNotebookRuntimeTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists NotebookRuntimeTemplates in a Location.
     pub fn list_notebook_runtime_templates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::ListNotebookRuntimeTemplates {
         super::builder::notebook_service::ListNotebookRuntimeTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a NotebookRuntimeTemplate.
@@ -7296,19 +5937,15 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_notebook_runtime_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::DeleteNotebookRuntimeTemplate {
         super::builder::notebook_service::DeleteNotebookRuntimeTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a NotebookRuntimeTemplate.
     pub fn update_notebook_runtime_template(
         &self,
-        notebook_runtime_template: impl Into<crate::model::NotebookRuntimeTemplate>,
     ) -> super::builder::notebook_service::UpdateNotebookRuntimeTemplate {
         super::builder::notebook_service::UpdateNotebookRuntimeTemplate::new(self.inner.clone())
-            .set_notebook_runtime_template(notebook_runtime_template.into())
     }
 
     /// Assigns a NotebookRuntime to a user for a particular Notebook file. This
@@ -7325,28 +5962,18 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn assign_notebook_runtime(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::AssignNotebookRuntime {
         super::builder::notebook_service::AssignNotebookRuntime::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a NotebookRuntime.
-    pub fn get_notebook_runtime(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetNotebookRuntime {
+    pub fn get_notebook_runtime(&self) -> super::builder::notebook_service::GetNotebookRuntime {
         super::builder::notebook_service::GetNotebookRuntime::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists NotebookRuntimes in a Location.
-    pub fn list_notebook_runtimes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListNotebookRuntimes {
+    pub fn list_notebook_runtimes(&self) -> super::builder::notebook_service::ListNotebookRuntimes {
         super::builder::notebook_service::ListNotebookRuntimes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a NotebookRuntime.
@@ -7362,10 +5989,8 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_notebook_runtime(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::DeleteNotebookRuntime {
         super::builder::notebook_service::DeleteNotebookRuntime::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Upgrades a NotebookRuntime.
@@ -7381,10 +6006,8 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn upgrade_notebook_runtime(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::UpgradeNotebookRuntime {
         super::builder::notebook_service::UpgradeNotebookRuntime::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts a NotebookRuntime.
@@ -7398,12 +6021,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_notebook_runtime(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::StartNotebookRuntime {
+    pub fn start_notebook_runtime(&self) -> super::builder::notebook_service::StartNotebookRuntime {
         super::builder::notebook_service::StartNotebookRuntime::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stops a NotebookRuntime.
@@ -7417,12 +6036,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_notebook_runtime(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::StopNotebookRuntime {
+    pub fn stop_notebook_runtime(&self) -> super::builder::notebook_service::StopNotebookRuntime {
         super::builder::notebook_service::StopNotebookRuntime::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a NotebookExecutionJob.
@@ -7438,28 +6053,22 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_notebook_execution_job(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::CreateNotebookExecutionJob {
         super::builder::notebook_service::CreateNotebookExecutionJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a NotebookExecutionJob.
     pub fn get_notebook_execution_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::GetNotebookExecutionJob {
         super::builder::notebook_service::GetNotebookExecutionJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists NotebookExecutionJobs in a Location.
     pub fn list_notebook_execution_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::ListNotebookExecutionJobs {
         super::builder::notebook_service::ListNotebookExecutionJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a NotebookExecutionJob.
@@ -7475,27 +6084,18 @@ impl NotebookService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_notebook_execution_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::DeleteNotebookExecutionJob {
         super::builder::notebook_service::DeleteNotebookExecutionJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::notebook_service::ListLocations {
         super::builder::notebook_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetLocation {
-        super::builder::notebook_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::notebook_service::GetLocation {
+        super::builder::notebook_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -7503,22 +6103,14 @@ impl NotebookService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::notebook_service::SetIamPolicy {
         super::builder::notebook_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::notebook_service::GetIamPolicy {
         super::builder::notebook_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -7528,67 +6120,43 @@ impl NotebookService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::notebook_service::TestIamPermissions {
         super::builder::notebook_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::notebook_service::ListOperations {
         super::builder::notebook_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::notebook_service::GetOperation {
         super::builder::notebook_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::notebook_service::DeleteOperation {
         super::builder::notebook_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::notebook_service::CancelOperation {
         super::builder::notebook_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::notebook_service::WaitOperation {
         super::builder::notebook_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -7710,32 +6278,26 @@ impl PersistentResourceService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_persistent_resource(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::CreatePersistentResource {
         super::builder::persistent_resource_service::CreatePersistentResource::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets a PersistentResource.
     pub fn get_persistent_resource(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::GetPersistentResource {
         super::builder::persistent_resource_service::GetPersistentResource::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists PersistentResources in a Location.
     pub fn list_persistent_resources(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::ListPersistentResources {
         super::builder::persistent_resource_service::ListPersistentResources::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Deletes a PersistentResource.
@@ -7751,12 +6313,10 @@ impl PersistentResourceService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_persistent_resource(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::DeletePersistentResource {
         super::builder::persistent_resource_service::DeletePersistentResource::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Updates a PersistentResource.
@@ -7772,12 +6332,10 @@ impl PersistentResourceService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_persistent_resource(
         &self,
-        persistent_resource: impl Into<crate::model::PersistentResource>,
     ) -> super::builder::persistent_resource_service::UpdatePersistentResource {
         super::builder::persistent_resource_service::UpdatePersistentResource::new(
             self.inner.clone(),
         )
-        .set_persistent_resource(persistent_resource.into())
     }
 
     /// Reboots a PersistentResource.
@@ -7793,30 +6351,20 @@ impl PersistentResourceService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reboot_persistent_resource(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::RebootPersistentResource {
         super::builder::persistent_resource_service::RebootPersistentResource::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::persistent_resource_service::ListLocations {
         super::builder::persistent_resource_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::persistent_resource_service::GetLocation {
         super::builder::persistent_resource_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -7824,22 +6372,14 @@ impl PersistentResourceService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::persistent_resource_service::SetIamPolicy {
         super::builder::persistent_resource_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::persistent_resource_service::GetIamPolicy {
         super::builder::persistent_resource_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -7851,65 +6391,43 @@ impl PersistentResourceService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::persistent_resource_service::TestIamPermissions {
         super::builder::persistent_resource_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::persistent_resource_service::ListOperations {
         super::builder::persistent_resource_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::persistent_resource_service::GetOperation {
         super::builder::persistent_resource_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::persistent_resource_service::DeleteOperation {
         super::builder::persistent_resource_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::persistent_resource_service::CancelOperation {
         super::builder::persistent_resource_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::persistent_resource_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::persistent_resource_service::WaitOperation {
         super::builder::persistent_resource_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -8024,28 +6542,20 @@ impl PipelineService {
     /// attempted to be run.
     pub fn create_training_pipeline(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::CreateTrainingPipeline {
         super::builder::pipeline_service::CreateTrainingPipeline::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a TrainingPipeline.
-    pub fn get_training_pipeline(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::GetTrainingPipeline {
+    pub fn get_training_pipeline(&self) -> super::builder::pipeline_service::GetTrainingPipeline {
         super::builder::pipeline_service::GetTrainingPipeline::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists TrainingPipelines in a Location.
     pub fn list_training_pipelines(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::ListTrainingPipelines {
         super::builder::pipeline_service::ListTrainingPipelines::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a TrainingPipeline.
@@ -8061,10 +6571,8 @@ impl PipelineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_training_pipeline(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::DeleteTrainingPipeline {
         super::builder::pipeline_service::DeleteTrainingPipeline::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a TrainingPipeline.
@@ -8088,37 +6596,23 @@ impl PipelineService {
     /// [google.rpc.Status.code]: rpc::model::Status::code
     pub fn cancel_training_pipeline(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::CancelTrainingPipeline {
         super::builder::pipeline_service::CancelTrainingPipeline::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a PipelineJob. A PipelineJob will run immediately when created.
-    pub fn create_pipeline_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::CreatePipelineJob {
+    pub fn create_pipeline_job(&self) -> super::builder::pipeline_service::CreatePipelineJob {
         super::builder::pipeline_service::CreatePipelineJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a PipelineJob.
-    pub fn get_pipeline_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::GetPipelineJob {
+    pub fn get_pipeline_job(&self) -> super::builder::pipeline_service::GetPipelineJob {
         super::builder::pipeline_service::GetPipelineJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists PipelineJobs in a Location.
-    pub fn list_pipeline_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::ListPipelineJobs {
+    pub fn list_pipeline_jobs(&self) -> super::builder::pipeline_service::ListPipelineJobs {
         super::builder::pipeline_service::ListPipelineJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a PipelineJob.
@@ -8132,12 +6626,8 @@ impl PipelineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_pipeline_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::DeletePipelineJob {
+    pub fn delete_pipeline_job(&self) -> super::builder::pipeline_service::DeletePipelineJob {
         super::builder::pipeline_service::DeletePipelineJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Batch deletes PipelineJobs
@@ -8155,10 +6645,8 @@ impl PipelineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_delete_pipeline_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::BatchDeletePipelineJobs {
         super::builder::pipeline_service::BatchDeletePipelineJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Cancels a PipelineJob.
@@ -8179,12 +6667,8 @@ impl PipelineService {
     /// [google.cloud.aiplatform.v1.PipelineJob.state]: crate::model::PipelineJob::state
     /// [google.cloud.aiplatform.v1.PipelineService.GetPipelineJob]: crate::client::PipelineService::get_pipeline_job
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_pipeline_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::CancelPipelineJob {
+    pub fn cancel_pipeline_job(&self) -> super::builder::pipeline_service::CancelPipelineJob {
         super::builder::pipeline_service::CancelPipelineJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Batch cancel PipelineJobs.
@@ -8206,27 +6690,18 @@ impl PipelineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_cancel_pipeline_jobs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::pipeline_service::BatchCancelPipelineJobs {
         super::builder::pipeline_service::BatchCancelPipelineJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::pipeline_service::ListLocations {
         super::builder::pipeline_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::GetLocation {
-        super::builder::pipeline_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::pipeline_service::GetLocation {
+        super::builder::pipeline_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -8234,22 +6709,14 @@ impl PipelineService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::pipeline_service::SetIamPolicy {
         super::builder::pipeline_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::pipeline_service::GetIamPolicy {
         super::builder::pipeline_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -8259,67 +6726,43 @@ impl PipelineService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::pipeline_service::TestIamPermissions {
         super::builder::pipeline_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::pipeline_service::ListOperations {
         super::builder::pipeline_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::pipeline_service::GetOperation {
         super::builder::pipeline_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::pipeline_service::DeleteOperation {
         super::builder::pipeline_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::pipeline_service::CancelOperation {
         super::builder::pipeline_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pipeline_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::pipeline_service::WaitOperation {
         super::builder::pipeline_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -8429,12 +6872,8 @@ impl PredictionService {
     }
 
     /// Perform an online prediction.
-    pub fn predict(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::Predict {
+    pub fn predict(&self) -> super::builder::prediction_service::Predict {
         super::builder::prediction_service::Predict::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Perform an online prediction with an arbitrary HTTP payload.
@@ -8452,32 +6891,20 @@ impl PredictionService {
     ///
     /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
     /// [google.cloud.aiplatform.v1.Endpoint]: crate::model::Endpoint
-    pub fn raw_predict(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::RawPredict {
+    pub fn raw_predict(&self) -> super::builder::prediction_service::RawPredict {
         super::builder::prediction_service::RawPredict::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Perform an unary online prediction request to a gRPC model server for
     /// Vertex first-party products and frameworks.
-    pub fn direct_predict(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::DirectPredict {
+    pub fn direct_predict(&self) -> super::builder::prediction_service::DirectPredict {
         super::builder::prediction_service::DirectPredict::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Perform an unary online prediction request to a gRPC model server for
     /// custom containers.
-    pub fn direct_raw_predict(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::DirectRawPredict {
+    pub fn direct_raw_predict(&self) -> super::builder::prediction_service::DirectRawPredict {
         super::builder::prediction_service::DirectRawPredict::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Perform an online explanation.
@@ -8494,39 +6921,23 @@ impl PredictionService {
     ///
     /// [google.cloud.aiplatform.v1.DeployedModel.explanation_spec]: crate::model::DeployedModel::explanation_spec
     /// [google.cloud.aiplatform.v1.ExplainRequest.deployed_model_id]: crate::model::ExplainRequest::deployed_model_id
-    pub fn explain(
-        &self,
-        endpoint: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::Explain {
+    pub fn explain(&self) -> super::builder::prediction_service::Explain {
         super::builder::prediction_service::Explain::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Generate content with multimodal inputs.
-    pub fn generate_content(
-        &self,
-        model: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::GenerateContent {
+    pub fn generate_content(&self) -> super::builder::prediction_service::GenerateContent {
         super::builder::prediction_service::GenerateContent::new(self.inner.clone())
-            .set_model(model.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::prediction_service::ListLocations {
         super::builder::prediction_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::prediction_service::GetLocation {
         super::builder::prediction_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -8534,22 +6945,14 @@ impl PredictionService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::prediction_service::SetIamPolicy {
         super::builder::prediction_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::prediction_service::GetIamPolicy {
         super::builder::prediction_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -8559,67 +6962,43 @@ impl PredictionService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::prediction_service::TestIamPermissions {
         super::builder::prediction_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::prediction_service::ListOperations {
         super::builder::prediction_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::prediction_service::GetOperation {
         super::builder::prediction_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::prediction_service::DeleteOperation {
         super::builder::prediction_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::prediction_service::CancelOperation {
         super::builder::prediction_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::prediction_service::WaitOperation {
         super::builder::prediction_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -8731,30 +7110,22 @@ impl ReasoningEngineExecutionService {
     /// Queries using a reasoning engine.
     pub fn query_reasoning_engine(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::QueryReasoningEngine {
         super::builder::reasoning_engine_execution_service::QueryReasoningEngine::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::ListLocations {
         super::builder::reasoning_engine_execution_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_execution_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::reasoning_engine_execution_service::GetLocation {
         super::builder::reasoning_engine_execution_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -8764,20 +7135,16 @@ impl ReasoningEngineExecutionService {
     /// errors.
     pub fn set_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::SetIamPolicy {
         super::builder::reasoning_engine_execution_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
     pub fn get_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::GetIamPolicy {
         super::builder::reasoning_engine_execution_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -8789,12 +7156,10 @@ impl ReasoningEngineExecutionService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::TestIamPermissions {
         super::builder::reasoning_engine_execution_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -8802,10 +7167,8 @@ impl ReasoningEngineExecutionService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::ListOperations {
         super::builder::reasoning_engine_execution_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -8813,10 +7176,8 @@ impl ReasoningEngineExecutionService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::GetOperation {
         super::builder::reasoning_engine_execution_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -8824,10 +7185,8 @@ impl ReasoningEngineExecutionService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::DeleteOperation {
         super::builder::reasoning_engine_execution_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -8835,10 +7194,8 @@ impl ReasoningEngineExecutionService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::CancelOperation {
         super::builder::reasoning_engine_execution_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -8846,10 +7203,8 @@ impl ReasoningEngineExecutionService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn wait_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_execution_service::WaitOperation {
         super::builder::reasoning_engine_execution_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -8971,28 +7326,22 @@ impl ReasoningEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_reasoning_engine(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_service::CreateReasoningEngine {
         super::builder::reasoning_engine_service::CreateReasoningEngine::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a reasoning engine.
     pub fn get_reasoning_engine(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_service::GetReasoningEngine {
         super::builder::reasoning_engine_service::GetReasoningEngine::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists reasoning engines in a location.
     pub fn list_reasoning_engines(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_service::ListReasoningEngines {
         super::builder::reasoning_engine_service::ListReasoningEngines::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a reasoning engine.
@@ -9008,10 +7357,8 @@ impl ReasoningEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_reasoning_engine(
         &self,
-        reasoning_engine: impl Into<crate::model::ReasoningEngine>,
     ) -> super::builder::reasoning_engine_service::UpdateReasoningEngine {
         super::builder::reasoning_engine_service::UpdateReasoningEngine::new(self.inner.clone())
-            .set_reasoning_engine(reasoning_engine.into())
     }
 
     /// Deletes a reasoning engine.
@@ -9027,28 +7374,18 @@ impl ReasoningEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_reasoning_engine(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_service::DeleteReasoningEngine {
         super::builder::reasoning_engine_service::DeleteReasoningEngine::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::reasoning_engine_service::ListLocations {
         super::builder::reasoning_engine_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::reasoning_engine_service::GetLocation {
         super::builder::reasoning_engine_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -9056,22 +7393,14 @@ impl ReasoningEngineService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::reasoning_engine_service::SetIamPolicy {
         super::builder::reasoning_engine_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::reasoning_engine_service::GetIamPolicy {
         super::builder::reasoning_engine_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -9083,65 +7412,43 @@ impl ReasoningEngineService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::reasoning_engine_service::TestIamPermissions {
         super::builder::reasoning_engine_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::reasoning_engine_service::ListOperations {
         super::builder::reasoning_engine_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::reasoning_engine_service::GetOperation {
         super::builder::reasoning_engine_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::reasoning_engine_service::DeleteOperation {
         super::builder::reasoning_engine_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::reasoning_engine_service::CancelOperation {
         super::builder::reasoning_engine_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reasoning_engine_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::reasoning_engine_service::WaitOperation {
         super::builder::reasoning_engine_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -9252,12 +7559,8 @@ impl ScheduleService {
     }
 
     /// Creates a Schedule.
-    pub fn create_schedule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::CreateSchedule {
+    pub fn create_schedule(&self) -> super::builder::schedule_service::CreateSchedule {
         super::builder::schedule_service::CreateSchedule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Schedule.
@@ -9271,29 +7574,18 @@ impl ScheduleService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::DeleteSchedule {
+    pub fn delete_schedule(&self) -> super::builder::schedule_service::DeleteSchedule {
         super::builder::schedule_service::DeleteSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a Schedule.
-    pub fn get_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::GetSchedule {
-        super::builder::schedule_service::GetSchedule::new(self.inner.clone()).set_name(name.into())
+    pub fn get_schedule(&self) -> super::builder::schedule_service::GetSchedule {
+        super::builder::schedule_service::GetSchedule::new(self.inner.clone())
     }
 
     /// Lists Schedules in a Location.
-    pub fn list_schedules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::ListSchedules {
+    pub fn list_schedules(&self) -> super::builder::schedule_service::ListSchedules {
         super::builder::schedule_service::ListSchedules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Pauses a Schedule. Will mark
@@ -9302,12 +7594,8 @@ impl ScheduleService {
     /// will NOT be paused or canceled.
     ///
     /// [google.cloud.aiplatform.v1.Schedule.state]: crate::model::Schedule::state
-    pub fn pause_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::PauseSchedule {
+    pub fn pause_schedule(&self) -> super::builder::schedule_service::PauseSchedule {
         super::builder::schedule_service::PauseSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resumes a paused Schedule to start scheduling new runs. Will mark
@@ -9322,12 +7610,8 @@ impl ScheduleService {
     ///
     /// [google.cloud.aiplatform.v1.Schedule.catch_up]: crate::model::Schedule::catch_up
     /// [google.cloud.aiplatform.v1.Schedule.state]: crate::model::Schedule::state
-    pub fn resume_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::ResumeSchedule {
+    pub fn resume_schedule(&self) -> super::builder::schedule_service::ResumeSchedule {
         super::builder::schedule_service::ResumeSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an active or paused Schedule.
@@ -9337,29 +7621,18 @@ impl ScheduleService {
     /// time_specification in the updated Schedule. All unstarted runs before the
     /// update time will be skipped while already created runs will NOT be paused
     /// or canceled.
-    pub fn update_schedule(
-        &self,
-        schedule: impl Into<crate::model::Schedule>,
-    ) -> super::builder::schedule_service::UpdateSchedule {
+    pub fn update_schedule(&self) -> super::builder::schedule_service::UpdateSchedule {
         super::builder::schedule_service::UpdateSchedule::new(self.inner.clone())
-            .set_schedule(schedule.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::schedule_service::ListLocations {
         super::builder::schedule_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::GetLocation {
-        super::builder::schedule_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::schedule_service::GetLocation {
+        super::builder::schedule_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -9367,22 +7640,14 @@ impl ScheduleService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::schedule_service::SetIamPolicy {
         super::builder::schedule_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::schedule_service::GetIamPolicy {
         super::builder::schedule_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -9392,67 +7657,43 @@ impl ScheduleService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::schedule_service::TestIamPermissions {
         super::builder::schedule_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::schedule_service::ListOperations {
         super::builder::schedule_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::schedule_service::GetOperation {
         super::builder::schedule_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::schedule_service::DeleteOperation {
         super::builder::schedule_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::schedule_service::CancelOperation {
         super::builder::schedule_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schedule_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::schedule_service::WaitOperation {
         super::builder::schedule_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -9579,28 +7820,22 @@ impl SpecialistPoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_specialist_pool(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::specialist_pool_service::CreateSpecialistPool {
         super::builder::specialist_pool_service::CreateSpecialistPool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a SpecialistPool.
     pub fn get_specialist_pool(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::specialist_pool_service::GetSpecialistPool {
         super::builder::specialist_pool_service::GetSpecialistPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists SpecialistPools in a Location.
     pub fn list_specialist_pools(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::specialist_pool_service::ListSpecialistPools {
         super::builder::specialist_pool_service::ListSpecialistPools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a SpecialistPool as well as all Specialists in the pool.
@@ -9616,10 +7851,8 @@ impl SpecialistPoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_specialist_pool(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::specialist_pool_service::DeleteSpecialistPool {
         super::builder::specialist_pool_service::DeleteSpecialistPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a SpecialistPool.
@@ -9635,28 +7868,18 @@ impl SpecialistPoolService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_specialist_pool(
         &self,
-        specialist_pool: impl Into<crate::model::SpecialistPool>,
     ) -> super::builder::specialist_pool_service::UpdateSpecialistPool {
         super::builder::specialist_pool_service::UpdateSpecialistPool::new(self.inner.clone())
-            .set_specialist_pool(specialist_pool.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::specialist_pool_service::ListLocations {
         super::builder::specialist_pool_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::specialist_pool_service::GetLocation {
         super::builder::specialist_pool_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -9664,22 +7887,14 @@ impl SpecialistPoolService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::specialist_pool_service::SetIamPolicy {
         super::builder::specialist_pool_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::specialist_pool_service::GetIamPolicy {
         super::builder::specialist_pool_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -9691,65 +7906,43 @@ impl SpecialistPoolService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::specialist_pool_service::TestIamPermissions {
         super::builder::specialist_pool_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::specialist_pool_service::ListOperations {
         super::builder::specialist_pool_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::specialist_pool_service::GetOperation {
         super::builder::specialist_pool_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::specialist_pool_service::DeleteOperation {
         super::builder::specialist_pool_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::specialist_pool_service::CancelOperation {
         super::builder::specialist_pool_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::specialist_pool_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::specialist_pool_service::WaitOperation {
         super::builder::specialist_pool_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -9869,21 +8062,13 @@ impl TensorboardService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_tensorboard(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::CreateTensorboard {
+    pub fn create_tensorboard(&self) -> super::builder::tensorboard_service::CreateTensorboard {
         super::builder::tensorboard_service::CreateTensorboard::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Tensorboard.
-    pub fn get_tensorboard(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::GetTensorboard {
+    pub fn get_tensorboard(&self) -> super::builder::tensorboard_service::GetTensorboard {
         super::builder::tensorboard_service::GetTensorboard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Tensorboard.
@@ -9897,21 +8082,13 @@ impl TensorboardService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_tensorboard(
-        &self,
-        tensorboard: impl Into<crate::model::Tensorboard>,
-    ) -> super::builder::tensorboard_service::UpdateTensorboard {
+    pub fn update_tensorboard(&self) -> super::builder::tensorboard_service::UpdateTensorboard {
         super::builder::tensorboard_service::UpdateTensorboard::new(self.inner.clone())
-            .set_tensorboard(tensorboard.into())
     }
 
     /// Lists Tensorboards in a Location.
-    pub fn list_tensorboards(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::ListTensorboards {
+    pub fn list_tensorboards(&self) -> super::builder::tensorboard_service::ListTensorboards {
         super::builder::tensorboard_service::ListTensorboards::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Tensorboard.
@@ -9925,66 +8102,50 @@ impl TensorboardService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tensorboard(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::DeleteTensorboard {
+    pub fn delete_tensorboard(&self) -> super::builder::tensorboard_service::DeleteTensorboard {
         super::builder::tensorboard_service::DeleteTensorboard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of monthly active users for a given TensorBoard instance.
     pub fn read_tensorboard_usage(
         &self,
-        tensorboard: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ReadTensorboardUsage {
         super::builder::tensorboard_service::ReadTensorboardUsage::new(self.inner.clone())
-            .set_tensorboard(tensorboard.into())
     }
 
     /// Returns the storage size for a given TensorBoard instance.
     pub fn read_tensorboard_size(
         &self,
-        tensorboard: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ReadTensorboardSize {
         super::builder::tensorboard_service::ReadTensorboardSize::new(self.inner.clone())
-            .set_tensorboard(tensorboard.into())
     }
 
     /// Creates a TensorboardExperiment.
     pub fn create_tensorboard_experiment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::CreateTensorboardExperiment {
         super::builder::tensorboard_service::CreateTensorboardExperiment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a TensorboardExperiment.
     pub fn get_tensorboard_experiment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::GetTensorboardExperiment {
         super::builder::tensorboard_service::GetTensorboardExperiment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a TensorboardExperiment.
     pub fn update_tensorboard_experiment(
         &self,
-        tensorboard_experiment: impl Into<crate::model::TensorboardExperiment>,
     ) -> super::builder::tensorboard_service::UpdateTensorboardExperiment {
         super::builder::tensorboard_service::UpdateTensorboardExperiment::new(self.inner.clone())
-            .set_tensorboard_experiment(tensorboard_experiment.into())
     }
 
     /// Lists TensorboardExperiments in a Location.
     pub fn list_tensorboard_experiments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ListTensorboardExperiments {
         super::builder::tensorboard_service::ListTensorboardExperiments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a TensorboardExperiment.
@@ -10000,55 +8161,41 @@ impl TensorboardService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_tensorboard_experiment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::DeleteTensorboardExperiment {
         super::builder::tensorboard_service::DeleteTensorboardExperiment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a TensorboardRun.
     pub fn create_tensorboard_run(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::CreateTensorboardRun {
         super::builder::tensorboard_service::CreateTensorboardRun::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Batch create TensorboardRuns.
     pub fn batch_create_tensorboard_runs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::BatchCreateTensorboardRuns {
         super::builder::tensorboard_service::BatchCreateTensorboardRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a TensorboardRun.
-    pub fn get_tensorboard_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::GetTensorboardRun {
+    pub fn get_tensorboard_run(&self) -> super::builder::tensorboard_service::GetTensorboardRun {
         super::builder::tensorboard_service::GetTensorboardRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a TensorboardRun.
     pub fn update_tensorboard_run(
         &self,
-        tensorboard_run: impl Into<crate::model::TensorboardRun>,
     ) -> super::builder::tensorboard_service::UpdateTensorboardRun {
         super::builder::tensorboard_service::UpdateTensorboardRun::new(self.inner.clone())
-            .set_tensorboard_run(tensorboard_run.into())
     }
 
     /// Lists TensorboardRuns in a Location.
     pub fn list_tensorboard_runs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ListTensorboardRuns {
         super::builder::tensorboard_service::ListTensorboardRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a TensorboardRun.
@@ -10064,57 +8211,45 @@ impl TensorboardService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_tensorboard_run(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::DeleteTensorboardRun {
         super::builder::tensorboard_service::DeleteTensorboardRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Batch create TensorboardTimeSeries that belong to a TensorboardExperiment.
     pub fn batch_create_tensorboard_time_series(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::BatchCreateTensorboardTimeSeries {
         super::builder::tensorboard_service::BatchCreateTensorboardTimeSeries::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Creates a TensorboardTimeSeries.
     pub fn create_tensorboard_time_series(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::CreateTensorboardTimeSeries {
         super::builder::tensorboard_service::CreateTensorboardTimeSeries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a TensorboardTimeSeries.
     pub fn get_tensorboard_time_series(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::GetTensorboardTimeSeries {
         super::builder::tensorboard_service::GetTensorboardTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a TensorboardTimeSeries.
     pub fn update_tensorboard_time_series(
         &self,
-        tensorboard_time_series: impl Into<crate::model::TensorboardTimeSeries>,
     ) -> super::builder::tensorboard_service::UpdateTensorboardTimeSeries {
         super::builder::tensorboard_service::UpdateTensorboardTimeSeries::new(self.inner.clone())
-            .set_tensorboard_time_series(tensorboard_time_series.into())
     }
 
     /// Lists TensorboardTimeSeries in a Location.
     pub fn list_tensorboard_time_series(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ListTensorboardTimeSeries {
         super::builder::tensorboard_service::ListTensorboardTimeSeries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a TensorboardTimeSeries.
@@ -10130,10 +8265,8 @@ impl TensorboardService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_tensorboard_time_series(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::DeleteTensorboardTimeSeries {
         super::builder::tensorboard_service::DeleteTensorboardTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reads multiple TensorboardTimeSeries' data. The data point number limit is
@@ -10143,12 +8276,10 @@ impl TensorboardService {
     /// this time series and returned.
     pub fn batch_read_tensorboard_time_series_data(
         &self,
-        tensorboard: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::BatchReadTensorboardTimeSeriesData {
         super::builder::tensorboard_service::BatchReadTensorboardTimeSeriesData::new(
             self.inner.clone(),
         )
-        .set_tensorboard(tensorboard.into())
     }
 
     /// Reads a TensorboardTimeSeries' data. By default, if the number of data
@@ -10158,60 +8289,44 @@ impl TensorboardService {
     /// greater than 10k.
     pub fn read_tensorboard_time_series_data(
         &self,
-        tensorboard_time_series: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ReadTensorboardTimeSeriesData {
         super::builder::tensorboard_service::ReadTensorboardTimeSeriesData::new(self.inner.clone())
-            .set_tensorboard_time_series(tensorboard_time_series.into())
     }
 
     /// Write time series data points of multiple TensorboardTimeSeries in multiple
     /// TensorboardRun's. If any data fail to be ingested, an error is returned.
     pub fn write_tensorboard_experiment_data(
         &self,
-        tensorboard_experiment: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::WriteTensorboardExperimentData {
         super::builder::tensorboard_service::WriteTensorboardExperimentData::new(self.inner.clone())
-            .set_tensorboard_experiment(tensorboard_experiment.into())
     }
 
     /// Write time series data points into multiple TensorboardTimeSeries under
     /// a TensorboardRun. If any data fail to be ingested, an error is returned.
     pub fn write_tensorboard_run_data(
         &self,
-        tensorboard_run: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::WriteTensorboardRunData {
         super::builder::tensorboard_service::WriteTensorboardRunData::new(self.inner.clone())
-            .set_tensorboard_run(tensorboard_run.into())
     }
 
     /// Exports a TensorboardTimeSeries' data. Data is returned in paginated
     /// responses.
     pub fn export_tensorboard_time_series_data(
         &self,
-        tensorboard_time_series: impl Into<std::string::String>,
     ) -> super::builder::tensorboard_service::ExportTensorboardTimeSeriesData {
         super::builder::tensorboard_service::ExportTensorboardTimeSeriesData::new(
             self.inner.clone(),
         )
-        .set_tensorboard_time_series(tensorboard_time_series.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::tensorboard_service::ListLocations {
         super::builder::tensorboard_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::tensorboard_service::GetLocation {
         super::builder::tensorboard_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -10219,22 +8334,14 @@ impl TensorboardService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::tensorboard_service::SetIamPolicy {
         super::builder::tensorboard_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::tensorboard_service::GetIamPolicy {
         super::builder::tensorboard_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -10244,67 +8351,43 @@ impl TensorboardService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::tensorboard_service::TestIamPermissions {
         super::builder::tensorboard_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::tensorboard_service::ListOperations {
         super::builder::tensorboard_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::tensorboard_service::GetOperation {
         super::builder::tensorboard_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::tensorboard_service::DeleteOperation {
         super::builder::tensorboard_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::tensorboard_service::CancelOperation {
         super::builder::tensorboard_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tensorboard_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::tensorboard_service::WaitOperation {
         super::builder::tensorboard_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -10424,12 +8507,8 @@ impl VertexRagDataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_rag_corpus(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::CreateRagCorpus {
+    pub fn create_rag_corpus(&self) -> super::builder::vertex_rag_data_service::CreateRagCorpus {
         super::builder::vertex_rag_data_service::CreateRagCorpus::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a RagCorpus.
@@ -10443,30 +8522,18 @@ impl VertexRagDataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_rag_corpus(
-        &self,
-        rag_corpus: impl Into<crate::model::RagCorpus>,
-    ) -> super::builder::vertex_rag_data_service::UpdateRagCorpus {
+    pub fn update_rag_corpus(&self) -> super::builder::vertex_rag_data_service::UpdateRagCorpus {
         super::builder::vertex_rag_data_service::UpdateRagCorpus::new(self.inner.clone())
-            .set_rag_corpus(rag_corpus.into())
     }
 
     /// Gets a RagCorpus.
-    pub fn get_rag_corpus(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::GetRagCorpus {
+    pub fn get_rag_corpus(&self) -> super::builder::vertex_rag_data_service::GetRagCorpus {
         super::builder::vertex_rag_data_service::GetRagCorpus::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists RagCorpora in a Location.
-    pub fn list_rag_corpora(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::ListRagCorpora {
+    pub fn list_rag_corpora(&self) -> super::builder::vertex_rag_data_service::ListRagCorpora {
         super::builder::vertex_rag_data_service::ListRagCorpora::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a RagCorpus.
@@ -10480,21 +8547,13 @@ impl VertexRagDataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_rag_corpus(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::DeleteRagCorpus {
+    pub fn delete_rag_corpus(&self) -> super::builder::vertex_rag_data_service::DeleteRagCorpus {
         super::builder::vertex_rag_data_service::DeleteRagCorpus::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Upload a file into a RagCorpus.
-    pub fn upload_rag_file(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::UploadRagFile {
+    pub fn upload_rag_file(&self) -> super::builder::vertex_rag_data_service::UploadRagFile {
         super::builder::vertex_rag_data_service::UploadRagFile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Import files from Google Cloud Storage or Google Drive into a RagCorpus.
@@ -10508,30 +8567,18 @@ impl VertexRagDataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_rag_files(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::ImportRagFiles {
+    pub fn import_rag_files(&self) -> super::builder::vertex_rag_data_service::ImportRagFiles {
         super::builder::vertex_rag_data_service::ImportRagFiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a RagFile.
-    pub fn get_rag_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::GetRagFile {
+    pub fn get_rag_file(&self) -> super::builder::vertex_rag_data_service::GetRagFile {
         super::builder::vertex_rag_data_service::GetRagFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists RagFiles in a RagCorpus.
-    pub fn list_rag_files(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::ListRagFiles {
+    pub fn list_rag_files(&self) -> super::builder::vertex_rag_data_service::ListRagFiles {
         super::builder::vertex_rag_data_service::ListRagFiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a RagFile.
@@ -10545,30 +8592,18 @@ impl VertexRagDataService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_rag_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::DeleteRagFile {
+    pub fn delete_rag_file(&self) -> super::builder::vertex_rag_data_service::DeleteRagFile {
         super::builder::vertex_rag_data_service::DeleteRagFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::vertex_rag_data_service::ListLocations {
         super::builder::vertex_rag_data_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::vertex_rag_data_service::GetLocation {
         super::builder::vertex_rag_data_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -10576,22 +8611,14 @@ impl VertexRagDataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::vertex_rag_data_service::SetIamPolicy {
         super::builder::vertex_rag_data_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::vertex_rag_data_service::GetIamPolicy {
         super::builder::vertex_rag_data_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -10603,65 +8630,43 @@ impl VertexRagDataService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::vertex_rag_data_service::TestIamPermissions {
         super::builder::vertex_rag_data_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::vertex_rag_data_service::ListOperations {
         super::builder::vertex_rag_data_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::vertex_rag_data_service::GetOperation {
         super::builder::vertex_rag_data_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::vertex_rag_data_service::DeleteOperation {
         super::builder::vertex_rag_data_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::vertex_rag_data_service::CancelOperation {
         super::builder::vertex_rag_data_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_data_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::vertex_rag_data_service::WaitOperation {
         super::builder::vertex_rag_data_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -10771,51 +8776,31 @@ impl VertexRagService {
     }
 
     /// Retrieves relevant contexts for a query.
-    pub fn retrieve_contexts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::RetrieveContexts {
+    pub fn retrieve_contexts(&self) -> super::builder::vertex_rag_service::RetrieveContexts {
         super::builder::vertex_rag_service::RetrieveContexts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Given an input prompt, it returns augmented prompt from vertex rag store
     /// to guide LLM towards generating grounded responses.
-    pub fn augment_prompt(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::AugmentPrompt {
+    pub fn augment_prompt(&self) -> super::builder::vertex_rag_service::AugmentPrompt {
         super::builder::vertex_rag_service::AugmentPrompt::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Given an input text, it returns a score that evaluates the factuality of
     /// the text. It also extracts and returns claims from the text and provides
     /// supporting facts.
-    pub fn corroborate_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::CorroborateContent {
+    pub fn corroborate_content(&self) -> super::builder::vertex_rag_service::CorroborateContent {
         super::builder::vertex_rag_service::CorroborateContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::vertex_rag_service::ListLocations {
         super::builder::vertex_rag_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::vertex_rag_service::GetLocation {
         super::builder::vertex_rag_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -10823,22 +8808,14 @@ impl VertexRagService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::vertex_rag_service::SetIamPolicy {
         super::builder::vertex_rag_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::vertex_rag_service::GetIamPolicy {
         super::builder::vertex_rag_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -10848,67 +8825,43 @@ impl VertexRagService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::vertex_rag_service::TestIamPermissions {
         super::builder::vertex_rag_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::vertex_rag_service::ListOperations {
         super::builder::vertex_rag_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::vertex_rag_service::GetOperation {
         super::builder::vertex_rag_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::vertex_rag_service::DeleteOperation {
         super::builder::vertex_rag_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::vertex_rag_service::CancelOperation {
         super::builder::vertex_rag_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vertex_rag_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::vertex_rag_service::WaitOperation {
         super::builder::vertex_rag_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -11021,47 +8974,29 @@ impl VizierService {
 
     /// Creates a Study. A resource name will be generated after creation of the
     /// Study.
-    pub fn create_study(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::CreateStudy {
+    pub fn create_study(&self) -> super::builder::vizier_service::CreateStudy {
         super::builder::vizier_service::CreateStudy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Study by name.
-    pub fn get_study(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::GetStudy {
-        super::builder::vizier_service::GetStudy::new(self.inner.clone()).set_name(name.into())
+    pub fn get_study(&self) -> super::builder::vizier_service::GetStudy {
+        super::builder::vizier_service::GetStudy::new(self.inner.clone())
     }
 
     /// Lists all the studies in a region for an associated project.
-    pub fn list_studies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::ListStudies {
+    pub fn list_studies(&self) -> super::builder::vizier_service::ListStudies {
         super::builder::vizier_service::ListStudies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Study.
-    pub fn delete_study(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::DeleteStudy {
-        super::builder::vizier_service::DeleteStudy::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_study(&self) -> super::builder::vizier_service::DeleteStudy {
+        super::builder::vizier_service::DeleteStudy::new(self.inner.clone())
     }
 
     /// Looks a study up using the user-defined display_name field instead of the
     /// fully qualified resource name.
-    pub fn lookup_study(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::LookupStudy {
+    pub fn lookup_study(&self) -> super::builder::vizier_service::LookupStudy {
         super::builder::vizier_service::LookupStudy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds one or more Trials to a Study, with parameter values
@@ -11082,64 +9017,39 @@ impl VizierService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn suggest_trials(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::SuggestTrials {
+    pub fn suggest_trials(&self) -> super::builder::vizier_service::SuggestTrials {
         super::builder::vizier_service::SuggestTrials::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds a user provided Trial to a Study.
-    pub fn create_trial(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::CreateTrial {
+    pub fn create_trial(&self) -> super::builder::vizier_service::CreateTrial {
         super::builder::vizier_service::CreateTrial::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Trial.
-    pub fn get_trial(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::GetTrial {
-        super::builder::vizier_service::GetTrial::new(self.inner.clone()).set_name(name.into())
+    pub fn get_trial(&self) -> super::builder::vizier_service::GetTrial {
+        super::builder::vizier_service::GetTrial::new(self.inner.clone())
     }
 
     /// Lists the Trials associated with a Study.
-    pub fn list_trials(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::ListTrials {
+    pub fn list_trials(&self) -> super::builder::vizier_service::ListTrials {
         super::builder::vizier_service::ListTrials::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds a measurement of the objective metrics to a Trial. This measurement
     /// is assumed to have been taken before the Trial is complete.
-    pub fn add_trial_measurement(
-        &self,
-        trial_name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::AddTrialMeasurement {
+    pub fn add_trial_measurement(&self) -> super::builder::vizier_service::AddTrialMeasurement {
         super::builder::vizier_service::AddTrialMeasurement::new(self.inner.clone())
-            .set_trial_name(trial_name.into())
     }
 
     /// Marks a Trial as complete.
-    pub fn complete_trial(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::CompleteTrial {
-        super::builder::vizier_service::CompleteTrial::new(self.inner.clone()).set_name(name.into())
+    pub fn complete_trial(&self) -> super::builder::vizier_service::CompleteTrial {
+        super::builder::vizier_service::CompleteTrial::new(self.inner.clone())
     }
 
     /// Deletes a Trial.
-    pub fn delete_trial(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::DeleteTrial {
-        super::builder::vizier_service::DeleteTrial::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_trial(&self) -> super::builder::vizier_service::DeleteTrial {
+        super::builder::vizier_service::DeleteTrial::new(self.inner.clone())
     }
 
     /// Checks  whether a Trial should stop or not. Returns a
@@ -11160,46 +9070,31 @@ impl VizierService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn check_trial_early_stopping_state(
         &self,
-        trial_name: impl Into<std::string::String>,
     ) -> super::builder::vizier_service::CheckTrialEarlyStoppingState {
         super::builder::vizier_service::CheckTrialEarlyStoppingState::new(self.inner.clone())
-            .set_trial_name(trial_name.into())
     }
 
     /// Stops a Trial.
-    pub fn stop_trial(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::StopTrial {
-        super::builder::vizier_service::StopTrial::new(self.inner.clone()).set_name(name.into())
+    pub fn stop_trial(&self) -> super::builder::vizier_service::StopTrial {
+        super::builder::vizier_service::StopTrial::new(self.inner.clone())
     }
 
     /// Lists the pareto-optimal Trials for multi-objective Study or the
     /// optimal Trials for single-objective Study. The definition of
     /// pareto-optimal can be checked in wiki page.
     /// <https://en.wikipedia.org/wiki/Pareto_efficiency>
-    pub fn list_optimal_trials(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::ListOptimalTrials {
+    pub fn list_optimal_trials(&self) -> super::builder::vizier_service::ListOptimalTrials {
         super::builder::vizier_service::ListOptimalTrials::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::ListLocations {
-        super::builder::vizier_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::vizier_service::ListLocations {
+        super::builder::vizier_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::GetLocation {
-        super::builder::vizier_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::vizier_service::GetLocation {
+        super::builder::vizier_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -11207,22 +9102,14 @@ impl VizierService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::vizier_service::SetIamPolicy {
         super::builder::vizier_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::vizier_service::GetIamPolicy {
         super::builder::vizier_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -11232,64 +9119,42 @@ impl VizierService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::vizier_service::TestIamPermissions {
         super::builder::vizier_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::vizier_service::ListOperations {
         super::builder::vizier_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::GetOperation {
-        super::builder::vizier_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::vizier_service::GetOperation {
+        super::builder::vizier_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::vizier_service::DeleteOperation {
         super::builder::vizier_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::vizier_service::CancelOperation {
         super::builder::vizier_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vizier_service::WaitOperation {
-        super::builder::vizier_service::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::vizier_service::WaitOperation {
+        super::builder::vizier_service::WaitOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -143,10 +143,15 @@ impl super::stub::DatasetService for DatasetService {
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dataset
+            let arg = &req
+                .dataset
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -310,10 +315,15 @@ impl super::stub::DatasetService for DatasetService {
     ) -> Result<gax::response::Response<crate::model::DatasetVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dataset_version
+            let arg = &req
+                .dataset_version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dataset_version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset_version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1097,10 +1107,17 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.deployment_resource_pool
+            let arg = &req
+                .deployment_resource_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deployment_resource_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "deployment_resource_pool.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1608,10 +1625,15 @@ impl super::stub::EndpointService for EndpointService {
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.endpoint
+            let arg = &req
+                .endpoint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1639,10 +1661,15 @@ impl super::stub::EndpointService for EndpointService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}:update", {
-            &req.endpoint
+            let arg = &req
+                .endpoint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2527,10 +2554,15 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feature_online_store
+            let arg = &req
+                .feature_online_store
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feature_online_store"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_online_store.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2669,10 +2701,15 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feature_view
+            let arg = &req
+                .feature_view
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feature_view"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_view.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3597,10 +3634,15 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feature_group
+            let arg = &req
+                .feature_group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feature_group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3769,10 +3811,15 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feature
+            let arg = &req
+                .feature
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4623,10 +4670,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.featurestore
+            let arg = &req
+                .featurestore
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("featurestore"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("featurestore.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4770,10 +4822,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entity_type
+            let arg = &req
+                .entity_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4942,10 +4999,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
     ) -> Result<gax::response::Response<crate::model::Feature>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feature
+            let arg = &req
+                .feature
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -5513,10 +5575,15 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
     ) -> Result<gax::response::Response<crate::model::CachedContent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cached_content
+            let arg = &req
+                .cached_content
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cached_content"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cached_content.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -6483,10 +6550,15 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
     ) -> Result<gax::response::Response<crate::model::IndexEndpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.index_endpoint
+            let arg = &req
+                .index_endpoint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("index_endpoint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -7036,10 +7108,15 @@ impl super::stub::IndexService for IndexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.index
+            let arg = &req
+                .index
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("index"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -8359,10 +8436,17 @@ impl super::stub::JobService for JobService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.model_deployment_monitoring_job
+            let arg = &req
+                .model_deployment_monitoring_job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("model_deployment_monitoring_job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "model_deployment_monitoring_job.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -9744,10 +9828,15 @@ impl super::stub::MetadataService for MetadataService {
     ) -> Result<gax::response::Response<crate::model::Artifact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.artifact
+            let arg = &req
+                .artifact
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("artifact"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("artifact.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -9910,10 +9999,15 @@ impl super::stub::MetadataService for MetadataService {
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.context
+            let arg = &req
+                .context
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("context"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -10176,10 +10270,15 @@ impl super::stub::MetadataService for MetadataService {
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.execution
+            let arg = &req
+                .execution
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("execution"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("execution.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -11644,10 +11743,15 @@ impl super::stub::ModelService for ModelService {
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.model
+            let arg = &req
+                .model
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -12472,10 +12576,17 @@ impl super::stub::NotebookService for NotebookService {
     ) -> Result<gax::response::Response<crate::model::NotebookRuntimeTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.notebook_runtime_template
+            let arg = &req
+                .notebook_runtime_template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("notebook_runtime_template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "notebook_runtime_template.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -13242,10 +13353,15 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.persistent_resource
+            let arg = &req
+                .persistent_resource
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("persistent_resource"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("persistent_resource.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -15200,10 +15316,15 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.reasoning_engine
+            let arg = &req
+                .reasoning_engine
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("reasoning_engine"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("reasoning_engine.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -15761,10 +15882,15 @@ impl super::stub::ScheduleService for ScheduleService {
     ) -> Result<gax::response::Response<crate::model::Schedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.schedule
+            let arg = &req
+                .schedule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("schedule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("schedule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -16242,10 +16368,15 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.specialist_pool
+            let arg = &req
+                .specialist_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("specialist_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("specialist_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -16662,10 +16793,15 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tensorboard
+            let arg = &req
+                .tensorboard
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tensorboard"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -16860,10 +16996,15 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::TensorboardExperiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tensorboard_experiment
+            let arg = &req
+                .tensorboard_experiment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_experiment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_experiment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -17030,10 +17171,15 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::TensorboardRun>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tensorboard_run
+            let arg = &req
+                .tensorboard_run
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_run"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_run.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -17202,10 +17348,17 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::TensorboardTimeSeries>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tensorboard_time_series
+            let arg = &req
+                .tensorboard_time_series
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_time_series"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "tensorboard_time_series.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -17790,10 +17943,15 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.rag_corpus
+            let arg = &req
+                .rag_corpus
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("rag_corpus"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rag_corpus.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -84,12 +84,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,9 +110,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -131,18 +142,15 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dataset
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dataset
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,9 +173,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatasetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,9 +209,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,9 +235,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:import", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:import", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,9 +259,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,12 +283,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datasetVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datasetVersions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -269,18 +309,15 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatasetVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dataset_version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dataset_version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dataset_version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dataset_version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -303,9 +340,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,9 +366,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatasetVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,12 +398,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatasetVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/datasetVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/datasetVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -379,9 +434,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:restore", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -398,12 +460,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataItemsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataItems", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataItems", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -430,12 +496,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchDataItemsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchDataItems", {
+            let arg = &req.dataset;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchDataItems", req.dataset),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -481,12 +551,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSavedQueriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/savedQueries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/savedQueries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -513,9 +587,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,9 +613,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnnotationSpec>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -557,12 +645,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAnnotationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/annotations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/annotations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -589,9 +681,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -611,9 +710,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,12 +736,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -650,12 +760,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -682,12 +796,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -708,9 +826,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -730,9 +855,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -749,9 +881,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -772,9 +911,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,9 +941,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -865,12 +1018,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deploymentResourcePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deploymentResourcePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -885,9 +1042,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeploymentResourcePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -904,12 +1068,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentResourcePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deploymentResourcePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deploymentResourcePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -928,18 +1096,15 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.deployment_resource_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deployment_resource_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.deployment_resource_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deployment_resource_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -962,9 +1127,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -981,12 +1153,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryDeployedModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryDeployedModels", {
+            let arg = &req.deployment_resource_pool;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deployment_resource_pool"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryDeployedModels", req.deployment_resource_pool),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1005,9 +1181,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1027,9 +1210,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1046,12 +1236,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1066,12 +1260,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1098,12 +1296,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1124,9 +1326,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1355,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1165,9 +1381,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1188,9 +1411,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1211,9 +1441,16 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1281,12 +1518,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1304,9 +1545,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1323,12 +1571,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEndpointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1355,18 +1607,15 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.endpoint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.endpoint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1389,18 +1638,15 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:update", {
+            &req.endpoint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:update",
-                    req.endpoint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1415,9 +1661,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1434,12 +1687,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deployModel", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:deployModel", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1454,12 +1711,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undeployModel", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:undeployModel", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1474,12 +1735,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:mutateDeployedModel", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:mutateDeployedModel", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1494,9 +1759,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1516,9 +1788,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1535,12 +1814,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1555,12 +1838,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1587,12 +1874,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1613,9 +1904,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1635,9 +1933,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1654,9 +1959,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1677,9 +1989,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1700,9 +2019,16 @@ impl super::stub::EndpointService for EndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1770,12 +2096,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EvaluateInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:evaluateInstances", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:evaluateInstances", req.location),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1790,9 +2120,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1812,9 +2149,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1831,12 +2175,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1851,12 +2199,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1883,12 +2235,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1909,9 +2265,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1931,9 +2294,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1950,9 +2320,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1973,9 +2350,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1996,9 +2380,16 @@ impl super::stub::EvaluationService for EvaluationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2052,12 +2443,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/featureOnlineStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/featureOnlineStores", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2075,9 +2470,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeatureOnlineStore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2094,12 +2496,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeatureOnlineStoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featureOnlineStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featureOnlineStores", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2120,18 +2526,15 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feature_online_store
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feature_online_store"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feature_online_store
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feature_online_store"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2154,9 +2557,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2174,12 +2584,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/featureViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/featureViews", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2198,9 +2612,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeatureView>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2217,12 +2638,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeatureViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featureViews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featureViews", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2243,18 +2668,15 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feature_view
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feature_view"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feature_view
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feature_view"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2277,9 +2699,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2296,12 +2725,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SyncFeatureViewResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:sync", {
+            let arg = &req.feature_view;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_view"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:sync", req.feature_view),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2316,9 +2749,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeatureViewSync>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2335,12 +2775,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeatureViewSyncsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featureViewSyncs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featureViewSyncs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2361,9 +2805,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2383,9 +2834,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2402,12 +2860,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2422,12 +2884,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2454,12 +2920,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2480,9 +2950,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2502,9 +2979,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2521,9 +3005,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2544,9 +3035,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2567,9 +3065,16 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2637,12 +3142,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchFeatureValuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:fetchFeatureValues", {
+            let arg = &req.feature_view;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_view"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:fetchFeatureValues", req.feature_view),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2657,12 +3166,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchNearestEntitiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchNearestEntities", {
+            let arg = &req.feature_view;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feature_view"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:searchNearestEntities", req.feature_view),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2677,9 +3190,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2699,9 +3219,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2718,12 +3245,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2738,12 +3269,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2770,12 +3305,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2796,9 +3335,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2818,9 +3364,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2837,9 +3390,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2860,9 +3420,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2883,9 +3450,16 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2939,12 +3513,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/featureGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/featureGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2962,9 +3540,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeatureGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2981,12 +3566,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeatureGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featureGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featureGroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3007,18 +3596,15 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feature_group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feature_group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feature_group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feature_group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3041,9 +3627,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3061,12 +3654,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/features", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3084,12 +3681,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/features:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/features:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3104,9 +3705,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feature>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3123,9 +3731,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeaturesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3153,18 +3768,15 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feature
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feature
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3187,9 +3799,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3206,9 +3825,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3228,9 +3854,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3247,12 +3880,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3267,12 +3904,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3299,12 +3940,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3325,9 +3970,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3347,9 +3999,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3366,9 +4025,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3389,9 +4055,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3412,9 +4085,16 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3482,12 +4162,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReadFeatureValuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:readFeatureValues", {
+            let arg = &req.entity_type;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:readFeatureValues", req.entity_type),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3502,12 +4186,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WriteFeatureValuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:writeFeatureValues", {
+            let arg = &req.entity_type;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:writeFeatureValues", req.entity_type),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3522,9 +4210,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3544,9 +4239,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3563,12 +4265,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3583,12 +4289,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3615,12 +4325,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3641,9 +4355,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3663,9 +4384,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3682,9 +4410,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3705,9 +4440,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3728,9 +4470,16 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3784,12 +4533,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/featurestores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/featurestores", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3807,9 +4560,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Featurestore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3826,12 +4586,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeaturestoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featurestores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featurestores", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3858,18 +4622,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.featurestore
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("featurestore"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.featurestore
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("featurestore"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3892,9 +4653,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3912,12 +4680,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3935,9 +4707,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3954,12 +4733,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntityTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3986,18 +4769,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entity_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entity_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4020,9 +4800,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4040,12 +4827,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/features", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4063,12 +4854,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/features:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/features:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4083,9 +4878,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feature>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4102,9 +4904,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeaturesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4132,18 +4941,15 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feature>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feature
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feature
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feature"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4166,9 +4972,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4185,12 +4998,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importFeatureValues", {
+            let arg = &req.entity_type;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importFeatureValues", req.entity_type),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4205,12 +5022,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchReadFeatureValues", {
+            let arg = &req.featurestore;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("featurestore"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchReadFeatureValues", req.featurestore),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4225,12 +5046,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportFeatureValues", {
+            let arg = &req.entity_type;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportFeatureValues", req.entity_type),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4245,12 +5070,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deleteFeatureValues", {
+            let arg = &req.entity_type;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:deleteFeatureValues", req.entity_type),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4265,12 +5094,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchFeaturesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/featurestores:searchFeatures", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/featurestores:searchFeatures", req.location),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4290,9 +5123,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4312,9 +5152,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4331,12 +5178,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4351,12 +5202,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4383,12 +5238,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4409,9 +5268,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4431,9 +5297,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4450,9 +5323,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4473,9 +5353,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4496,9 +5383,16 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4566,12 +5460,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CachedContent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cachedContents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cachedContents", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4588,9 +5486,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CachedContent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4607,18 +5512,15 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CachedContent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cached_content
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cached_content"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cached_content
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cached_content"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4641,9 +5543,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4664,12 +5573,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCachedContentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cachedContents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cachedContents", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4688,9 +5601,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4710,9 +5630,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4729,12 +5656,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4749,12 +5680,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4781,12 +5716,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4807,9 +5746,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4829,9 +5775,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4848,9 +5801,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4871,9 +5831,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4894,9 +5861,16 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4950,12 +5924,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TuningJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tuningJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tuningJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4972,9 +5950,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TuningJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4991,12 +5976,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTuningJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tuningJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/tuningJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5016,9 +6005,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5038,12 +6034,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tuningJobs:rebaseTunedModel", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tuningJobs:rebaseTunedModel", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5058,9 +6058,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5080,9 +6087,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5099,12 +6113,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5119,12 +6137,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5151,12 +6173,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5177,9 +6203,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5199,9 +6232,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5218,9 +6258,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5241,9 +6288,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5264,9 +6318,16 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5334,12 +6395,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/indexEndpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/indexEndpoints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5356,9 +6421,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IndexEndpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5375,12 +6447,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIndexEndpointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/indexEndpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/indexEndpoints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5406,18 +6482,15 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IndexEndpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.index_endpoint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("index_endpoint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.index_endpoint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("index_endpoint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5440,9 +6513,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5459,12 +6539,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deployIndex", {
+            let arg = &req.index_endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:deployIndex", req.index_endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5479,12 +6563,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undeployIndex", {
+            let arg = &req.index_endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:undeployIndex", req.index_endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5499,12 +6587,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:mutateDeployedIndex", {
+            let arg = &req.index_endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:mutateDeployedIndex", req.index_endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5521,9 +6613,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5543,9 +6642,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5562,12 +6668,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5582,12 +6692,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5614,12 +6728,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5640,9 +6758,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5662,9 +6787,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5681,9 +6813,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5704,9 +6843,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5727,9 +6873,16 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5797,9 +6950,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/indexes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/indexes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5814,9 +6974,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Index>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5833,9 +7000,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIndexesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/indexes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/indexes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5861,18 +7035,15 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.index
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("index"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.index
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("index"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5893,9 +7064,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5912,12 +7090,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UpsertDatapointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:upsertDatapoints", {
+            let arg = &req.index;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:upsertDatapoints", req.index),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5932,12 +7114,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RemoveDatapointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeDatapoints", {
+            let arg = &req.index;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeDatapoints", req.index),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5952,9 +7138,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5974,9 +7167,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5993,12 +7193,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6013,12 +7217,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6045,12 +7253,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6071,9 +7283,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6093,9 +7312,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6112,9 +7338,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6135,9 +7368,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6158,9 +7398,16 @@ impl super::stub::IndexService for IndexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6228,12 +7475,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/customJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/customJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6250,9 +7501,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6269,12 +7527,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/customJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/customJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6300,9 +7562,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6319,9 +7588,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6341,12 +7617,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataLabelingJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataLabelingJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataLabelingJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6363,9 +7643,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataLabelingJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6382,12 +7669,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataLabelingJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataLabelingJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataLabelingJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6414,9 +7705,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6433,9 +7731,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6455,12 +7760,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HyperparameterTuningJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/hyperparameterTuningJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/hyperparameterTuningJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6477,9 +7786,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HyperparameterTuningJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6496,12 +7812,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHyperparameterTuningJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/hyperparameterTuningJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/hyperparameterTuningJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6527,9 +7847,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6546,9 +7873,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6568,9 +7902,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NasJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/nasJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/nasJobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6587,9 +7928,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NasJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6606,9 +7954,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNasJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nasJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/nasJobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6634,9 +7989,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6653,9 +8015,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6675,9 +8044,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NasTrialDetail>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6694,12 +8070,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNasTrialDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nasTrialDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/nasTrialDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6718,12 +8098,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchPredictionJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/batchPredictionJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/batchPredictionJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6740,9 +8124,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchPredictionJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6759,12 +8150,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBatchPredictionJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/batchPredictionJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/batchPredictionJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6790,9 +8185,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6809,9 +8211,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6831,12 +8240,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModelDeploymentMonitoringJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/modelDeploymentMonitoringJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/modelDeploymentMonitoringJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6857,15 +8270,18 @@ impl super::stub::JobService for JobService {
         >,
     > {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchModelDeploymentMonitoringStatsAnomalies", {
+            let arg = &req.model_deployment_monitoring_job;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "model_deployment_monitoring_job",
+                ));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:searchModelDeploymentMonitoringStatsAnomalies",
-                    req.model_deployment_monitoring_job
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6880,9 +8296,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModelDeploymentMonitoringJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6900,12 +8323,16 @@ impl super::stub::JobService for JobService {
     ) -> Result<gax::response::Response<crate::model::ListModelDeploymentMonitoringJobsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/modelDeploymentMonitoringJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/modelDeploymentMonitoringJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6931,20 +8358,15 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.model_deployment_monitoring_job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("model_deployment_monitoring_job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.model_deployment_monitoring_job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing(
-                            "model_deployment_monitoring_job"
-                        ))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6967,9 +8389,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -6986,9 +8415,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7008,9 +8444,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7030,9 +8473,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7052,9 +8502,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7071,12 +8528,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7091,12 +8552,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7123,12 +8588,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7149,9 +8618,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7171,9 +8647,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7190,9 +8673,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7213,9 +8703,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7236,9 +8733,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7306,12 +8810,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CountTokensResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:countTokens", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:countTokens", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7326,12 +8834,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ComputeTokensResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:computeTokens", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:computeTokens", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7346,9 +8858,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7368,9 +8887,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7387,12 +8913,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7407,12 +8937,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7439,12 +8973,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7465,9 +9003,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7487,9 +9032,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7506,9 +9058,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7529,9 +9088,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7552,9 +9118,16 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7608,12 +9181,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FindNeighborsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:findNeighbors", {
+            let arg = &req.index_endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:findNeighbors", req.index_endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7628,12 +9205,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReadIndexDatapointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:readIndexDatapoints", {
+            let arg = &req.index_endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("index_endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:readIndexDatapoints", req.index_endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7648,9 +9229,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7670,9 +9258,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7689,12 +9284,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7709,12 +9308,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7741,12 +9344,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7767,9 +9374,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7789,9 +9403,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7808,9 +9429,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7831,9 +9459,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7854,9 +9489,16 @@ impl super::stub::MatchService for MatchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7910,12 +9552,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/metadataStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/metadataStores", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7933,9 +9579,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetadataStore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7952,12 +9605,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMetadataStoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/metadataStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/metadataStores", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7976,9 +9633,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -7996,12 +9660,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Artifact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/artifacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/artifacts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8019,9 +9687,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Artifact>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8038,12 +9713,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListArtifactsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/artifacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/artifacts", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8064,18 +9743,15 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Artifact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.artifact
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("artifact"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.artifact
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("artifact"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8099,9 +9775,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8119,12 +9802,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/artifacts:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/artifacts:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8139,12 +9826,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/contexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/contexts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8162,9 +9853,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8181,9 +9879,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListContextsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/contexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/contexts", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8204,18 +9909,15 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.context
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("context"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.context
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("context"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8239,9 +9941,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8260,12 +9969,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/contexts:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/contexts:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8281,12 +9994,16 @@ impl super::stub::MetadataService for MetadataService {
     ) -> Result<gax::response::Response<crate::model::AddContextArtifactsAndExecutionsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addContextArtifactsAndExecutions", {
+            let arg = &req.context;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addContextArtifactsAndExecutions", req.context),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8301,12 +10018,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AddContextChildrenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addContextChildren", {
+            let arg = &req.context;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addContextChildren", req.context),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8321,12 +10042,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RemoveContextChildrenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeContextChildren", {
+            let arg = &req.context;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeContextChildren", req.context),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8341,12 +10066,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LineageSubgraph>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryContextLineageSubgraph", {
+            let arg = &req.context;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryContextLineageSubgraph", req.context),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8363,12 +10092,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/executions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/executions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8386,9 +10119,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8405,12 +10145,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExecutionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/executions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/executions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8431,18 +10175,15 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.execution
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("execution"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.execution
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("execution"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8466,9 +10207,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8486,12 +10234,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/executions:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/executions:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8506,12 +10258,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AddExecutionEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addExecutionEvents", {
+            let arg = &req.execution;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("execution"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addExecutionEvents", req.execution),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8526,12 +10282,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LineageSubgraph>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryExecutionInputsAndOutputs", {
+            let arg = &req.execution;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("execution"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryExecutionInputsAndOutputs", req.execution),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8548,12 +10308,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetadataSchema>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/metadataSchemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/metadataSchemas", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8571,9 +10335,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetadataSchema>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8590,12 +10361,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMetadataSchemasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/metadataSchemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/metadataSchemas", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8615,12 +10390,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LineageSubgraph>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryArtifactLineageSubgraph", {
+            let arg = &req.artifact;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("artifact"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryArtifactLineageSubgraph", req.artifact),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8639,9 +10418,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8661,9 +10447,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8680,12 +10473,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8700,12 +10497,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8732,12 +10533,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8758,9 +10563,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8780,9 +10592,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8799,9 +10618,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8822,9 +10648,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8845,9 +10678,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8915,12 +10755,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchMigratableResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/migratableResources:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/migratableResources:search", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8935,12 +10779,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/migratableResources:batchMigrate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/migratableResources:batchMigrate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8955,9 +10803,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8977,9 +10832,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -8996,12 +10858,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9016,12 +10882,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9048,12 +10918,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9074,9 +10948,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9096,9 +10977,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9115,9 +11003,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9138,9 +11033,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9161,9 +11063,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9231,9 +11140,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PublisherModel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9254,9 +11170,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9276,9 +11199,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9295,12 +11225,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9315,12 +11249,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9347,12 +11285,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9373,9 +11315,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9395,9 +11344,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9414,9 +11370,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9437,9 +11400,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9460,9 +11430,16 @@ impl super::stub::ModelGardenService for ModelGardenService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9516,12 +11493,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/models:upload", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/models:upload", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9536,9 +11517,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9555,9 +11543,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/models", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9584,12 +11579,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listVersions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listVersions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9616,12 +11615,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelVersionCheckpointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listCheckpoints", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listCheckpoints", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9640,18 +11643,15 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.model
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("model"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.model
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9672,12 +11672,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:updateExplanationDataset", {
+            let arg = &req.model;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:updateExplanationDataset", req.model),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9692,9 +11696,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9711,12 +11722,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:deleteVersion", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v1/{}:deleteVersion", req.name),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9733,12 +11748,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:mergeVersionAliases", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:mergeVersionAliases", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9753,9 +11772,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9770,12 +11796,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/models:copy", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/models:copy", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9790,12 +11820,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModelEvaluation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/evaluations:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/evaluations:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9811,12 +11845,16 @@ impl super::stub::ModelService for ModelService {
     ) -> Result<gax::response::Response<crate::model::BatchImportModelEvaluationSlicesResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/slices:batchImport", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/slices:batchImport", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9832,12 +11870,16 @@ impl super::stub::ModelService for ModelService {
     ) -> Result<gax::response::Response<crate::model::BatchImportEvaluatedAnnotationsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchImport", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchImport", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9852,9 +11894,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModelEvaluation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9871,12 +11920,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelEvaluationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/evaluations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/evaluations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9902,9 +11955,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModelEvaluationSlice>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9921,9 +11981,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelEvaluationSlicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/slices", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/slices", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9949,9 +12016,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9971,9 +12045,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -9990,12 +12071,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10010,12 +12095,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10042,12 +12131,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10068,9 +12161,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10090,9 +12190,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10109,9 +12216,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10132,9 +12246,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10155,9 +12276,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10225,12 +12353,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/notebookRuntimeTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/notebookRuntimeTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10251,9 +12383,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotebookRuntimeTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10270,12 +12409,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotebookRuntimeTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notebookRuntimeTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/notebookRuntimeTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10302,9 +12445,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10321,18 +12471,15 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotebookRuntimeTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.notebook_runtime_template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("notebook_runtime_template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.notebook_runtime_template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("notebook_runtime_template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10355,12 +12502,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/notebookRuntimes:assign", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/notebookRuntimes:assign", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10375,9 +12526,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotebookRuntime>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10394,12 +12552,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotebookRuntimesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notebookRuntimes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/notebookRuntimes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10426,9 +12588,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10445,9 +12614,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:upgrade", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10462,9 +12638,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10479,9 +12662,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10496,12 +12686,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/notebookExecutionJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/notebookExecutionJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10519,9 +12713,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotebookExecutionJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10539,12 +12740,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotebookExecutionJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notebookExecutionJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/notebookExecutionJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10566,9 +12771,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10585,9 +12797,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10607,9 +12826,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10626,12 +12852,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10646,12 +12876,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10678,12 +12912,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10704,9 +12942,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10726,9 +12971,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10745,9 +12997,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10768,9 +13027,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10791,9 +13057,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10861,12 +13134,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/persistentResources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/persistentResources", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10884,9 +13161,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PersistentResource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10903,12 +13187,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPersistentResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/persistentResources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/persistentResources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10927,9 +13215,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10946,18 +13241,15 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.persistent_resource
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("persistent_resource"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.persistent_resource
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("persistent_resource"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10980,9 +13272,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reboot", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:reboot", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -10997,9 +13296,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11019,9 +13325,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11038,12 +13351,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11058,12 +13375,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11090,12 +13411,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11116,9 +13441,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11138,9 +13470,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11157,9 +13496,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11180,9 +13526,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11203,9 +13556,16 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11273,12 +13633,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TrainingPipeline>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/trainingPipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/trainingPipelines", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11295,9 +13659,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TrainingPipeline>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11314,12 +13685,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTrainingPipelinesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/trainingPipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/trainingPipelines", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11345,9 +13720,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11364,9 +13746,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11386,12 +13775,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PipelineJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/pipelineJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/pipelineJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11409,9 +13802,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PipelineJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11428,12 +13828,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPipelineJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/pipelineJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/pipelineJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11460,9 +13864,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11479,12 +13890,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/pipelineJobs:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/pipelineJobs:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11499,9 +13914,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11521,12 +13943,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/pipelineJobs:batchCancel", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/pipelineJobs:batchCancel", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11541,9 +13967,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11563,9 +13996,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11582,12 +14022,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11602,12 +14046,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11634,12 +14082,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11660,9 +14112,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11682,9 +14141,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11701,9 +14167,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11724,9 +14197,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11747,9 +14227,16 @@ impl super::stub::PipelineService for PipelineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11817,12 +14304,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PredictResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:predict", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:predict", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11837,12 +14328,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::HttpBody>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rawPredict", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rawPredict", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11857,12 +14352,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DirectPredictResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:directPredict", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:directPredict", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11877,12 +14376,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DirectRawPredictResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:directRawPredict", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:directRawPredict", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11897,12 +14400,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExplainResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:explain", {
+            let arg = &req.endpoint;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:explain", req.endpoint),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11917,12 +14424,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateContent", {
+            let arg = &req.model;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateContent", req.model),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11937,9 +14448,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11959,9 +14477,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11978,12 +14503,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -11998,12 +14527,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12030,12 +14563,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12056,9 +14593,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12078,9 +14622,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12097,9 +14648,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12120,9 +14678,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12143,9 +14708,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12199,9 +14771,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryReasoningEngineResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:query", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:query", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12216,9 +14795,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12238,9 +14824,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12257,12 +14850,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12277,12 +14874,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12309,12 +14910,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12335,9 +14940,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12357,9 +14969,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12376,9 +14995,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12399,9 +15025,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12422,9 +15055,16 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12478,12 +15118,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/reasoningEngines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/reasoningEngines", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12500,9 +15144,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReasoningEngine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12519,12 +15170,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReasoningEnginesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reasoningEngines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/reasoningEngines", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12544,18 +15199,15 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.reasoning_engine
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("reasoning_engine"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.reasoning_engine
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("reasoning_engine"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12578,9 +15230,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12598,9 +15257,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12620,9 +15286,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12639,12 +15312,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12659,12 +15336,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12691,12 +15372,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12717,9 +15402,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12739,9 +15431,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12758,9 +15457,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12781,9 +15487,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12804,9 +15517,16 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12874,12 +15594,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Schedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/schedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/schedules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12896,9 +15620,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12915,9 +15646,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Schedule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12934,12 +15672,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSchedulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/schedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/schedules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12960,9 +15702,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -12982,9 +15731,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13004,18 +15760,15 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Schedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.schedule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("schedule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.schedule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("schedule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13038,9 +15791,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13060,9 +15820,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13079,12 +15846,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13099,12 +15870,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13131,12 +15906,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13157,9 +15936,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13179,9 +15965,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13198,9 +15991,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13221,9 +16021,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13244,9 +16051,16 @@ impl super::stub::ScheduleService for ScheduleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13314,12 +16128,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/specialistPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/specialistPools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13336,9 +16154,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SpecialistPool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13355,12 +16180,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSpecialistPoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/specialistPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/specialistPools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13385,9 +16214,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13405,18 +16241,15 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.specialist_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("specialist_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.specialist_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("specialist_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13439,9 +16272,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13461,9 +16301,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13480,12 +16327,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13500,12 +16351,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13532,12 +16387,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13558,9 +16417,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13580,9 +16446,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13599,9 +16472,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13622,9 +16502,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13645,9 +16532,16 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13715,12 +16609,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tensorboards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tensorboards", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13737,9 +16635,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tensorboard>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13756,18 +16661,15 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tensorboard
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tensorboard"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tensorboard
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tensorboard"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13790,12 +16692,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTensorboardsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tensorboards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/tensorboards", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13822,9 +16728,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13841,12 +16754,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReadTensorboardUsageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:readUsage", {
+            let arg = &req.tensorboard;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:readUsage", req.tensorboard),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13863,12 +16780,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReadTensorboardSizeResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:readSize", {
+            let arg = &req.tensorboard;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:readSize", req.tensorboard),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13885,12 +16806,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardExperiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/experiments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/experiments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13908,9 +16833,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardExperiment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13927,18 +16859,15 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardExperiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tensorboard_experiment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_experiment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tensorboard_experiment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_experiment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13961,12 +16890,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTensorboardExperimentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/experiments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/experiments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -13993,9 +16926,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14012,9 +16952,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardRun>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/runs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/runs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14032,12 +16979,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchCreateTensorboardRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/runs:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/runs:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14052,9 +17003,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14071,18 +17029,15 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardRun>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tensorboard_run
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_run"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tensorboard_run
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_run"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14105,9 +17060,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTensorboardRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14134,9 +17096,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14154,12 +17123,16 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::BatchCreateTensorboardTimeSeriesResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14174,12 +17147,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardTimeSeries>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/timeSeries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/timeSeries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14198,9 +17175,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardTimeSeries>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14217,18 +17201,15 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TensorboardTimeSeries>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tensorboard_time_series
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_time_series"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tensorboard_time_series
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tensorboard_time_series"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14251,12 +17232,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTensorboardTimeSeriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/timeSeries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/timeSeries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14283,9 +17268,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14303,12 +17295,16 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::BatchReadTensorboardTimeSeriesDataResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:batchRead", {
+            let arg = &req.tensorboard;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:batchRead", req.tensorboard),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14329,12 +17325,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReadTensorboardTimeSeriesDataResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:read", {
+            let arg = &req.tensorboard_time_series;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_time_series"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:read", req.tensorboard_time_series),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14353,12 +17353,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WriteTensorboardExperimentDataResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:write", {
+            let arg = &req.tensorboard_experiment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_experiment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:write", req.tensorboard_experiment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14373,12 +17377,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WriteTensorboardRunDataResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:write", {
+            let arg = &req.tensorboard_run;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_run"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:write", req.tensorboard_run),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14394,15 +17402,16 @@ impl super::stub::TensorboardService for TensorboardService {
     ) -> Result<gax::response::Response<crate::model::ExportTensorboardTimeSeriesDataResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportTensorboardTimeSeries", {
+            let arg = &req.tensorboard_time_series;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tensorboard_time_series"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:exportTensorboardTimeSeries",
-                    req.tensorboard_time_series
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14417,9 +17426,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14439,9 +17455,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14458,12 +17481,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14478,12 +17505,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14510,12 +17541,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14536,9 +17571,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14558,9 +17600,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14577,9 +17626,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14600,9 +17656,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14623,9 +17686,16 @@ impl super::stub::TensorboardService for TensorboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14693,12 +17763,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/ragCorpora", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/ragCorpora", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14715,18 +17789,15 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.rag_corpus
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("rag_corpus"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.rag_corpus
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("rag_corpus"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14743,9 +17814,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RagCorpus>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14762,12 +17840,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRagCorporaResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/ragCorpora", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/ragCorpora", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14786,9 +17868,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14806,12 +17895,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UploadRagFileResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/ragFiles:upload", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/ragFiles:upload", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14826,12 +17919,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/ragFiles:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/ragFiles:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14846,9 +17943,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RagFile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14865,9 +17969,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRagFilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/ragFiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/ragFiles", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14886,9 +17997,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14905,9 +18023,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14927,9 +18052,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14946,12 +18078,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14966,12 +18102,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -14998,12 +18138,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15024,9 +18168,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15046,9 +18197,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15065,9 +18223,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15088,9 +18253,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15111,9 +18283,16 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15181,12 +18360,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RetrieveContextsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:retrieveContexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:retrieveContexts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15201,12 +18384,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AugmentPromptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:augmentPrompt", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:augmentPrompt", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15221,12 +18408,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CorroborateContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:corroborateContent", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:corroborateContent", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15241,9 +18432,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15263,9 +18461,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15282,12 +18487,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15302,12 +18511,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15334,12 +18547,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15360,9 +18577,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15382,9 +18606,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15401,9 +18632,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15424,9 +18662,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15447,9 +18692,16 @@ impl super::stub::VertexRagService for VertexRagService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15503,9 +18755,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Study>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/studies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/studies", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15520,9 +18779,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Study>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15539,9 +18805,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListStudiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/studies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/studies", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15560,9 +18833,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15583,12 +18863,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Study>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/studies:lookup", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/studies:lookup", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15603,12 +18887,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/trials:suggest", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/trials:suggest", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15623,9 +18911,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trial>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/trials", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/trials", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15640,9 +18935,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trial>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15659,9 +18961,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTrialsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/trials", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/trials", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15680,12 +18989,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trial>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addTrialMeasurement", {
+            let arg = &req.trial_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("trial_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addTrialMeasurement", req.trial_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15700,9 +19013,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trial>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:complete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:complete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15717,9 +19037,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15740,12 +19067,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:checkTrialEarlyStoppingState", {
+            let arg = &req.trial_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("trial_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:checkTrialEarlyStoppingState", req.trial_name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15760,9 +19091,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trial>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15777,12 +19115,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOptimalTrialsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/trials:listOptimalTrials", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/trials:listOptimalTrials", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15797,9 +19139,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15819,9 +19168,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15838,12 +19194,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15858,12 +19218,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15890,12 +19254,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15916,9 +19284,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15938,9 +19313,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15957,9 +19339,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/ui/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/ui/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -15980,9 +19369,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -16003,9 +19399,16 @@ impl super::stub::VizierService for VizierService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/ui/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/ui/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/alloydb/v1/src/client.rs
+++ b/src/generated/cloud/alloydb/v1/src/client.rs
@@ -119,20 +119,13 @@ impl AlloyDBAdmin {
     }
 
     /// Lists Clusters in a given project and location.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::alloy_db_admin::ListClusters {
         super::builder::alloy_db_admin::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Cluster.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetCluster {
-        super::builder::alloy_db_admin::GetCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn get_cluster(&self) -> super::builder::alloy_db_admin::GetCluster {
+        super::builder::alloy_db_admin::GetCluster::new(self.inner.clone())
     }
 
     /// Creates a new Cluster in a given project and location.
@@ -146,12 +139,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::alloy_db_admin::CreateCluster {
         super::builder::alloy_db_admin::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Cluster.
@@ -165,12 +154,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        cluster: impl Into<crate::model::Cluster>,
-    ) -> super::builder::alloy_db_admin::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::alloy_db_admin::UpdateCluster {
         super::builder::alloy_db_admin::UpdateCluster::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Deletes a single Cluster.
@@ -184,11 +169,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::DeleteCluster {
-        super::builder::alloy_db_admin::DeleteCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_cluster(&self) -> super::builder::alloy_db_admin::DeleteCluster {
+        super::builder::alloy_db_admin::DeleteCluster::new(self.inner.clone())
     }
 
     /// Promotes a SECONDARY cluster. This turns down replication
@@ -205,12 +187,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn promote_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::PromoteCluster {
+    pub fn promote_cluster(&self) -> super::builder::alloy_db_admin::PromoteCluster {
         super::builder::alloy_db_admin::PromoteCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Switches the roles of PRIMARY and SECONDARY clusters without any data loss.
@@ -226,12 +204,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn switchover_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::SwitchoverCluster {
+    pub fn switchover_cluster(&self) -> super::builder::alloy_db_admin::SwitchoverCluster {
         super::builder::alloy_db_admin::SwitchoverCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Cluster in a given project and location, with a volume
@@ -247,12 +221,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::RestoreCluster {
+    pub fn restore_cluster(&self) -> super::builder::alloy_db_admin::RestoreCluster {
         super::builder::alloy_db_admin::RestoreCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a cluster of type SECONDARY in the given location using
@@ -269,27 +239,18 @@ impl AlloyDBAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_secondary_cluster(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::alloy_db_admin::CreateSecondaryCluster {
         super::builder::alloy_db_admin::CreateSecondaryCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListInstances {
+    pub fn list_instances(&self) -> super::builder::alloy_db_admin::ListInstances {
         super::builder::alloy_db_admin::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetInstance {
-        super::builder::alloy_db_admin::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::alloy_db_admin::GetInstance {
+        super::builder::alloy_db_admin::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new Instance in a given project and location.
@@ -303,12 +264,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::alloy_db_admin::CreateInstance {
         super::builder::alloy_db_admin::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new SECONDARY Instance in a given project and location.
@@ -324,10 +281,8 @@ impl AlloyDBAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_secondary_instance(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::alloy_db_admin::CreateSecondaryInstance {
         super::builder::alloy_db_admin::CreateSecondaryInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates new instances under the given project, location and cluster.
@@ -350,12 +305,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_create_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::BatchCreateInstances {
+    pub fn batch_create_instances(&self) -> super::builder::alloy_db_admin::BatchCreateInstances {
         super::builder::alloy_db_admin::BatchCreateInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Instance.
@@ -369,12 +320,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::alloy_db_admin::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::alloy_db_admin::UpdateInstance {
         super::builder::alloy_db_admin::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes a single Instance.
@@ -388,12 +335,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::alloy_db_admin::DeleteInstance {
         super::builder::alloy_db_admin::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Forces a Failover for a highly available instance.
@@ -409,12 +352,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn failover_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::FailoverInstance {
+    pub fn failover_instance(&self) -> super::builder::alloy_db_admin::FailoverInstance {
         super::builder::alloy_db_admin::FailoverInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Injects fault in an instance.
@@ -429,11 +368,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn inject_fault(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::InjectFault {
-        super::builder::alloy_db_admin::InjectFault::new(self.inner.clone()).set_name(name.into())
+    pub fn inject_fault(&self) -> super::builder::alloy_db_admin::InjectFault {
+        super::builder::alloy_db_admin::InjectFault::new(self.inner.clone())
     }
 
     /// Restart an Instance in a cluster.
@@ -448,38 +384,23 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restart_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::RestartInstance {
+    pub fn restart_instance(&self) -> super::builder::alloy_db_admin::RestartInstance {
         super::builder::alloy_db_admin::RestartInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Executes a SQL statement in a database inside an AlloyDB instance.
-    pub fn execute_sql(
-        &self,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ExecuteSql {
+    pub fn execute_sql(&self) -> super::builder::alloy_db_admin::ExecuteSql {
         super::builder::alloy_db_admin::ExecuteSql::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Lists Backups in a given project and location.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListBackups {
+    pub fn list_backups(&self) -> super::builder::alloy_db_admin::ListBackups {
         super::builder::alloy_db_admin::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetBackup {
-        super::builder::alloy_db_admin::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::alloy_db_admin::GetBackup {
+        super::builder::alloy_db_admin::GetBackup::new(self.inner.clone())
     }
 
     /// Creates a new Backup in a given project and location.
@@ -493,12 +414,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::alloy_db_admin::CreateBackup {
         super::builder::alloy_db_admin::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Backup.
@@ -512,12 +429,8 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::alloy_db_admin::UpdateBackup {
+    pub fn update_backup(&self) -> super::builder::alloy_db_admin::UpdateBackup {
         super::builder::alloy_db_admin::UpdateBackup::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Deletes a single Backup.
@@ -531,20 +444,15 @@ impl AlloyDBAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::DeleteBackup {
-        super::builder::alloy_db_admin::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::alloy_db_admin::DeleteBackup {
+        super::builder::alloy_db_admin::DeleteBackup::new(self.inner.clone())
     }
 
     /// Lists SupportedDatabaseFlags for a given project and location.
     pub fn list_supported_database_flags(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::alloy_db_admin::ListSupportedDatabaseFlags {
         super::builder::alloy_db_admin::ListSupportedDatabaseFlags::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Generate a client certificate signed by a Cluster CA.
@@ -554,127 +462,80 @@ impl AlloyDBAdmin {
     /// will not break AlloyDB connectors or the Auth Proxy client.
     pub fn generate_client_certificate(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::alloy_db_admin::GenerateClientCertificate {
         super::builder::alloy_db_admin::GenerateClientCertificate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get instance metadata used for a connection.
-    pub fn get_connection_info(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetConnectionInfo {
+    pub fn get_connection_info(&self) -> super::builder::alloy_db_admin::GetConnectionInfo {
         super::builder::alloy_db_admin::GetConnectionInfo::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Users in a given project and location.
-    pub fn list_users(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListUsers {
-        super::builder::alloy_db_admin::ListUsers::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_users(&self) -> super::builder::alloy_db_admin::ListUsers {
+        super::builder::alloy_db_admin::ListUsers::new(self.inner.clone())
     }
 
     /// Gets details of a single User.
-    pub fn get_user(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetUser {
-        super::builder::alloy_db_admin::GetUser::new(self.inner.clone()).set_name(name.into())
+    pub fn get_user(&self) -> super::builder::alloy_db_admin::GetUser {
+        super::builder::alloy_db_admin::GetUser::new(self.inner.clone())
     }
 
     /// Creates a new User in a given project, location, and cluster.
-    pub fn create_user(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::CreateUser {
+    pub fn create_user(&self) -> super::builder::alloy_db_admin::CreateUser {
         super::builder::alloy_db_admin::CreateUser::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single User.
-    pub fn update_user(
-        &self,
-        user: impl Into<crate::model::User>,
-    ) -> super::builder::alloy_db_admin::UpdateUser {
-        super::builder::alloy_db_admin::UpdateUser::new(self.inner.clone()).set_user(user.into())
+    pub fn update_user(&self) -> super::builder::alloy_db_admin::UpdateUser {
+        super::builder::alloy_db_admin::UpdateUser::new(self.inner.clone())
     }
 
     /// Deletes a single User.
-    pub fn delete_user(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::DeleteUser {
-        super::builder::alloy_db_admin::DeleteUser::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_user(&self) -> super::builder::alloy_db_admin::DeleteUser {
+        super::builder::alloy_db_admin::DeleteUser::new(self.inner.clone())
     }
 
     /// Lists Databases in a given project and location.
-    pub fn list_databases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListDatabases {
+    pub fn list_databases(&self) -> super::builder::alloy_db_admin::ListDatabases {
         super::builder::alloy_db_admin::ListDatabases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListLocations {
-        super::builder::alloy_db_admin::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::alloy_db_admin::ListLocations {
+        super::builder::alloy_db_admin::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetLocation {
-        super::builder::alloy_db_admin::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::alloy_db_admin::GetLocation {
+        super::builder::alloy_db_admin::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::alloy_db_admin::ListOperations {
         super::builder::alloy_db_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::GetOperation {
-        super::builder::alloy_db_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::alloy_db_admin::GetOperation {
+        super::builder::alloy_db_admin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::alloy_db_admin::DeleteOperation {
         super::builder::alloy_db_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alloy_db_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::alloy_db_admin::CancelOperation {
         super::builder::alloy_db_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +103,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +132,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -151,9 +166,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +196,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:promote", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:promote", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,12 +220,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:switchover", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:switchover", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,12 +244,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters:restore", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters:restore", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,12 +268,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters:createsecondary", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters:createsecondary", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,12 +297,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,9 +327,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -302,12 +354,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -327,12 +383,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances:createsecondary", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances:createsecondary", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,12 +412,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -375,18 +439,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,9 +473,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -434,9 +502,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:failover", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:failover", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -451,12 +526,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:injectFault", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:injectFault", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +550,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restart", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -488,12 +574,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExecuteSqlResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:executeSql", {
+            let arg = &req.instance;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:executeSql", req.instance),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,9 +598,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -531,9 +628,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -550,9 +654,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -570,18 +681,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -605,9 +713,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -627,12 +742,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSupportedDatabaseFlagsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/supportedDatabaseFlags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/supportedDatabaseFlags", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -651,12 +770,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateClientCertificateResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateClientCertificate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateClientCertificate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -671,12 +794,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectionInfo>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectionInfo", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectionInfo", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -694,9 +821,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/users", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/users", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -717,9 +851,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -736,9 +877,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/users", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/users", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -756,18 +904,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.user
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("user"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.user
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("user"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -791,9 +936,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -816,12 +968,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatabasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/databases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/databases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -841,9 +997,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -863,9 +1026,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -882,9 +1052,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -904,9 +1081,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -923,9 +1107,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -946,9 +1137,16 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -133,10 +133,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cluster
+            let arg = &req
+                .cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -440,10 +445,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -682,10 +692,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -905,10 +920,15 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.user
+            let arg = &req
+                .user
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("user"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("user.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/apigateway/v1/src/client.rs
+++ b/src/generated/cloud/apigateway/v1/src/client.rs
@@ -121,21 +121,13 @@ impl ApiGatewayService {
     }
 
     /// Lists Gateways in a given project and location.
-    pub fn list_gateways(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::ListGateways {
+    pub fn list_gateways(&self) -> super::builder::api_gateway_service::ListGateways {
         super::builder::api_gateway_service::ListGateways::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Gateway.
-    pub fn get_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::GetGateway {
+    pub fn get_gateway(&self) -> super::builder::api_gateway_service::GetGateway {
         super::builder::api_gateway_service::GetGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Gateway in a given project and location.
@@ -149,12 +141,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_gateway(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::CreateGateway {
+    pub fn create_gateway(&self) -> super::builder::api_gateway_service::CreateGateway {
         super::builder::api_gateway_service::CreateGateway::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Gateway.
@@ -168,12 +156,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_gateway(
-        &self,
-        gateway: impl Into<crate::model::Gateway>,
-    ) -> super::builder::api_gateway_service::UpdateGateway {
+    pub fn update_gateway(&self) -> super::builder::api_gateway_service::UpdateGateway {
         super::builder::api_gateway_service::UpdateGateway::new(self.inner.clone())
-            .set_gateway(gateway.into())
     }
 
     /// Deletes a single Gateway.
@@ -187,29 +171,18 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::DeleteGateway {
+    pub fn delete_gateway(&self) -> super::builder::api_gateway_service::DeleteGateway {
         super::builder::api_gateway_service::DeleteGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Apis in a given project and location.
-    pub fn list_apis(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::ListApis {
+    pub fn list_apis(&self) -> super::builder::api_gateway_service::ListApis {
         super::builder::api_gateway_service::ListApis::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Api.
-    pub fn get_api(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::GetApi {
-        super::builder::api_gateway_service::GetApi::new(self.inner.clone()).set_name(name.into())
+    pub fn get_api(&self) -> super::builder::api_gateway_service::GetApi {
+        super::builder::api_gateway_service::GetApi::new(self.inner.clone())
     }
 
     /// Creates a new Api in a given project and location.
@@ -223,12 +196,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_api(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::CreateApi {
+    pub fn create_api(&self) -> super::builder::api_gateway_service::CreateApi {
         super::builder::api_gateway_service::CreateApi::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Api.
@@ -242,11 +211,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_api(
-        &self,
-        api: impl Into<crate::model::Api>,
-    ) -> super::builder::api_gateway_service::UpdateApi {
-        super::builder::api_gateway_service::UpdateApi::new(self.inner.clone()).set_api(api.into())
+    pub fn update_api(&self) -> super::builder::api_gateway_service::UpdateApi {
+        super::builder::api_gateway_service::UpdateApi::new(self.inner.clone())
     }
 
     /// Deletes a single Api.
@@ -260,30 +226,18 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_api(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::DeleteApi {
+    pub fn delete_api(&self) -> super::builder::api_gateway_service::DeleteApi {
         super::builder::api_gateway_service::DeleteApi::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ApiConfigs in a given project and location.
-    pub fn list_api_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::ListApiConfigs {
+    pub fn list_api_configs(&self) -> super::builder::api_gateway_service::ListApiConfigs {
         super::builder::api_gateway_service::ListApiConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ApiConfig.
-    pub fn get_api_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::GetApiConfig {
+    pub fn get_api_config(&self) -> super::builder::api_gateway_service::GetApiConfig {
         super::builder::api_gateway_service::GetApiConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ApiConfig in a given project and location.
@@ -297,12 +251,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_api_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::CreateApiConfig {
+    pub fn create_api_config(&self) -> super::builder::api_gateway_service::CreateApiConfig {
         super::builder::api_gateway_service::CreateApiConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ApiConfig.
@@ -316,12 +266,8 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_api_config(
-        &self,
-        api_config: impl Into<crate::model::ApiConfig>,
-    ) -> super::builder::api_gateway_service::UpdateApiConfig {
+    pub fn update_api_config(&self) -> super::builder::api_gateway_service::UpdateApiConfig {
         super::builder::api_gateway_service::UpdateApiConfig::new(self.inner.clone())
-            .set_api_config(api_config.into())
     }
 
     /// Deletes a single ApiConfig.
@@ -335,55 +281,35 @@ impl ApiGatewayService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_api_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::DeleteApiConfig {
+    pub fn delete_api_config(&self) -> super::builder::api_gateway_service::DeleteApiConfig {
         super::builder::api_gateway_service::DeleteApiConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::api_gateway_service::ListOperations {
         super::builder::api_gateway_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::api_gateway_service::GetOperation {
         super::builder::api_gateway_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::api_gateway_service::DeleteOperation {
         super::builder::api_gateway_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_gateway_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::api_gateway_service::CancelOperation {
         super::builder::api_gateway_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.gateway
+            let arg = &req
+                .gateway
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("gateway.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -268,10 +273,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.api
+            let arg = &req
+                .api
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("api"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("api.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -407,10 +417,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.api_config
+            let arg = &req
+                .api_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("api_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("api_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGatewaysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/gateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/gateways", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Gateway>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +102,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/gateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/gateways", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,18 +129,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.gateway
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.gateway
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,9 +160,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -164,9 +186,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApisResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/apis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/apis", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -187,9 +216,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Api>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,9 +242,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/apis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/apis", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -224,18 +267,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.api
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("api"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.api
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("api"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,9 +296,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +322,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApiConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/configs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/configs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,9 +352,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApiConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,9 +379,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/configs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/configs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,18 +406,15 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.api_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("api_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.api_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("api_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -372,9 +437,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -391,9 +463,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -413,9 +492,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -432,9 +518,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -455,9 +548,16 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/apigeeconnect/v1/src/client.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/client.rs
@@ -122,11 +122,7 @@ impl ConnectionService {
 
     /// Lists connections that are currently active for the given Apigee Connect
     /// endpoint.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::ListConnections {
+    pub fn list_connections(&self) -> super::builder::connection_service::ListConnections {
         super::builder::connection_service::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/apigeeconnect/v1/src/transport.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/apihub/v1/src/client.rs
+++ b/src/generated/cloud/apihub/v1/src/client.rs
@@ -120,24 +120,18 @@ impl ApiHub {
 
     /// Create an API resource in the API hub.
     /// Once an API resource is created, versions can be added to it.
-    pub fn create_api(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateApi {
-        super::builder::api_hub::CreateApi::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_api(&self) -> super::builder::api_hub::CreateApi {
+        super::builder::api_hub::CreateApi::new(self.inner.clone())
     }
 
     /// Get API resource details including the API versions contained in it.
-    pub fn get_api(&self, name: impl Into<std::string::String>) -> super::builder::api_hub::GetApi {
-        super::builder::api_hub::GetApi::new(self.inner.clone()).set_name(name.into())
+    pub fn get_api(&self) -> super::builder::api_hub::GetApi {
+        super::builder::api_hub::GetApi::new(self.inner.clone())
     }
 
     /// List API resources in the API hub.
-    pub fn list_apis(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListApis {
-        super::builder::api_hub::ListApis::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_apis(&self) -> super::builder::api_hub::ListApis {
+        super::builder::api_hub::ListApis::new(self.inner.clone())
     }
 
     /// Update an API resource in the API hub. The following fields in the
@@ -170,46 +164,31 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Api.target_user]: crate::model::Api::target_user
     /// [google.cloud.apihub.v1.Api.team]: crate::model::Api::team
     /// [google.cloud.apihub.v1.UpdateApiRequest.update_mask]: crate::model::UpdateApiRequest::update_mask
-    pub fn update_api(
-        &self,
-        api: impl Into<crate::model::Api>,
-    ) -> super::builder::api_hub::UpdateApi {
-        super::builder::api_hub::UpdateApi::new(self.inner.clone()).set_api(api.into())
+    pub fn update_api(&self) -> super::builder::api_hub::UpdateApi {
+        super::builder::api_hub::UpdateApi::new(self.inner.clone())
     }
 
     /// Delete an API resource in the API hub. API can only be deleted if all
     /// underlying versions are deleted.
-    pub fn delete_api(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteApi {
-        super::builder::api_hub::DeleteApi::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_api(&self) -> super::builder::api_hub::DeleteApi {
+        super::builder::api_hub::DeleteApi::new(self.inner.clone())
     }
 
     /// Create an API version for an API resource in the API hub.
-    pub fn create_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateVersion {
-        super::builder::api_hub::CreateVersion::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_version(&self) -> super::builder::api_hub::CreateVersion {
+        super::builder::api_hub::CreateVersion::new(self.inner.clone())
     }
 
     /// Get details about the API version of an API resource. This will include
     /// information about the specs and operations present in the API
     /// version as well as the deployments linked to it.
-    pub fn get_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetVersion {
-        super::builder::api_hub::GetVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_version(&self) -> super::builder::api_hub::GetVersion {
+        super::builder::api_hub::GetVersion::new(self.inner.clone())
     }
 
     /// List API versions of an API resource in the API hub.
-    pub fn list_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListVersions {
-        super::builder::api_hub::ListVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_versions(&self) -> super::builder::api_hub::ListVersions {
+        super::builder::api_hub::ListVersions::new(self.inner.clone())
     }
 
     /// Update API version. The following fields in the
@@ -238,20 +217,14 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Version.display_name]: crate::model::Version::display_name
     /// [google.cloud.apihub.v1.Version.documentation]: crate::model::Version::documentation
     /// [google.cloud.apihub.v1.Version.lifecycle]: crate::model::Version::lifecycle
-    pub fn update_version(
-        &self,
-        version: impl Into<crate::model::Version>,
-    ) -> super::builder::api_hub::UpdateVersion {
-        super::builder::api_hub::UpdateVersion::new(self.inner.clone()).set_version(version.into())
+    pub fn update_version(&self) -> super::builder::api_hub::UpdateVersion {
+        super::builder::api_hub::UpdateVersion::new(self.inner.clone())
     }
 
     /// Delete an API version. Version can only be deleted if all underlying specs,
     /// operations, definitions and linked deployments are deleted.
-    pub fn delete_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteVersion {
-        super::builder::api_hub::DeleteVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_version(&self) -> super::builder::api_hub::DeleteVersion {
+        super::builder::api_hub::DeleteVersion::new(self.inner.clone())
     }
 
     /// Add a spec to an API version in the API hub.
@@ -279,11 +252,8 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.ApiHub.GetSpec]: crate::client::ApiHub::get_spec
     /// [google.cloud.apihub.v1.ApiHub.GetSpecContents]: crate::client::ApiHub::get_spec_contents
     /// [google.cloud.apihub.v1.ApiHub.ListApiOperations]: crate::client::ApiHub::list_api_operations
-    pub fn create_spec(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateSpec {
-        super::builder::api_hub::CreateSpec::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_spec(&self) -> super::builder::api_hub::CreateSpec {
+        super::builder::api_hub::CreateSpec::new(self.inner.clone())
     }
 
     /// Get details about the information parsed from a spec.
@@ -292,27 +262,18 @@ impl ApiHub {
     /// to retrieve the same.
     ///
     /// [google.cloud.apihub.v1.ApiHub.GetSpecContents]: crate::client::ApiHub::get_spec_contents
-    pub fn get_spec(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetSpec {
-        super::builder::api_hub::GetSpec::new(self.inner.clone()).set_name(name.into())
+    pub fn get_spec(&self) -> super::builder::api_hub::GetSpec {
+        super::builder::api_hub::GetSpec::new(self.inner.clone())
     }
 
     /// Get spec contents.
-    pub fn get_spec_contents(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetSpecContents {
-        super::builder::api_hub::GetSpecContents::new(self.inner.clone()).set_name(name.into())
+    pub fn get_spec_contents(&self) -> super::builder::api_hub::GetSpecContents {
+        super::builder::api_hub::GetSpecContents::new(self.inner.clone())
     }
 
     /// List specs corresponding to a particular API resource.
-    pub fn list_specs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListSpecs {
-        super::builder::api_hub::ListSpecs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_specs(&self) -> super::builder::api_hub::ListSpecs {
+        super::builder::api_hub::ListSpecs::new(self.inner.clone())
     }
 
     /// Update spec. The following fields in the
@@ -347,72 +308,47 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Spec.source_uri]: crate::model::Spec::source_uri
     /// [google.cloud.apihub.v1.Spec.spec_type]: crate::model::Spec::spec_type
     /// [google.cloud.apihub.v1.UpdateSpecRequest.update_mask]: crate::model::UpdateSpecRequest::update_mask
-    pub fn update_spec(
-        &self,
-        spec: impl Into<crate::model::Spec>,
-    ) -> super::builder::api_hub::UpdateSpec {
-        super::builder::api_hub::UpdateSpec::new(self.inner.clone()).set_spec(spec.into())
+    pub fn update_spec(&self) -> super::builder::api_hub::UpdateSpec {
+        super::builder::api_hub::UpdateSpec::new(self.inner.clone())
     }
 
     /// Delete a spec.
     /// Deleting a spec will also delete the associated operations from the
     /// version.
-    pub fn delete_spec(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteSpec {
-        super::builder::api_hub::DeleteSpec::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_spec(&self) -> super::builder::api_hub::DeleteSpec {
+        super::builder::api_hub::DeleteSpec::new(self.inner.clone())
     }
 
     /// Get details about a particular operation in API version.
-    pub fn get_api_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetApiOperation {
-        super::builder::api_hub::GetApiOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_api_operation(&self) -> super::builder::api_hub::GetApiOperation {
+        super::builder::api_hub::GetApiOperation::new(self.inner.clone())
     }
 
     /// List operations in an API version.
-    pub fn list_api_operations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListApiOperations {
+    pub fn list_api_operations(&self) -> super::builder::api_hub::ListApiOperations {
         super::builder::api_hub::ListApiOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details about a definition in an API version.
-    pub fn get_definition(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetDefinition {
-        super::builder::api_hub::GetDefinition::new(self.inner.clone()).set_name(name.into())
+    pub fn get_definition(&self) -> super::builder::api_hub::GetDefinition {
+        super::builder::api_hub::GetDefinition::new(self.inner.clone())
     }
 
     /// Create a deployment resource in the API hub.
     /// Once a deployment resource is created, it can be associated with API
     /// versions.
-    pub fn create_deployment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateDeployment {
-        super::builder::api_hub::CreateDeployment::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_deployment(&self) -> super::builder::api_hub::CreateDeployment {
+        super::builder::api_hub::CreateDeployment::new(self.inner.clone())
     }
 
     /// Get details about a deployment and the API versions linked to it.
-    pub fn get_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetDeployment {
-        super::builder::api_hub::GetDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_deployment(&self) -> super::builder::api_hub::GetDeployment {
+        super::builder::api_hub::GetDeployment::new(self.inner.clone())
     }
 
     /// List deployment resources in the API hub.
-    pub fn list_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListDeployments {
-        super::builder::api_hub::ListDeployments::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_deployments(&self) -> super::builder::api_hub::ListDeployments {
+        super::builder::api_hub::ListDeployments::new(self.inner.clone())
     }
 
     /// Update a deployment resource in the API hub. The following fields in the
@@ -444,20 +380,13 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Deployment.resource_uri]: crate::model::Deployment::resource_uri
     /// [google.cloud.apihub.v1.Deployment.slo]: crate::model::Deployment::slo
     /// [google.cloud.apihub.v1.UpdateDeploymentRequest.update_mask]: crate::model::UpdateDeploymentRequest::update_mask
-    pub fn update_deployment(
-        &self,
-        deployment: impl Into<crate::model::Deployment>,
-    ) -> super::builder::api_hub::UpdateDeployment {
+    pub fn update_deployment(&self) -> super::builder::api_hub::UpdateDeployment {
         super::builder::api_hub::UpdateDeployment::new(self.inner.clone())
-            .set_deployment(deployment.into())
     }
 
     /// Delete a deployment resource in the API hub.
-    pub fn delete_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteDeployment {
-        super::builder::api_hub::DeleteDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_deployment(&self) -> super::builder::api_hub::DeleteDeployment {
+        super::builder::api_hub::DeleteDeployment::new(self.inner.clone())
     }
 
     /// Create a user defined attribute.
@@ -470,19 +399,13 @@ impl ApiHub {
     ///
     /// [google.cloud.apihub.v1.ApiHub.ListAttributes]: crate::client::ApiHub::list_attributes
     /// [google.cloud.apihub.v1.ApiHub.UpdateAttribute]: crate::client::ApiHub::update_attribute
-    pub fn create_attribute(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateAttribute {
-        super::builder::api_hub::CreateAttribute::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_attribute(&self) -> super::builder::api_hub::CreateAttribute {
+        super::builder::api_hub::CreateAttribute::new(self.inner.clone())
     }
 
     /// Get details about the attribute.
-    pub fn get_attribute(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetAttribute {
-        super::builder::api_hub::GetAttribute::new(self.inner.clone()).set_name(name.into())
+    pub fn get_attribute(&self) -> super::builder::api_hub::GetAttribute {
+        super::builder::api_hub::GetAttribute::new(self.inner.clone())
     }
 
     /// Update the attribute.  The following fields in the
@@ -515,12 +438,8 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Attribute.description]: crate::model::Attribute::description
     /// [google.cloud.apihub.v1.Attribute.display_name]: crate::model::Attribute::display_name
     /// [google.cloud.apihub.v1.UpdateAttributeRequest.update_mask]: crate::model::UpdateAttributeRequest::update_mask
-    pub fn update_attribute(
-        &self,
-        attribute: impl Into<crate::model::Attribute>,
-    ) -> super::builder::api_hub::UpdateAttribute {
+    pub fn update_attribute(&self) -> super::builder::api_hub::UpdateAttribute {
         super::builder::api_hub::UpdateAttribute::new(self.inner.clone())
-            .set_attribute(attribute.into())
     }
 
     /// Delete an attribute.
@@ -528,45 +447,28 @@ impl ApiHub {
     /// Note: System defined attributes cannot be deleted. All
     /// associations of the attribute being deleted with any API hub resource will
     /// also get deleted.
-    pub fn delete_attribute(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteAttribute {
-        super::builder::api_hub::DeleteAttribute::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_attribute(&self) -> super::builder::api_hub::DeleteAttribute {
+        super::builder::api_hub::DeleteAttribute::new(self.inner.clone())
     }
 
     /// List all attributes.
-    pub fn list_attributes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListAttributes {
-        super::builder::api_hub::ListAttributes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_attributes(&self) -> super::builder::api_hub::ListAttributes {
+        super::builder::api_hub::ListAttributes::new(self.inner.clone())
     }
 
     /// Search across API-Hub resources.
-    pub fn search_resources(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::SearchResources {
+    pub fn search_resources(&self) -> super::builder::api_hub::SearchResources {
         super::builder::api_hub::SearchResources::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Create an External API resource in the API hub.
-    pub fn create_external_api(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CreateExternalApi {
+    pub fn create_external_api(&self) -> super::builder::api_hub::CreateExternalApi {
         super::builder::api_hub::CreateExternalApi::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details about an External API resource in the API hub.
-    pub fn get_external_api(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetExternalApi {
-        super::builder::api_hub::GetExternalApi::new(self.inner.clone()).set_name(name.into())
+    pub fn get_external_api(&self) -> super::builder::api_hub::GetExternalApi {
+        super::builder::api_hub::GetExternalApi::new(self.inner.clone())
     }
 
     /// Update an External API resource in the API hub. The following fields can be
@@ -588,84 +490,56 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.ExternalApi.endpoints]: crate::model::ExternalApi::endpoints
     /// [google.cloud.apihub.v1.ExternalApi.paths]: crate::model::ExternalApi::paths
     /// [google.cloud.apihub.v1.UpdateExternalApiRequest.update_mask]: crate::model::UpdateExternalApiRequest::update_mask
-    pub fn update_external_api(
-        &self,
-        external_api: impl Into<crate::model::ExternalApi>,
-    ) -> super::builder::api_hub::UpdateExternalApi {
+    pub fn update_external_api(&self) -> super::builder::api_hub::UpdateExternalApi {
         super::builder::api_hub::UpdateExternalApi::new(self.inner.clone())
-            .set_external_api(external_api.into())
     }
 
     /// Delete an External API resource in the API hub.
-    pub fn delete_external_api(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteExternalApi {
-        super::builder::api_hub::DeleteExternalApi::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_external_api(&self) -> super::builder::api_hub::DeleteExternalApi {
+        super::builder::api_hub::DeleteExternalApi::new(self.inner.clone())
     }
 
     /// List External API resources in the API hub.
-    pub fn list_external_apis(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListExternalApis {
-        super::builder::api_hub::ListExternalApis::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_external_apis(&self) -> super::builder::api_hub::ListExternalApis {
+        super::builder::api_hub::ListExternalApis::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListLocations {
-        super::builder::api_hub::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::api_hub::ListLocations {
+        super::builder::api_hub::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetLocation {
-        super::builder::api_hub::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::api_hub::GetLocation {
+        super::builder::api_hub::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::ListOperations {
-        super::builder::api_hub::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::api_hub::ListOperations {
+        super::builder::api_hub::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::GetOperation {
-        super::builder::api_hub::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::api_hub::GetOperation {
+        super::builder::api_hub::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::DeleteOperation {
-        super::builder::api_hub::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::api_hub::DeleteOperation {
+        super::builder::api_hub::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub::CancelOperation {
-        super::builder::api_hub::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::api_hub::CancelOperation {
+        super::builder::api_hub::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -775,21 +649,13 @@ impl ApiHubDependencies {
     }
 
     /// Create a dependency between two entities in the API hub.
-    pub fn create_dependency(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::CreateDependency {
+    pub fn create_dependency(&self) -> super::builder::api_hub_dependencies::CreateDependency {
         super::builder::api_hub_dependencies::CreateDependency::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details about a dependency resource in the API hub.
-    pub fn get_dependency(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::GetDependency {
+    pub fn get_dependency(&self) -> super::builder::api_hub_dependencies::GetDependency {
         super::builder::api_hub_dependencies::GetDependency::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a dependency based on the
@@ -804,92 +670,56 @@ impl ApiHubDependencies {
     /// [google.cloud.apihub.v1.Dependency]: crate::model::Dependency
     /// [google.cloud.apihub.v1.Dependency.description]: crate::model::Dependency::description
     /// [google.cloud.apihub.v1.UpdateDependencyRequest.update_mask]: crate::model::UpdateDependencyRequest::update_mask
-    pub fn update_dependency(
-        &self,
-        dependency: impl Into<crate::model::Dependency>,
-    ) -> super::builder::api_hub_dependencies::UpdateDependency {
+    pub fn update_dependency(&self) -> super::builder::api_hub_dependencies::UpdateDependency {
         super::builder::api_hub_dependencies::UpdateDependency::new(self.inner.clone())
-            .set_dependency(dependency.into())
     }
 
     /// Delete the dependency resource.
-    pub fn delete_dependency(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::DeleteDependency {
+    pub fn delete_dependency(&self) -> super::builder::api_hub_dependencies::DeleteDependency {
         super::builder::api_hub_dependencies::DeleteDependency::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List dependencies based on the provided filter and pagination parameters.
-    pub fn list_dependencies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::ListDependencies {
+    pub fn list_dependencies(&self) -> super::builder::api_hub_dependencies::ListDependencies {
         super::builder::api_hub_dependencies::ListDependencies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::ListLocations {
+    pub fn list_locations(&self) -> super::builder::api_hub_dependencies::ListLocations {
         super::builder::api_hub_dependencies::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::GetLocation {
+    pub fn get_location(&self) -> super::builder::api_hub_dependencies::GetLocation {
         super::builder::api_hub_dependencies::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::ListOperations {
+    pub fn list_operations(&self) -> super::builder::api_hub_dependencies::ListOperations {
         super::builder::api_hub_dependencies::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::GetOperation {
+    pub fn get_operation(&self) -> super::builder::api_hub_dependencies::GetOperation {
         super::builder::api_hub_dependencies::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::api_hub_dependencies::DeleteOperation {
         super::builder::api_hub_dependencies::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_dependencies::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::api_hub_dependencies::CancelOperation {
         super::builder::api_hub_dependencies::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1002,52 +832,40 @@ impl HostProjectRegistrationService {
     /// register calls for the same project will fail.
     pub fn create_host_project_registration(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::CreateHostProjectRegistration {
         super::builder::host_project_registration_service::CreateHostProjectRegistration::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get a host project registration.
     pub fn get_host_project_registration(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::GetHostProjectRegistration {
         super::builder::host_project_registration_service::GetHostProjectRegistration::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists host project registrations.
     pub fn list_host_project_registrations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::ListHostProjectRegistrations {
         super::builder::host_project_registration_service::ListHostProjectRegistrations::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::ListLocations {
         super::builder::host_project_registration_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::host_project_registration_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::host_project_registration_service::GetLocation {
         super::builder::host_project_registration_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1055,21 +873,15 @@ impl HostProjectRegistrationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::ListOperations {
         super::builder::host_project_registration_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::host_project_registration_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::host_project_registration_service::GetOperation {
         super::builder::host_project_registration_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1077,10 +889,8 @@ impl HostProjectRegistrationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::DeleteOperation {
         super::builder::host_project_registration_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1088,10 +898,8 @@ impl HostProjectRegistrationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::host_project_registration_service::CancelOperation {
         super::builder::host_project_registration_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1196,100 +1004,65 @@ impl LintingService {
     }
 
     /// Get the style guide being used for linting.
-    pub fn get_style_guide(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::GetStyleGuide {
+    pub fn get_style_guide(&self) -> super::builder::linting_service::GetStyleGuide {
         super::builder::linting_service::GetStyleGuide::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update the styleGuide to be used for liniting in by API hub.
-    pub fn update_style_guide(
-        &self,
-        style_guide: impl Into<crate::model::StyleGuide>,
-    ) -> super::builder::linting_service::UpdateStyleGuide {
+    pub fn update_style_guide(&self) -> super::builder::linting_service::UpdateStyleGuide {
         super::builder::linting_service::UpdateStyleGuide::new(self.inner.clone())
-            .set_style_guide(style_guide.into())
     }
 
     /// Get the contents of the style guide.
     pub fn get_style_guide_contents(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::linting_service::GetStyleGuideContents {
         super::builder::linting_service::GetStyleGuideContents::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lints the requested spec and updates the corresponding API Spec with the
     /// lint response. This lint response will be available in all subsequent
     /// Get and List Spec calls to Core service.
-    pub fn lint_spec(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::LintSpec {
-        super::builder::linting_service::LintSpec::new(self.inner.clone()).set_name(name.into())
+    pub fn lint_spec(&self) -> super::builder::linting_service::LintSpec {
+        super::builder::linting_service::LintSpec::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::linting_service::ListLocations {
         super::builder::linting_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::GetLocation {
-        super::builder::linting_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::linting_service::GetLocation {
+        super::builder::linting_service::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::linting_service::ListOperations {
         super::builder::linting_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::GetOperation {
-        super::builder::linting_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::linting_service::GetOperation {
+        super::builder::linting_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::linting_service::DeleteOperation {
         super::builder::linting_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::linting_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::linting_service::CancelOperation {
         super::builder::linting_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1394,88 +1167,58 @@ impl ApiHubPlugin {
     }
 
     /// Get details about an API Hub plugin.
-    pub fn get_plugin(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::GetPlugin {
-        super::builder::api_hub_plugin::GetPlugin::new(self.inner.clone()).set_name(name.into())
+    pub fn get_plugin(&self) -> super::builder::api_hub_plugin::GetPlugin {
+        super::builder::api_hub_plugin::GetPlugin::new(self.inner.clone())
     }
 
     /// Enables a plugin.
     /// The `state` of the plugin after enabling is `ENABLED`
-    pub fn enable_plugin(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::EnablePlugin {
-        super::builder::api_hub_plugin::EnablePlugin::new(self.inner.clone()).set_name(name.into())
+    pub fn enable_plugin(&self) -> super::builder::api_hub_plugin::EnablePlugin {
+        super::builder::api_hub_plugin::EnablePlugin::new(self.inner.clone())
     }
 
     /// Disables a plugin.
     /// The `state` of the plugin after disabling is `DISABLED`
-    pub fn disable_plugin(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::DisablePlugin {
-        super::builder::api_hub_plugin::DisablePlugin::new(self.inner.clone()).set_name(name.into())
+    pub fn disable_plugin(&self) -> super::builder::api_hub_plugin::DisablePlugin {
+        super::builder::api_hub_plugin::DisablePlugin::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::ListLocations {
-        super::builder::api_hub_plugin::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::api_hub_plugin::ListLocations {
+        super::builder::api_hub_plugin::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::GetLocation {
-        super::builder::api_hub_plugin::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::api_hub_plugin::GetLocation {
+        super::builder::api_hub_plugin::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::api_hub_plugin::ListOperations {
         super::builder::api_hub_plugin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::GetOperation {
-        super::builder::api_hub_plugin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::api_hub_plugin::GetOperation {
+        super::builder::api_hub_plugin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::api_hub_plugin::DeleteOperation {
         super::builder::api_hub_plugin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::api_hub_plugin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::api_hub_plugin::CancelOperation {
         super::builder::api_hub_plugin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1590,87 +1333,57 @@ impl Provisioning {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_api_hub_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::CreateApiHubInstance {
+    pub fn create_api_hub_instance(&self) -> super::builder::provisioning::CreateApiHubInstance {
         super::builder::provisioning::CreateApiHubInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single API Hub instance.
-    pub fn get_api_hub_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::GetApiHubInstance {
+    pub fn get_api_hub_instance(&self) -> super::builder::provisioning::GetApiHubInstance {
         super::builder::provisioning::GetApiHubInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Looks up an Api Hub instance in a given GCP project. There will always be
     /// only one Api Hub instance for a GCP project across all locations.
-    pub fn lookup_api_hub_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::LookupApiHubInstance {
+    pub fn lookup_api_hub_instance(&self) -> super::builder::provisioning::LookupApiHubInstance {
         super::builder::provisioning::LookupApiHubInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::ListLocations {
-        super::builder::provisioning::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::provisioning::ListLocations {
+        super::builder::provisioning::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::GetLocation {
-        super::builder::provisioning::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::provisioning::GetLocation {
+        super::builder::provisioning::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::ListOperations {
-        super::builder::provisioning::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::provisioning::ListOperations {
+        super::builder::provisioning::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::GetOperation {
-        super::builder::provisioning::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::provisioning::GetOperation {
+        super::builder::provisioning::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::DeleteOperation {
-        super::builder::provisioning::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::provisioning::DeleteOperation {
+        super::builder::provisioning::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::provisioning::CancelOperation {
-        super::builder::provisioning::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::provisioning::CancelOperation {
+        super::builder::provisioning::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1779,76 +1492,60 @@ impl RuntimeProjectAttachmentService {
     /// Attaches a runtime project to the host project.
     pub fn create_runtime_project_attachment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::CreateRuntimeProjectAttachment {
         super::builder::runtime_project_attachment_service::CreateRuntimeProjectAttachment::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets a runtime project attachment.
     pub fn get_runtime_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::GetRuntimeProjectAttachment {
         super::builder::runtime_project_attachment_service::GetRuntimeProjectAttachment::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// List runtime projects attached to the host project.
     pub fn list_runtime_project_attachments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::ListRuntimeProjectAttachments {
         super::builder::runtime_project_attachment_service::ListRuntimeProjectAttachments::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Delete a runtime project attachment in the API Hub. This call will detach
     /// the runtime project from the host project.
     pub fn delete_runtime_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::DeleteRuntimeProjectAttachment {
         super::builder::runtime_project_attachment_service::DeleteRuntimeProjectAttachment::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Look up a runtime project attachment. This API can be called in the context
     /// of any project.
     pub fn lookup_runtime_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::LookupRuntimeProjectAttachment {
         super::builder::runtime_project_attachment_service::LookupRuntimeProjectAttachment::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::ListLocations {
         super::builder::runtime_project_attachment_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::runtime_project_attachment_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::runtime_project_attachment_service::GetLocation {
         super::builder::runtime_project_attachment_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1856,10 +1553,8 @@ impl RuntimeProjectAttachmentService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::ListOperations {
         super::builder::runtime_project_attachment_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1867,10 +1562,8 @@ impl RuntimeProjectAttachmentService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::GetOperation {
         super::builder::runtime_project_attachment_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1878,10 +1571,8 @@ impl RuntimeProjectAttachmentService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::DeleteOperation {
         super::builder::runtime_project_attachment_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1889,9 +1580,7 @@ impl RuntimeProjectAttachmentService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::runtime_project_attachment_service::CancelOperation {
         super::builder::runtime_project_attachment_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Api>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/apis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/apis", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -64,9 +71,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Api>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -83,9 +97,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApisResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/apis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/apis", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,18 +126,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Api>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.api
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("api"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.api
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("api"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -137,9 +155,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,12 +186,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/versions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,9 +213,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -203,9 +239,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,18 +268,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,9 +299,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -283,9 +330,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Spec>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/specs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/specs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,9 +355,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Spec>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -320,9 +381,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SpecContents>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:contents", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:contents", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -339,9 +407,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSpecsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/specs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/specs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,18 +436,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Spec>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.spec
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("spec"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.spec
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("spec"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -393,9 +465,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,9 +495,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApiOperation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -435,12 +521,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApiOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/operations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -460,9 +550,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Definition>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -479,12 +576,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -502,9 +603,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -521,12 +629,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,18 +658,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -580,9 +689,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -603,12 +719,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attribute>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attributes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attributes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,9 +746,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attribute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -645,18 +772,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attribute>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.attribute
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("attribute"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.attribute
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("attribute"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -679,9 +803,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -702,12 +833,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttributesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/attributes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/attributes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -727,12 +862,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchResources", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:searchResources", req.location),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -747,12 +886,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalApi>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/externalApis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/externalApis", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -770,9 +913,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalApi>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -789,18 +939,15 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalApi>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.external_api
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("external_api"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.external_api
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("external_api"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -823,9 +970,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -846,12 +1000,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExternalApisResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/externalApis", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/externalApis", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -870,9 +1028,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -892,9 +1057,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -911,9 +1083,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -933,9 +1112,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -952,9 +1138,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -975,9 +1168,16 @@ impl super::stub::ApiHub for ApiHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1020,12 +1220,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dependency>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dependencies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dependencies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1043,9 +1247,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dependency>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1062,18 +1273,15 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dependency>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dependency
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dependency"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dependency
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dependency"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1096,9 +1304,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1119,12 +1334,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDependenciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dependencies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dependencies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1144,9 +1363,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1166,9 +1392,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1185,9 +1418,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1207,9 +1447,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1226,9 +1473,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1249,9 +1503,16 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1294,12 +1555,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HostProjectRegistration>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/hostProjectRegistrations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/hostProjectRegistrations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1320,9 +1585,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HostProjectRegistration>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1339,12 +1611,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHostProjectRegistrationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/hostProjectRegistrations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/hostProjectRegistrations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1365,9 +1641,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1387,9 +1670,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1406,9 +1696,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1428,9 +1725,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1447,9 +1751,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1470,9 +1781,16 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1515,9 +1833,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StyleGuide>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1534,18 +1859,15 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StyleGuide>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.style_guide
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("style_guide"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.style_guide
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("style_guide"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1568,9 +1890,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StyleGuideContents>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:contents", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:contents", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1587,9 +1916,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:lint", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:lint", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1609,9 +1945,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1631,9 +1974,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1650,9 +2000,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1672,9 +2029,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1691,9 +2055,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1714,9 +2085,16 @@ impl super::stub::LintingService for LintingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1759,9 +2137,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Plugin>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1778,9 +2163,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Plugin>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1795,9 +2187,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Plugin>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1812,9 +2211,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1834,9 +2240,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1853,9 +2266,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1875,9 +2295,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1894,9 +2321,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1917,9 +2351,16 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1962,12 +2403,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/apiHubInstances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/apiHubInstances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1985,9 +2430,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApiHubInstance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2004,12 +2456,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupApiHubInstanceResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/apiHubInstances:lookup", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/apiHubInstances:lookup", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2026,9 +2482,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2048,9 +2511,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2067,9 +2537,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2089,9 +2566,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2108,9 +2592,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2131,9 +2622,16 @@ impl super::stub::Provisioning for Provisioning {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2190,12 +2688,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuntimeProjectAttachment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/runtimeProjectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/runtimeProjectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2216,9 +2718,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuntimeProjectAttachment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2235,12 +2744,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuntimeProjectAttachmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runtimeProjectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/runtimeProjectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2261,9 +2774,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2284,12 +2804,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupRuntimeProjectAttachmentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:lookupRuntimeProjectAttachment", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:lookupRuntimeProjectAttachment", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2306,9 +2830,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2328,9 +2859,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2347,9 +2885,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2369,9 +2914,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2388,9 +2940,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2411,9 +2970,16 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -127,10 +127,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::Api>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.api
+            let arg = &req
+                .api
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("api"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("api.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -269,10 +274,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.version
+            let arg = &req
+                .version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -437,10 +447,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::Spec>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.spec
+            let arg = &req
+                .spec
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("spec"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("spec.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -659,10 +674,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.deployment
+            let arg = &req
+                .deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -773,10 +793,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::Attribute>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.attribute
+            let arg = &req
+                .attribute
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("attribute"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attribute.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -940,10 +965,15 @@ impl super::stub::ApiHub for ApiHub {
     ) -> Result<gax::response::Response<crate::model::ExternalApi>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.external_api
+            let arg = &req
+                .external_api
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("external_api"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("external_api.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1274,10 +1304,15 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
     ) -> Result<gax::response::Response<crate::model::Dependency>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dependency
+            let arg = &req
+                .dependency
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dependency"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dependency.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1860,10 +1895,15 @@ impl super::stub::LintingService for LintingService {
     ) -> Result<gax::response::Response<crate::model::StyleGuide>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.style_guide
+            let arg = &req
+                .style_guide
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("style_guide"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("style_guide.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/apphub/v1/src/client.rs
+++ b/src/generated/cloud/apphub/v1/src/client.rs
@@ -122,19 +122,15 @@ impl AppHub {
     /// call this API from any project to find if it is attached to a host project.
     pub fn lookup_service_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_hub::LookupServiceProjectAttachment {
         super::builder::app_hub::LookupServiceProjectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists service projects attached to the host project.
     pub fn list_service_project_attachments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_hub::ListServiceProjectAttachments {
         super::builder::app_hub::ListServiceProjectAttachments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Attaches a service project to the host project.
@@ -150,19 +146,15 @@ impl AppHub {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_service_project_attachment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_hub::CreateServiceProjectAttachment {
         super::builder::app_hub::CreateServiceProjectAttachment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a service project attachment.
     pub fn get_service_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_hub::GetServiceProjectAttachment {
         super::builder::app_hub::GetServiceProjectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a service project attachment.
@@ -178,10 +170,8 @@ impl AppHub {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_hub::DeleteServiceProjectAttachment {
         super::builder::app_hub::DeleteServiceProjectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Detaches a service project from a host project.
@@ -189,46 +179,30 @@ impl AppHub {
     /// the host project that it is attached to.
     pub fn detach_service_project_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_hub::DetachServiceProjectAttachment {
         super::builder::app_hub::DetachServiceProjectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Discovered Services that can be added to an Application in a host
     /// project and location.
-    pub fn list_discovered_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListDiscoveredServices {
+    pub fn list_discovered_services(&self) -> super::builder::app_hub::ListDiscoveredServices {
         super::builder::app_hub::ListDiscoveredServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Discovered Service in a host project and location.
-    pub fn get_discovered_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetDiscoveredService {
-        super::builder::app_hub::GetDiscoveredService::new(self.inner.clone()).set_name(name.into())
+    pub fn get_discovered_service(&self) -> super::builder::app_hub::GetDiscoveredService {
+        super::builder::app_hub::GetDiscoveredService::new(self.inner.clone())
     }
 
     /// Lists a Discovered Service in a host project and location, with a
     /// given resource URI.
-    pub fn lookup_discovered_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::LookupDiscoveredService {
+    pub fn lookup_discovered_service(&self) -> super::builder::app_hub::LookupDiscoveredService {
         super::builder::app_hub::LookupDiscoveredService::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Services in an Application.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListServices {
-        super::builder::app_hub::ListServices::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_services(&self) -> super::builder::app_hub::ListServices {
+        super::builder::app_hub::ListServices::new(self.inner.clone())
     }
 
     /// Creates a Service in an Application.
@@ -242,19 +216,13 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::CreateService {
-        super::builder::app_hub::CreateService::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_service(&self) -> super::builder::app_hub::CreateService {
+        super::builder::app_hub::CreateService::new(self.inner.clone())
     }
 
     /// Gets a Service in an Application.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetService {
-        super::builder::app_hub::GetService::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service(&self) -> super::builder::app_hub::GetService {
+        super::builder::app_hub::GetService::new(self.inner.clone())
     }
 
     /// Updates a Service in an Application.
@@ -268,11 +236,8 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_service(
-        &self,
-        service: impl Into<crate::model::Service>,
-    ) -> super::builder::app_hub::UpdateService {
-        super::builder::app_hub::UpdateService::new(self.inner.clone()).set_service(service.into())
+    pub fn update_service(&self) -> super::builder::app_hub::UpdateService {
+        super::builder::app_hub::UpdateService::new(self.inner.clone())
     }
 
     /// Deletes a Service from an Application.
@@ -286,48 +251,30 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::DeleteService {
-        super::builder::app_hub::DeleteService::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_service(&self) -> super::builder::app_hub::DeleteService {
+        super::builder::app_hub::DeleteService::new(self.inner.clone())
     }
 
     /// Lists Discovered Workloads that can be added to an Application in a host
     /// project and location.
-    pub fn list_discovered_workloads(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListDiscoveredWorkloads {
+    pub fn list_discovered_workloads(&self) -> super::builder::app_hub::ListDiscoveredWorkloads {
         super::builder::app_hub::ListDiscoveredWorkloads::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Discovered Workload in a host project and location.
-    pub fn get_discovered_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetDiscoveredWorkload {
+    pub fn get_discovered_workload(&self) -> super::builder::app_hub::GetDiscoveredWorkload {
         super::builder::app_hub::GetDiscoveredWorkload::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists a Discovered Workload in a host project and location, with a
     /// given resource URI.
-    pub fn lookup_discovered_workload(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::LookupDiscoveredWorkload {
+    pub fn lookup_discovered_workload(&self) -> super::builder::app_hub::LookupDiscoveredWorkload {
         super::builder::app_hub::LookupDiscoveredWorkload::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Workloads in an Application.
-    pub fn list_workloads(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListWorkloads {
-        super::builder::app_hub::ListWorkloads::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_workloads(&self) -> super::builder::app_hub::ListWorkloads {
+        super::builder::app_hub::ListWorkloads::new(self.inner.clone())
     }
 
     /// Creates a Workload in an Application.
@@ -341,19 +288,13 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_workload(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::CreateWorkload {
-        super::builder::app_hub::CreateWorkload::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_workload(&self) -> super::builder::app_hub::CreateWorkload {
+        super::builder::app_hub::CreateWorkload::new(self.inner.clone())
     }
 
     /// Gets a Workload in an Application.
-    pub fn get_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetWorkload {
-        super::builder::app_hub::GetWorkload::new(self.inner.clone()).set_name(name.into())
+    pub fn get_workload(&self) -> super::builder::app_hub::GetWorkload {
+        super::builder::app_hub::GetWorkload::new(self.inner.clone())
     }
 
     /// Updates a Workload in an Application.
@@ -367,12 +308,8 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_workload(
-        &self,
-        workload: impl Into<crate::model::Workload>,
-    ) -> super::builder::app_hub::UpdateWorkload {
+    pub fn update_workload(&self) -> super::builder::app_hub::UpdateWorkload {
         super::builder::app_hub::UpdateWorkload::new(self.inner.clone())
-            .set_workload(workload.into())
     }
 
     /// Deletes a Workload from an Application.
@@ -386,19 +323,13 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::DeleteWorkload {
-        super::builder::app_hub::DeleteWorkload::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_workload(&self) -> super::builder::app_hub::DeleteWorkload {
+        super::builder::app_hub::DeleteWorkload::new(self.inner.clone())
     }
 
     /// Lists Applications in a host project and location.
-    pub fn list_applications(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListApplications {
-        super::builder::app_hub::ListApplications::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_applications(&self) -> super::builder::app_hub::ListApplications {
+        super::builder::app_hub::ListApplications::new(self.inner.clone())
     }
 
     /// Creates an Application in a host project and location.
@@ -412,20 +343,13 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_application(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::CreateApplication {
+    pub fn create_application(&self) -> super::builder::app_hub::CreateApplication {
         super::builder::app_hub::CreateApplication::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an Application in a host project and location.
-    pub fn get_application(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetApplication {
-        super::builder::app_hub::GetApplication::new(self.inner.clone()).set_name(name.into())
+    pub fn get_application(&self) -> super::builder::app_hub::GetApplication {
+        super::builder::app_hub::GetApplication::new(self.inner.clone())
     }
 
     /// Updates an Application in a host project and location.
@@ -439,12 +363,8 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_application(
-        &self,
-        application: impl Into<crate::model::Application>,
-    ) -> super::builder::app_hub::UpdateApplication {
+    pub fn update_application(&self) -> super::builder::app_hub::UpdateApplication {
         super::builder::app_hub::UpdateApplication::new(self.inner.clone())
-            .set_application(application.into())
     }
 
     /// Deletes an Application in a host project and location.
@@ -458,27 +378,18 @@ impl AppHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_application(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::DeleteApplication {
-        super::builder::app_hub::DeleteApplication::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_application(&self) -> super::builder::app_hub::DeleteApplication {
+        super::builder::app_hub::DeleteApplication::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListLocations {
-        super::builder::app_hub::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::app_hub::ListLocations {
+        super::builder::app_hub::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetLocation {
-        super::builder::app_hub::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::app_hub::GetLocation {
+        super::builder::app_hub::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -486,20 +397,14 @@ impl AppHub {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::SetIamPolicy {
-        super::builder::app_hub::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::app_hub::SetIamPolicy {
+        super::builder::app_hub::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetIamPolicy {
-        super::builder::app_hub::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::app_hub::GetIamPolicy {
+        super::builder::app_hub::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -509,51 +414,35 @@ impl AppHub {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::app_hub::TestIamPermissions {
         super::builder::app_hub::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::ListOperations {
-        super::builder::app_hub::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::app_hub::ListOperations {
+        super::builder::app_hub::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::GetOperation {
-        super::builder::app_hub::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::app_hub::GetOperation {
+        super::builder::app_hub::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::DeleteOperation {
-        super::builder::app_hub::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::app_hub::DeleteOperation {
+        super::builder::app_hub::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_hub::CancelOperation {
-        super::builder::app_hub::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::app_hub::CancelOperation {
+        super::builder::app_hub::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupServiceProjectAttachmentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:lookupServiceProjectAttachment", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:lookupServiceProjectAttachment", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,12 +72,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceProjectAttachmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceProjectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceProjectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -94,12 +102,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceProjectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceProjectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,9 +133,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceProjectAttachment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -140,9 +159,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,12 +186,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DetachServiceProjectAttachmentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:detachServiceProjectAttachment", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:detachServiceProjectAttachment", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,12 +210,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDiscoveredServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/discoveredServices", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/discoveredServices", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,9 +240,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoveredService>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,12 +266,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupDiscoveredServiceResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/discoveredServices:lookup", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/discoveredServices:lookup", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -248,9 +293,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,12 +323,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/services", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,9 +351,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,18 +377,15 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -349,9 +409,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -369,12 +436,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDiscoveredWorkloadsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/discoveredWorkloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/discoveredWorkloads", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -395,9 +466,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoveredWorkload>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -414,12 +492,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupDiscoveredWorkloadResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/discoveredWorkloads:lookup", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/discoveredWorkloads:lookup", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -437,12 +519,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkloadsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,12 +549,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -487,9 +577,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workload>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -506,18 +603,15 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workload
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workload
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -541,9 +635,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -561,12 +662,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListApplicationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/applications", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/applications", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -587,12 +692,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/applications", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/applications", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -611,9 +720,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Application>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,18 +746,15 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.application
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("application"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.application
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("application"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -665,9 +778,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -685,9 +805,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -707,9 +834,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -726,12 +860,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -746,12 +884,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -778,12 +920,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -798,9 +944,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -820,9 +973,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -839,9 +999,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -862,9 +1029,16 @@ impl super::stub::AppHub for AppHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -378,10 +378,15 @@ impl super::stub::AppHub for AppHub {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service
+            let arg = &req
+                .service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -604,10 +609,15 @@ impl super::stub::AppHub for AppHub {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workload
+            let arg = &req
+                .workload
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workload.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -747,10 +757,15 @@ impl super::stub::AppHub for AppHub {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.application
+            let arg = &req
+                .application
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("application"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("application.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/asset/v1/src/client.rs
+++ b/src/generated/cloud/asset/v1/src/client.rs
@@ -142,21 +142,14 @@ impl AssetService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::ExportAssets {
+    pub fn export_assets(&self) -> super::builder::asset_service::ExportAssets {
         super::builder::asset_service::ExportAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists assets with time and resource types and returns paged results in
     /// response.
-    pub fn list_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::ListAssets {
-        super::builder::asset_service::ListAssets::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_assets(&self) -> super::builder::asset_service::ListAssets {
+        super::builder::asset_service::ListAssets::new(self.inner.clone())
     }
 
     /// Batch gets the update history of assets that overlap a time window.
@@ -166,87 +159,56 @@ impl AssetService {
     /// deleted status.
     /// If a specified asset does not exist, this API returns an INVALID_ARGUMENT
     /// error.
-    pub fn batch_get_assets_history(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::BatchGetAssetsHistory {
+    pub fn batch_get_assets_history(&self) -> super::builder::asset_service::BatchGetAssetsHistory {
         super::builder::asset_service::BatchGetAssetsHistory::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a feed in a parent project/folder/organization to listen to its
     /// asset updates.
-    pub fn create_feed(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::CreateFeed {
-        super::builder::asset_service::CreateFeed::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_feed(&self) -> super::builder::asset_service::CreateFeed {
+        super::builder::asset_service::CreateFeed::new(self.inner.clone())
     }
 
     /// Gets details about an asset feed.
-    pub fn get_feed(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::GetFeed {
-        super::builder::asset_service::GetFeed::new(self.inner.clone()).set_name(name.into())
+    pub fn get_feed(&self) -> super::builder::asset_service::GetFeed {
+        super::builder::asset_service::GetFeed::new(self.inner.clone())
     }
 
     /// Lists all asset feeds in a parent project/folder/organization.
-    pub fn list_feeds(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::ListFeeds {
-        super::builder::asset_service::ListFeeds::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_feeds(&self) -> super::builder::asset_service::ListFeeds {
+        super::builder::asset_service::ListFeeds::new(self.inner.clone())
     }
 
     /// Updates an asset feed configuration.
-    pub fn update_feed(
-        &self,
-        feed: impl Into<crate::model::Feed>,
-    ) -> super::builder::asset_service::UpdateFeed {
-        super::builder::asset_service::UpdateFeed::new(self.inner.clone()).set_feed(feed.into())
+    pub fn update_feed(&self) -> super::builder::asset_service::UpdateFeed {
+        super::builder::asset_service::UpdateFeed::new(self.inner.clone())
     }
 
     /// Deletes an asset feed.
-    pub fn delete_feed(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::DeleteFeed {
-        super::builder::asset_service::DeleteFeed::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_feed(&self) -> super::builder::asset_service::DeleteFeed {
+        super::builder::asset_service::DeleteFeed::new(self.inner.clone())
     }
 
     /// Searches all Google Cloud resources within the specified scope, such as a
     /// project, folder, or organization. The caller must be granted the
     /// `cloudasset.assets.searchAllResources` permission on the desired scope,
     /// otherwise the request will be rejected.
-    pub fn search_all_resources(
-        &self,
-        scope: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::SearchAllResources {
+    pub fn search_all_resources(&self) -> super::builder::asset_service::SearchAllResources {
         super::builder::asset_service::SearchAllResources::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Searches all IAM policies within the specified scope, such as a project,
     /// folder, or organization. The caller must be granted the
     /// `cloudasset.assets.searchAllIamPolicies` permission on the desired scope,
     /// otherwise the request will be rejected.
-    pub fn search_all_iam_policies(
-        &self,
-        scope: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::SearchAllIamPolicies {
+    pub fn search_all_iam_policies(&self) -> super::builder::asset_service::SearchAllIamPolicies {
         super::builder::asset_service::SearchAllIamPolicies::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Analyzes IAM policies to answer which identities have what accesses on
     /// which resources.
-    pub fn analyze_iam_policy(
-        &self,
-        analysis_query: impl Into<crate::model::IamPolicyAnalysisQuery>,
-    ) -> super::builder::asset_service::AnalyzeIamPolicy {
+    pub fn analyze_iam_policy(&self) -> super::builder::asset_service::AnalyzeIamPolicy {
         super::builder::asset_service::AnalyzeIamPolicy::new(self.inner.clone())
-            .set_analysis_query(analysis_query.into())
     }
 
     /// Analyzes IAM policies asynchronously to answer which identities have what
@@ -274,10 +236,8 @@ impl AssetService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn analyze_iam_policy_longrunning(
         &self,
-        analysis_query: impl Into<crate::model::IamPolicyAnalysisQuery>,
     ) -> super::builder::asset_service::AnalyzeIamPolicyLongrunning {
         super::builder::asset_service::AnalyzeIamPolicyLongrunning::new(self.inner.clone())
-            .set_analysis_query(analysis_query.into())
     }
 
     /// Analyze moving a resource to a specified destination without kicking off
@@ -285,12 +245,8 @@ impl AssetService {
     /// permissions of viewing different hierarchical policies and configurations.
     /// The policies and configuration are subject to change before the actual
     /// resource migration takes place.
-    pub fn analyze_move(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::AnalyzeMove {
+    pub fn analyze_move(&self) -> super::builder::asset_service::AnalyzeMove {
         super::builder::asset_service::AnalyzeMove::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Issue a job that queries assets using a SQL statement compatible with
@@ -305,84 +261,53 @@ impl AssetService {
     /// Note, the query result has approximately 10 GB limitation enforced by
     /// [BigQuery](https://cloud.google.com/bigquery/docs/best-practices-performance-output).
     /// Queries return larger results will result in errors.
-    pub fn query_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::QueryAssets {
+    pub fn query_assets(&self) -> super::builder::asset_service::QueryAssets {
         super::builder::asset_service::QueryAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a saved query in a parent project/folder/organization.
-    pub fn create_saved_query(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::CreateSavedQuery {
+    pub fn create_saved_query(&self) -> super::builder::asset_service::CreateSavedQuery {
         super::builder::asset_service::CreateSavedQuery::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details about a saved query.
-    pub fn get_saved_query(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::GetSavedQuery {
-        super::builder::asset_service::GetSavedQuery::new(self.inner.clone()).set_name(name.into())
+    pub fn get_saved_query(&self) -> super::builder::asset_service::GetSavedQuery {
+        super::builder::asset_service::GetSavedQuery::new(self.inner.clone())
     }
 
     /// Lists all saved queries in a parent project/folder/organization.
-    pub fn list_saved_queries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::ListSavedQueries {
+    pub fn list_saved_queries(&self) -> super::builder::asset_service::ListSavedQueries {
         super::builder::asset_service::ListSavedQueries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a saved query.
-    pub fn update_saved_query(
-        &self,
-        saved_query: impl Into<crate::model::SavedQuery>,
-    ) -> super::builder::asset_service::UpdateSavedQuery {
+    pub fn update_saved_query(&self) -> super::builder::asset_service::UpdateSavedQuery {
         super::builder::asset_service::UpdateSavedQuery::new(self.inner.clone())
-            .set_saved_query(saved_query.into())
     }
 
     /// Deletes a saved query.
-    pub fn delete_saved_query(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::DeleteSavedQuery {
+    pub fn delete_saved_query(&self) -> super::builder::asset_service::DeleteSavedQuery {
         super::builder::asset_service::DeleteSavedQuery::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets effective IAM policies for a batch of resources.
     pub fn batch_get_effective_iam_policies(
         &self,
-        scope: impl Into<std::string::String>,
     ) -> super::builder::asset_service::BatchGetEffectiveIamPolicies {
         super::builder::asset_service::BatchGetEffectiveIamPolicies::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Analyzes organization policies under a scope.
-    pub fn analyze_org_policies(
-        &self,
-        scope: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::AnalyzeOrgPolicies {
+    pub fn analyze_org_policies(&self) -> super::builder::asset_service::AnalyzeOrgPolicies {
         super::builder::asset_service::AnalyzeOrgPolicies::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Analyzes organization policies governed containers (projects, folders or
     /// organization) under a scope.
     pub fn analyze_org_policy_governed_containers(
         &self,
-        scope: impl Into<std::string::String>,
     ) -> super::builder::asset_service::AnalyzeOrgPolicyGovernedContainers {
         super::builder::asset_service::AnalyzeOrgPolicyGovernedContainers::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Analyzes organization policies governed assets (Google Cloud resources or
@@ -436,19 +361,14 @@ impl AssetService {
     /// or IAM policies.
     pub fn analyze_org_policy_governed_assets(
         &self,
-        scope: impl Into<std::string::String>,
     ) -> super::builder::asset_service::AnalyzeOrgPolicyGovernedAssets {
         super::builder::asset_service::AnalyzeOrgPolicyGovernedAssets::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::asset_service::GetOperation {
-        super::builder::asset_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::asset_service::GetOperation {
+        super::builder::asset_service::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportAssets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportAssets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,12 +116,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchGetAssetsHistoryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:batchGetAssetsHistory", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:batchGetAssetsHistory", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,9 +160,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feed>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/feeds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/feeds", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -162,9 +184,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feed>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -181,9 +210,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeedsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/feeds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/feeds", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,18 +236,15 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feed>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feed
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feed"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feed
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feed"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,9 +259,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -249,12 +289,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchAllResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchAllResources", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchAllResources", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,12 +329,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchAllIamPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchAllIamPolicies", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchAllIamPolicies", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -315,18 +363,15 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeIamPolicyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:analyzeIamPolicy", {
+            &req.analysis_query
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
+                .scope
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/{}:analyzeIamPolicy",
-                    req.analysis_query
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
-                        .scope
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -364,18 +409,15 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:analyzeIamPolicyLongrunning", {
+            &req.analysis_query
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
+                .scope
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:analyzeIamPolicyLongrunning",
-                    req.analysis_query
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
-                        .scope
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -390,12 +432,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeMoveResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:analyzeMove", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:analyzeMove", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -414,12 +460,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:queryAssets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:queryAssets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -434,12 +484,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SavedQuery>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/savedQueries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/savedQueries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -457,9 +511,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SavedQuery>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,12 +537,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSavedQueriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/savedQueries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/savedQueries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -501,18 +566,15 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SavedQuery>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.saved_query
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("saved_query"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.saved_query
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("saved_query"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -535,9 +597,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -558,12 +627,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchGetEffectiveIamPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/effectiveIamPolicies:batchGet", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/effectiveIamPolicies:batchGet", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -584,12 +657,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeOrgPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:analyzeOrgPolicies", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:analyzeOrgPolicies", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -614,12 +691,16 @@ impl super::stub::AssetService for AssetService {
     ) -> Result<gax::response::Response<crate::model::AnalyzeOrgPolicyGovernedContainersResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:analyzeOrgPolicyGovernedContainers", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:analyzeOrgPolicyGovernedContainers", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -643,12 +724,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeOrgPolicyGovernedAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:analyzeOrgPolicyGovernedAssets", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:analyzeOrgPolicyGovernedAssets", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -672,9 +757,16 @@ impl super::stub::AssetService for AssetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -237,10 +237,15 @@ impl super::stub::AssetService for AssetService {
     ) -> Result<gax::response::Response<crate::model::Feed>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feed
+            let arg = &req
+                .feed
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feed"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feed.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -364,10 +369,15 @@ impl super::stub::AssetService for AssetService {
     ) -> Result<gax::response::Response<crate::model::AnalyzeIamPolicyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}:analyzeIamPolicy", {
-            &req.analysis_query
+            let arg = &req
+                .analysis_query
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
-                .scope
+                .scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("analysis_query.scope"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -410,10 +420,15 @@ impl super::stub::AssetService for AssetService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}:analyzeIamPolicyLongrunning", {
-            &req.analysis_query
+            let arg = &req
+                .analysis_query
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("analysis_query"))?
-                .scope
+                .scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("analysis_query.scope"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -567,10 +582,15 @@ impl super::stub::AssetService for AssetService {
     ) -> Result<gax::response::Response<crate::model::SavedQuery>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.saved_query
+            let arg = &req
+                .saved_query
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("saved_query"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("saved_query.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/assuredworkloads/v1/src/client.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/client.rs
@@ -131,24 +131,16 @@ impl AssuredWorkloadsService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_workload(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::CreateWorkload {
+    pub fn create_workload(&self) -> super::builder::assured_workloads_service::CreateWorkload {
         super::builder::assured_workloads_service::CreateWorkload::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing workload.
     /// Currently allows updating of workload display_name and labels.
     /// For force updates don't set etag field in the Workload.
     /// Only one update operation per workload can be in progress.
-    pub fn update_workload(
-        &self,
-        workload: impl Into<crate::model::Workload>,
-    ) -> super::builder::assured_workloads_service::UpdateWorkload {
+    pub fn update_workload(&self) -> super::builder::assured_workloads_service::UpdateWorkload {
         super::builder::assured_workloads_service::UpdateWorkload::new(self.inner.clone())
-            .set_workload(workload.into())
     }
 
     /// Restrict the list of resources allowed in the Workload environment.
@@ -159,60 +151,38 @@ impl AssuredWorkloadsService {
     /// to use this functionality.
     pub fn restrict_allowed_resources(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::assured_workloads_service::RestrictAllowedResources {
         super::builder::assured_workloads_service::RestrictAllowedResources::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the workload. Make sure that workload's direct children are already
     /// in a deleted state, otherwise the request will fail with a
     /// FAILED_PRECONDITION error.
-    pub fn delete_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::DeleteWorkload {
+    pub fn delete_workload(&self) -> super::builder::assured_workloads_service::DeleteWorkload {
         super::builder::assured_workloads_service::DeleteWorkload::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets Assured Workload associated with a CRM Node
-    pub fn get_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::GetWorkload {
+    pub fn get_workload(&self) -> super::builder::assured_workloads_service::GetWorkload {
         super::builder::assured_workloads_service::GetWorkload::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Assured Workloads under a CRM Node.
-    pub fn list_workloads(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::ListWorkloads {
+    pub fn list_workloads(&self) -> super::builder::assured_workloads_service::ListWorkloads {
         super::builder::assured_workloads_service::ListWorkloads::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::assured_workloads_service::ListOperations {
         super::builder::assured_workloads_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::assured_workloads_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::assured_workloads_service::GetOperation {
         super::builder::assured_workloads_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,18 +73,15 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workload>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workload
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workload
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,12 +104,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RestrictAllowedResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restrictAllowedResources", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:restrictAllowedResources", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,9 +128,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -147,9 +159,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workload>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -166,12 +185,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkloadsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,9 +214,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,9 +243,16 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -74,10 +74,15 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
     ) -> Result<gax::response::Response<crate::model::Workload>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workload
+            let arg = &req
+                .workload
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workload"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workload.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/backupdr/v1/src/client.rs
+++ b/src/generated/cloud/backupdr/v1/src/client.rs
@@ -119,21 +119,13 @@ impl BackupDR {
     }
 
     /// Lists ManagementServers in a given project and location.
-    pub fn list_management_servers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListManagementServers {
+    pub fn list_management_servers(&self) -> super::builder::backup_dr::ListManagementServers {
         super::builder::backup_dr::ListManagementServers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ManagementServer.
-    pub fn get_management_server(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetManagementServer {
+    pub fn get_management_server(&self) -> super::builder::backup_dr::GetManagementServer {
         super::builder::backup_dr::GetManagementServer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ManagementServer in a given project and location.
@@ -147,12 +139,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_management_server(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::CreateManagementServer {
+    pub fn create_management_server(&self) -> super::builder::backup_dr::CreateManagementServer {
         super::builder::backup_dr::CreateManagementServer::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single ManagementServer.
@@ -166,12 +154,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_management_server(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::DeleteManagementServer {
+    pub fn delete_management_server(&self) -> super::builder::backup_dr::DeleteManagementServer {
         super::builder::backup_dr::DeleteManagementServer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new BackupVault in a given project and location.
@@ -185,40 +169,25 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_vault(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::CreateBackupVault {
+    pub fn create_backup_vault(&self) -> super::builder::backup_dr::CreateBackupVault {
         super::builder::backup_dr::CreateBackupVault::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists BackupVaults in a given project and location.
-    pub fn list_backup_vaults(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListBackupVaults {
+    pub fn list_backup_vaults(&self) -> super::builder::backup_dr::ListBackupVaults {
         super::builder::backup_dr::ListBackupVaults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// FetchUsableBackupVaults lists usable BackupVaults in a given project and
     /// location. Usable BackupVault are the ones that user has
     /// backupdr.backupVaults.get permission.
-    pub fn fetch_usable_backup_vaults(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::FetchUsableBackupVaults {
+    pub fn fetch_usable_backup_vaults(&self) -> super::builder::backup_dr::FetchUsableBackupVaults {
         super::builder::backup_dr::FetchUsableBackupVaults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a BackupVault.
-    pub fn get_backup_vault(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetBackupVault {
-        super::builder::backup_dr::GetBackupVault::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup_vault(&self) -> super::builder::backup_dr::GetBackupVault {
+        super::builder::backup_dr::GetBackupVault::new(self.inner.clone())
     }
 
     /// Updates the settings of a BackupVault.
@@ -232,12 +201,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup_vault(
-        &self,
-        backup_vault: impl Into<crate::model::BackupVault>,
-    ) -> super::builder::backup_dr::UpdateBackupVault {
+    pub fn update_backup_vault(&self) -> super::builder::backup_dr::UpdateBackupVault {
         super::builder::backup_dr::UpdateBackupVault::new(self.inner.clone())
-            .set_backup_vault(backup_vault.into())
     }
 
     /// Deletes a BackupVault.
@@ -251,28 +216,18 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_vault(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::DeleteBackupVault {
-        super::builder::backup_dr::DeleteBackupVault::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup_vault(&self) -> super::builder::backup_dr::DeleteBackupVault {
+        super::builder::backup_dr::DeleteBackupVault::new(self.inner.clone())
     }
 
     /// Lists DataSources in a given project and location.
-    pub fn list_data_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListDataSources {
+    pub fn list_data_sources(&self) -> super::builder::backup_dr::ListDataSources {
         super::builder::backup_dr::ListDataSources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a DataSource.
-    pub fn get_data_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetDataSource {
-        super::builder::backup_dr::GetDataSource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_data_source(&self) -> super::builder::backup_dr::GetDataSource {
+        super::builder::backup_dr::GetDataSource::new(self.inner.clone())
     }
 
     /// Updates the settings of a DataSource.
@@ -286,28 +241,18 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_data_source(
-        &self,
-        data_source: impl Into<crate::model::DataSource>,
-    ) -> super::builder::backup_dr::UpdateDataSource {
+    pub fn update_data_source(&self) -> super::builder::backup_dr::UpdateDataSource {
         super::builder::backup_dr::UpdateDataSource::new(self.inner.clone())
-            .set_data_source(data_source.into())
     }
 
     /// Lists Backups in a given project and location.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListBackups {
-        super::builder::backup_dr::ListBackups::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_backups(&self) -> super::builder::backup_dr::ListBackups {
+        super::builder::backup_dr::ListBackups::new(self.inner.clone())
     }
 
     /// Gets details of a Backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetBackup {
-        super::builder::backup_dr::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::backup_dr::GetBackup {
+        super::builder::backup_dr::GetBackup::new(self.inner.clone())
     }
 
     /// Updates the settings of a Backup.
@@ -321,11 +266,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::backup_dr::UpdateBackup {
-        super::builder::backup_dr::UpdateBackup::new(self.inner.clone()).set_backup(backup.into())
+    pub fn update_backup(&self) -> super::builder::backup_dr::UpdateBackup {
+        super::builder::backup_dr::UpdateBackup::new(self.inner.clone())
     }
 
     /// Deletes a Backup.
@@ -339,11 +281,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::DeleteBackup {
-        super::builder::backup_dr::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::backup_dr::DeleteBackup {
+        super::builder::backup_dr::DeleteBackup::new(self.inner.clone())
     }
 
     /// Restore from a Backup
@@ -357,11 +296,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::RestoreBackup {
-        super::builder::backup_dr::RestoreBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn restore_backup(&self) -> super::builder::backup_dr::RestoreBackup {
+        super::builder::backup_dr::RestoreBackup::new(self.inner.clone())
     }
 
     /// Create a BackupPlan
@@ -375,29 +311,18 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_plan(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::CreateBackupPlan {
+    pub fn create_backup_plan(&self) -> super::builder::backup_dr::CreateBackupPlan {
         super::builder::backup_dr::CreateBackupPlan::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single BackupPlan.
-    pub fn get_backup_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetBackupPlan {
-        super::builder::backup_dr::GetBackupPlan::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup_plan(&self) -> super::builder::backup_dr::GetBackupPlan {
+        super::builder::backup_dr::GetBackupPlan::new(self.inner.clone())
     }
 
     /// Lists BackupPlans in a given project and location.
-    pub fn list_backup_plans(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListBackupPlans {
+    pub fn list_backup_plans(&self) -> super::builder::backup_dr::ListBackupPlans {
         super::builder::backup_dr::ListBackupPlans::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single BackupPlan.
@@ -411,11 +336,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::DeleteBackupPlan {
-        super::builder::backup_dr::DeleteBackupPlan::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup_plan(&self) -> super::builder::backup_dr::DeleteBackupPlan {
+        super::builder::backup_dr::DeleteBackupPlan::new(self.inner.clone())
     }
 
     /// Create a BackupPlanAssociation
@@ -431,28 +353,22 @@ impl BackupDR {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_backup_plan_association(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::backup_dr::CreateBackupPlanAssociation {
         super::builder::backup_dr::CreateBackupPlanAssociation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single BackupPlanAssociation.
     pub fn get_backup_plan_association(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::backup_dr::GetBackupPlanAssociation {
         super::builder::backup_dr::GetBackupPlanAssociation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists BackupPlanAssociations in a given project and location.
     pub fn list_backup_plan_associations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::backup_dr::ListBackupPlanAssociations {
         super::builder::backup_dr::ListBackupPlanAssociations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single BackupPlanAssociation.
@@ -468,10 +384,8 @@ impl BackupDR {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_backup_plan_association(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::backup_dr::DeleteBackupPlanAssociation {
         super::builder::backup_dr::DeleteBackupPlanAssociation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Triggers a new Backup.
@@ -485,11 +399,8 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn trigger_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::TriggerBackup {
-        super::builder::backup_dr::TriggerBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn trigger_backup(&self) -> super::builder::backup_dr::TriggerBackup {
+        super::builder::backup_dr::TriggerBackup::new(self.inner.clone())
     }
 
     /// Initializes the service related config for a project.
@@ -503,27 +414,18 @@ impl BackupDR {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn initialize_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::InitializeService {
-        super::builder::backup_dr::InitializeService::new(self.inner.clone()).set_name(name.into())
+    pub fn initialize_service(&self) -> super::builder::backup_dr::InitializeService {
+        super::builder::backup_dr::InitializeService::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListLocations {
-        super::builder::backup_dr::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::backup_dr::ListLocations {
+        super::builder::backup_dr::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetLocation {
-        super::builder::backup_dr::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::backup_dr::GetLocation {
+        super::builder::backup_dr::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -531,22 +433,14 @@ impl BackupDR {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::backup_dr::SetIamPolicy {
         super::builder::backup_dr::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::backup_dr::GetIamPolicy {
         super::builder::backup_dr::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -556,51 +450,35 @@ impl BackupDR {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::backup_dr::TestIamPermissions {
         super::builder::backup_dr::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::ListOperations {
-        super::builder::backup_dr::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::backup_dr::ListOperations {
+        super::builder::backup_dr::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::GetOperation {
-        super::builder::backup_dr::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::backup_dr::GetOperation {
+        super::builder::backup_dr::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::DeleteOperation {
-        super::builder::backup_dr::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::backup_dr::DeleteOperation {
+        super::builder::backup_dr::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_dr::CancelOperation {
-        super::builder::backup_dr::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::backup_dr::CancelOperation {
+        super::builder::backup_dr::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListManagementServersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/managementServers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/managementServers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -78,9 +82,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ManagementServer>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -97,12 +108,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/managementServers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/managementServers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,9 +136,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -141,12 +163,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupVaults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupVaults", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -166,12 +192,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupVaultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupVaults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupVaults", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,12 +223,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchUsableBackupVaultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupVaults:fetchUsable", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupVaults:fetchUsable", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,9 +253,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupVault>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,18 +280,15 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_vault
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_vault
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,9 +314,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,12 +349,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataSources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataSources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -330,9 +379,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataSource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -349,18 +405,15 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_source
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_source"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_source
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_source"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -385,9 +438,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,9 +469,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,18 +496,15 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -462,9 +526,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -482,9 +553,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -499,12 +577,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupPlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupPlans", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -523,9 +605,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupPlan>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -542,12 +631,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupPlansResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupPlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupPlans", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -568,9 +661,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -588,12 +688,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupPlanAssociations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupPlanAssociations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -613,9 +717,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupPlanAssociation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -632,12 +743,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupPlanAssociationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupPlanAssociations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupPlanAssociations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -657,9 +772,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -677,12 +799,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:triggerBackup", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:triggerBackup", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -697,12 +823,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:initialize", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:initialize", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -717,9 +847,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -739,9 +876,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -758,12 +902,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -778,12 +926,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -810,12 +962,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -830,9 +986,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -852,9 +1015,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -871,9 +1041,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -894,9 +1071,16 @@ impl super::stub::BackupDR for BackupDR {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -281,10 +281,15 @@ impl super::stub::BackupDR for BackupDR {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_vault
+            let arg = &req
+                .backup_vault
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_vault.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -406,10 +411,15 @@ impl super::stub::BackupDR for BackupDR {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_source
+            let arg = &req
+                .data_source
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_source"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_source.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -497,10 +507,15 @@ impl super::stub::BackupDR for BackupDR {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/baremetalsolution/v2/src/client.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/client.rs
@@ -128,21 +128,13 @@ impl BareMetalSolution {
     }
 
     /// List servers in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListInstances {
+    pub fn list_instances(&self) -> super::builder::bare_metal_solution::ListInstances {
         super::builder::bare_metal_solution::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details about a single server.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetInstance {
+    pub fn get_instance(&self) -> super::builder::bare_metal_solution::GetInstance {
         super::builder::bare_metal_solution::GetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update details of a single server.
@@ -156,22 +148,14 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::bare_metal_solution::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::bare_metal_solution::UpdateInstance {
         super::builder::bare_metal_solution::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// RenameInstance sets a new name for an instance.
     /// Use with caution, previous names become immediately invalidated.
-    pub fn rename_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::RenameInstance {
+    pub fn rename_instance(&self) -> super::builder::bare_metal_solution::RenameInstance {
         super::builder::bare_metal_solution::RenameInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Perform an ungraceful, hard reset on a server. Equivalent to shutting the
@@ -186,12 +170,8 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reset_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ResetInstance {
+    pub fn reset_instance(&self) -> super::builder::bare_metal_solution::ResetInstance {
         super::builder::bare_metal_solution::ResetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts a server that was shutdown.
@@ -205,12 +185,8 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::StartInstance {
+    pub fn start_instance(&self) -> super::builder::bare_metal_solution::StartInstance {
         super::builder::bare_metal_solution::StartInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stop a running server.
@@ -224,12 +200,8 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::StopInstance {
+    pub fn stop_instance(&self) -> super::builder::bare_metal_solution::StopInstance {
         super::builder::bare_metal_solution::StopInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Enable the interactive serial console feature on an instance.
@@ -245,10 +217,8 @@ impl BareMetalSolution {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn enable_interactive_serial_console(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::EnableInteractiveSerialConsole {
         super::builder::bare_metal_solution::EnableInteractiveSerialConsole::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Disable the interactive serial console feature on an instance.
@@ -264,12 +234,10 @@ impl BareMetalSolution {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn disable_interactive_serial_console(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::DisableInteractiveSerialConsole {
         super::builder::bare_metal_solution::DisableInteractiveSerialConsole::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Detach LUN from Instance.
@@ -283,59 +251,35 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn detach_lun(
-        &self,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::DetachLun {
+    pub fn detach_lun(&self) -> super::builder::bare_metal_solution::DetachLun {
         super::builder::bare_metal_solution::DetachLun::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Lists the public SSH keys registered for the specified project.
     /// These SSH keys are used only for the interactive serial console feature.
-    pub fn list_ssh_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListSSHKeys {
+    pub fn list_ssh_keys(&self) -> super::builder::bare_metal_solution::ListSSHKeys {
         super::builder::bare_metal_solution::ListSSHKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Register a public SSH key in the specified project for use with the
     /// interactive serial console feature.
-    pub fn create_ssh_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::CreateSSHKey {
+    pub fn create_ssh_key(&self) -> super::builder::bare_metal_solution::CreateSSHKey {
         super::builder::bare_metal_solution::CreateSSHKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a public SSH key registered in the specified project.
-    pub fn delete_ssh_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::DeleteSSHKey {
+    pub fn delete_ssh_key(&self) -> super::builder::bare_metal_solution::DeleteSSHKey {
         super::builder::bare_metal_solution::DeleteSSHKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List storage volumes in a given project and location.
-    pub fn list_volumes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListVolumes {
+    pub fn list_volumes(&self) -> super::builder::bare_metal_solution::ListVolumes {
         super::builder::bare_metal_solution::ListVolumes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details of a single storage volume.
-    pub fn get_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetVolume {
+    pub fn get_volume(&self) -> super::builder::bare_metal_solution::GetVolume {
         super::builder::bare_metal_solution::GetVolume::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update details of a single storage volume.
@@ -349,22 +293,14 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_volume(
-        &self,
-        volume: impl Into<crate::model::Volume>,
-    ) -> super::builder::bare_metal_solution::UpdateVolume {
+    pub fn update_volume(&self) -> super::builder::bare_metal_solution::UpdateVolume {
         super::builder::bare_metal_solution::UpdateVolume::new(self.inner.clone())
-            .set_volume(volume.into())
     }
 
     /// RenameVolume sets a new name for a volume.
     /// Use with caution, previous names become immediately invalidated.
-    pub fn rename_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::RenameVolume {
+    pub fn rename_volume(&self) -> super::builder::bare_metal_solution::RenameVolume {
         super::builder::bare_metal_solution::RenameVolume::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Skips volume's cooloff and deletes it now.
@@ -379,12 +315,8 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn evict_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::EvictVolume {
+    pub fn evict_volume(&self) -> super::builder::bare_metal_solution::EvictVolume {
         super::builder::bare_metal_solution::EvictVolume::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Emergency Volume resize.
@@ -398,40 +330,24 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn resize_volume(
-        &self,
-        volume: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ResizeVolume {
+    pub fn resize_volume(&self) -> super::builder::bare_metal_solution::ResizeVolume {
         super::builder::bare_metal_solution::ResizeVolume::new(self.inner.clone())
-            .set_volume(volume.into())
     }
 
     /// List network in a given project and location.
-    pub fn list_networks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListNetworks {
+    pub fn list_networks(&self) -> super::builder::bare_metal_solution::ListNetworks {
         super::builder::bare_metal_solution::ListNetworks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List all Networks (and used IPs for each Network) in the vendor account
     /// associated with the specified project.
-    pub fn list_network_usage(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListNetworkUsage {
+    pub fn list_network_usage(&self) -> super::builder::bare_metal_solution::ListNetworkUsage {
         super::builder::bare_metal_solution::ListNetworkUsage::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Get details of a single network.
-    pub fn get_network(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetNetwork {
+    pub fn get_network(&self) -> super::builder::bare_metal_solution::GetNetwork {
         super::builder::bare_metal_solution::GetNetwork::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update details of a single network.
@@ -445,22 +361,16 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_network(
-        &self,
-        network: impl Into<crate::model::Network>,
-    ) -> super::builder::bare_metal_solution::UpdateNetwork {
+    pub fn update_network(&self) -> super::builder::bare_metal_solution::UpdateNetwork {
         super::builder::bare_metal_solution::UpdateNetwork::new(self.inner.clone())
-            .set_network(network.into())
     }
 
     /// Takes a snapshot of a boot volume.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
     pub fn create_volume_snapshot(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::CreateVolumeSnapshot {
         super::builder::bare_metal_solution::CreateVolumeSnapshot::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Uses the specified snapshot to restore its parent volume.
@@ -477,30 +387,22 @@ impl BareMetalSolution {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn restore_volume_snapshot(
         &self,
-        volume_snapshot: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::RestoreVolumeSnapshot {
         super::builder::bare_metal_solution::RestoreVolumeSnapshot::new(self.inner.clone())
-            .set_volume_snapshot(volume_snapshot.into())
     }
 
     /// Deletes a volume snapshot.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
     pub fn delete_volume_snapshot(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::DeleteVolumeSnapshot {
         super::builder::bare_metal_solution::DeleteVolumeSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the specified snapshot resource.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
-    pub fn get_volume_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetVolumeSnapshot {
+    pub fn get_volume_snapshot(&self) -> super::builder::bare_metal_solution::GetVolumeSnapshot {
         super::builder::bare_metal_solution::GetVolumeSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves the list of snapshots for the specified volume.
@@ -508,27 +410,18 @@ impl BareMetalSolution {
     /// for a non-boot volume.
     pub fn list_volume_snapshots(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::ListVolumeSnapshots {
         super::builder::bare_metal_solution::ListVolumeSnapshots::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details of a single storage logical unit number(LUN).
-    pub fn get_lun(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetLun {
-        super::builder::bare_metal_solution::GetLun::new(self.inner.clone()).set_name(name.into())
+    pub fn get_lun(&self) -> super::builder::bare_metal_solution::GetLun {
+        super::builder::bare_metal_solution::GetLun::new(self.inner.clone())
     }
 
     /// List storage volume luns for given storage volume.
-    pub fn list_luns(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListLuns {
+    pub fn list_luns(&self) -> super::builder::bare_metal_solution::ListLuns {
         super::builder::bare_metal_solution::ListLuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Skips lun's cooloff and deletes it now.
@@ -543,29 +436,18 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn evict_lun(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::EvictLun {
-        super::builder::bare_metal_solution::EvictLun::new(self.inner.clone()).set_name(name.into())
+    pub fn evict_lun(&self) -> super::builder::bare_metal_solution::EvictLun {
+        super::builder::bare_metal_solution::EvictLun::new(self.inner.clone())
     }
 
     /// Get details of a single NFS share.
-    pub fn get_nfs_share(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetNfsShare {
+    pub fn get_nfs_share(&self) -> super::builder::bare_metal_solution::GetNfsShare {
         super::builder::bare_metal_solution::GetNfsShare::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List NFS shares.
-    pub fn list_nfs_shares(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListNfsShares {
+    pub fn list_nfs_shares(&self) -> super::builder::bare_metal_solution::ListNfsShares {
         super::builder::bare_metal_solution::ListNfsShares::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update details of a single NFS share.
@@ -579,12 +461,8 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_nfs_share(
-        &self,
-        nfs_share: impl Into<crate::model::NfsShare>,
-    ) -> super::builder::bare_metal_solution::UpdateNfsShare {
+    pub fn update_nfs_share(&self) -> super::builder::bare_metal_solution::UpdateNfsShare {
         super::builder::bare_metal_solution::UpdateNfsShare::new(self.inner.clone())
-            .set_nfs_share(nfs_share.into())
     }
 
     /// Create an NFS share.
@@ -598,22 +476,14 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_nfs_share(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::CreateNfsShare {
+    pub fn create_nfs_share(&self) -> super::builder::bare_metal_solution::CreateNfsShare {
         super::builder::bare_metal_solution::CreateNfsShare::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// RenameNfsShare sets a new name for an nfsshare.
     /// Use with caution, previous names become immediately invalidated.
-    pub fn rename_nfs_share(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::RenameNfsShare {
+    pub fn rename_nfs_share(&self) -> super::builder::bare_metal_solution::RenameNfsShare {
         super::builder::bare_metal_solution::RenameNfsShare::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Delete an NFS share. The underlying volume is automatically deleted.
@@ -627,104 +497,70 @@ impl BareMetalSolution {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_nfs_share(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::DeleteNfsShare {
+    pub fn delete_nfs_share(&self) -> super::builder::bare_metal_solution::DeleteNfsShare {
         super::builder::bare_metal_solution::DeleteNfsShare::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List the budget details to provision resources on a given project.
     pub fn list_provisioning_quotas(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::ListProvisioningQuotas {
         super::builder::bare_metal_solution::ListProvisioningQuotas::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Submit a provisiong configuration for a given project.
     pub fn submit_provisioning_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::SubmitProvisioningConfig {
         super::builder::bare_metal_solution::SubmitProvisioningConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get ProvisioningConfig by name.
     pub fn get_provisioning_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::GetProvisioningConfig {
         super::builder::bare_metal_solution::GetProvisioningConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create new ProvisioningConfig.
     pub fn create_provisioning_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::bare_metal_solution::CreateProvisioningConfig {
         super::builder::bare_metal_solution::CreateProvisioningConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update existing ProvisioningConfig.
     pub fn update_provisioning_config(
         &self,
-        provisioning_config: impl Into<crate::model::ProvisioningConfig>,
     ) -> super::builder::bare_metal_solution::UpdateProvisioningConfig {
         super::builder::bare_metal_solution::UpdateProvisioningConfig::new(self.inner.clone())
-            .set_provisioning_config(provisioning_config.into())
     }
 
     /// RenameNetwork sets a new name for a network.
     /// Use with caution, previous names become immediately invalidated.
-    pub fn rename_network(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::RenameNetwork {
+    pub fn rename_network(&self) -> super::builder::bare_metal_solution::RenameNetwork {
         super::builder::bare_metal_solution::RenameNetwork::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves the list of OS images which are currently approved.
-    pub fn list_os_images(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListOSImages {
+    pub fn list_os_images(&self) -> super::builder::bare_metal_solution::ListOSImages {
         super::builder::bare_metal_solution::ListOSImages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::ListLocations {
+    pub fn list_locations(&self) -> super::builder::bare_metal_solution::ListLocations {
         super::builder::bare_metal_solution::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetLocation {
+    pub fn get_location(&self) -> super::builder::bare_metal_solution::GetLocation {
         super::builder::bare_metal_solution::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::bare_metal_solution::GetOperation {
+    pub fn get_operation(&self) -> super::builder::bare_metal_solution::GetOperation {
         super::builder::bare_metal_solution::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,9 +75,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,18 +101,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,9 +132,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -141,9 +156,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:reset", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +180,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +204,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,12 +228,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:enableInteractiveSerialConsole", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:enableInteractiveSerialConsole", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +252,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:disableInteractiveSerialConsole", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:disableInteractiveSerialConsole", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -232,12 +276,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:detachLun", {
+            let arg = &req.instance;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:detachLun", req.instance),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,9 +300,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSSHKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/sshKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/sshKeys", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,9 +328,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SSHKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/sshKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/sshKeys", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -293,9 +355,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +385,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVolumesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/volumes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/volumes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,9 +414,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Volume>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,18 +440,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.volume
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.volume
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,9 +469,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Volume>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -406,9 +493,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:evict", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:evict", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -423,9 +517,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:resize", {
+            let arg = &req.volume;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("volume"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:resize", req.volume))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -440,9 +541,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNetworksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/networks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/networks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -462,12 +570,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNetworkUsageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/networks:listNetworkUsage", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/networks:listNetworkUsage", req.location),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -484,9 +596,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Network>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -503,18 +622,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.network
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("network"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.network
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("network"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -537,12 +653,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VolumeSnapshot>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,12 +679,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:restoreVolumeSnapshot", {
+            let arg = &req.volume_snapshot;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("volume_snapshot"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:restoreVolumeSnapshot", req.volume_snapshot),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -579,9 +703,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -602,9 +733,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VolumeSnapshot>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -621,12 +759,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVolumeSnapshotsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -645,9 +787,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Lun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -664,9 +813,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/luns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/luns", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -685,9 +841,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:evict", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:evict", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -702,9 +865,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NfsShare>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -721,12 +891,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNfsSharesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/nfsShares", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/nfsShares", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -746,18 +920,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.nfs_share
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("nfs_share"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.nfs_share
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("nfs_share"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -780,12 +951,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/nfsShares", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/nfsShares", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -802,9 +977,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NfsShare>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -819,9 +1001,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -838,12 +1027,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProvisioningQuotasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/provisioningQuotas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/provisioningQuotas", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -862,12 +1055,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SubmitProvisioningConfigResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/provisioningConfigs:submit", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/provisioningConfigs:submit", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -882,9 +1079,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProvisioningConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -901,12 +1105,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProvisioningConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/provisioningConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/provisioningConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -924,18 +1132,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProvisioningConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.provisioning_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("provisioning_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.provisioning_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("provisioning_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -959,9 +1164,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Network>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -976,9 +1188,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOSImagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/osImages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/osImages", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -997,9 +1216,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1019,9 +1245,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1038,9 +1271,16 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -102,10 +102,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -441,10 +446,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.volume
+            let arg = &req
+                .volume
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("volume.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -623,10 +633,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.network
+            let arg = &req
+                .network
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("network"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("network.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -921,10 +936,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.nfs_share
+            let arg = &req
+                .nfs_share
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("nfs_share"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("nfs_share.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1133,10 +1153,15 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
     ) -> Result<gax::response::Response<crate::model::ProvisioningConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.provisioning_config
+            let arg = &req
+                .provisioning_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("provisioning_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("provisioning_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
@@ -136,19 +136,13 @@ impl AppConnectionsService {
     /// Lists AppConnections in a given project and location.
     pub fn list_app_connections(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_connections_service::ListAppConnections {
         super::builder::app_connections_service::ListAppConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single AppConnection.
-    pub fn get_app_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::GetAppConnection {
+    pub fn get_app_connection(&self) -> super::builder::app_connections_service::GetAppConnection {
         super::builder::app_connections_service::GetAppConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new AppConnection in a given project and location.
@@ -164,10 +158,8 @@ impl AppConnectionsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_app_connection(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_connections_service::CreateAppConnection {
         super::builder::app_connections_service::CreateAppConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single AppConnection.
@@ -183,10 +175,8 @@ impl AppConnectionsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_app_connection(
         &self,
-        app_connection: impl Into<crate::model::AppConnection>,
     ) -> super::builder::app_connections_service::UpdateAppConnection {
         super::builder::app_connections_service::UpdateAppConnection::new(self.inner.clone())
-            .set_app_connection(app_connection.into())
     }
 
     /// Deletes a single AppConnection.
@@ -202,10 +192,8 @@ impl AppConnectionsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_app_connection(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_connections_service::DeleteAppConnection {
         super::builder::app_connections_service::DeleteAppConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resolves AppConnections details for a given AppConnector.
@@ -213,28 +201,18 @@ impl AppConnectionsService {
     /// to.
     pub fn resolve_app_connections(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_connections_service::ResolveAppConnections {
         super::builder::app_connections_service::ResolveAppConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::app_connections_service::ListLocations {
         super::builder::app_connections_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::app_connections_service::GetLocation {
         super::builder::app_connections_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -242,22 +220,14 @@ impl AppConnectionsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::app_connections_service::SetIamPolicy {
         super::builder::app_connections_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::app_connections_service::GetIamPolicy {
         super::builder::app_connections_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -269,53 +239,35 @@ impl AppConnectionsService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::app_connections_service::TestIamPermissions {
         super::builder::app_connections_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::app_connections_service::ListOperations {
         super::builder::app_connections_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::app_connections_service::GetOperation {
         super::builder::app_connections_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::app_connections_service::DeleteOperation {
         super::builder::app_connections_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connections_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::app_connections_service::CancelOperation {
         super::builder::app_connections_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAppConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/appConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/appConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/appConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/appConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.app_connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("app_connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.app_connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("app_connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -153,9 +165,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +193,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ResolveAppConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/appConnections:resolve", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/appConnections:resolve", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,9 +222,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -221,9 +251,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,12 +277,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,12 +301,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,12 +337,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,9 +361,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -334,9 +390,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,9 +416,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -376,9 +446,16 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.app_connection
+            let arg = &req
+                .app_connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("app_connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("app_connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
@@ -134,21 +134,13 @@ impl AppConnectorsService {
     }
 
     /// Lists AppConnectors in a given project and location.
-    pub fn list_app_connectors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::ListAppConnectors {
+    pub fn list_app_connectors(&self) -> super::builder::app_connectors_service::ListAppConnectors {
         super::builder::app_connectors_service::ListAppConnectors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single AppConnector.
-    pub fn get_app_connector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::GetAppConnector {
+    pub fn get_app_connector(&self) -> super::builder::app_connectors_service::GetAppConnector {
         super::builder::app_connectors_service::GetAppConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new AppConnector in a given project and location.
@@ -164,10 +156,8 @@ impl AppConnectorsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_app_connector(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::app_connectors_service::CreateAppConnector {
         super::builder::app_connectors_service::CreateAppConnector::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single AppConnector.
@@ -183,10 +173,8 @@ impl AppConnectorsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_app_connector(
         &self,
-        app_connector: impl Into<crate::model::AppConnector>,
     ) -> super::builder::app_connectors_service::UpdateAppConnector {
         super::builder::app_connectors_service::UpdateAppConnector::new(self.inner.clone())
-            .set_app_connector(app_connector.into())
     }
 
     /// Deletes a single AppConnector.
@@ -202,10 +190,8 @@ impl AppConnectorsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_app_connector(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::app_connectors_service::DeleteAppConnector {
         super::builder::app_connectors_service::DeleteAppConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Report status for a given connector.
@@ -219,30 +205,18 @@ impl AppConnectorsService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn report_status(
-        &self,
-        app_connector: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::ReportStatus {
+    pub fn report_status(&self) -> super::builder::app_connectors_service::ReportStatus {
         super::builder::app_connectors_service::ReportStatus::new(self.inner.clone())
-            .set_app_connector(app_connector.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::app_connectors_service::ListLocations {
         super::builder::app_connectors_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::app_connectors_service::GetLocation {
         super::builder::app_connectors_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -250,22 +224,14 @@ impl AppConnectorsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::app_connectors_service::SetIamPolicy {
         super::builder::app_connectors_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::app_connectors_service::GetIamPolicy {
         super::builder::app_connectors_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -277,53 +243,35 @@ impl AppConnectorsService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::app_connectors_service::TestIamPermissions {
         super::builder::app_connectors_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::app_connectors_service::ListOperations {
         super::builder::app_connectors_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::app_connectors_service::GetOperation {
         super::builder::app_connectors_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::app_connectors_service::DeleteOperation {
         super::builder::app_connectors_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_connectors_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::app_connectors_service::CancelOperation {
         super::builder::app_connectors_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAppConnectorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/appConnectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/appConnectors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppConnector>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/appConnectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/appConnectors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.app_connector
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("app_connector"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.app_connector
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("app_connector"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,9 +164,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -173,12 +192,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reportStatus", {
+            let arg = &req.app_connector;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("app_connector"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:reportStatus", req.app_connector),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +216,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -215,9 +245,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -234,12 +271,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,12 +295,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -286,12 +331,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -306,9 +355,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +384,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +410,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -370,9 +440,16 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.app_connector
+            let arg = &req
+                .app_connector
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("app_connector"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("app_connector.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
@@ -134,21 +134,13 @@ impl AppGatewaysService {
     }
 
     /// Lists AppGateways in a given project and location.
-    pub fn list_app_gateways(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::ListAppGateways {
+    pub fn list_app_gateways(&self) -> super::builder::app_gateways_service::ListAppGateways {
         super::builder::app_gateways_service::ListAppGateways::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single AppGateway.
-    pub fn get_app_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::GetAppGateway {
+    pub fn get_app_gateway(&self) -> super::builder::app_gateways_service::GetAppGateway {
         super::builder::app_gateways_service::GetAppGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new AppGateway in a given project and location.
@@ -162,12 +154,8 @@ impl AppGatewaysService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_app_gateway(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::CreateAppGateway {
+    pub fn create_app_gateway(&self) -> super::builder::app_gateways_service::CreateAppGateway {
         super::builder::app_gateways_service::CreateAppGateway::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single AppGateway.
@@ -181,30 +169,18 @@ impl AppGatewaysService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_app_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::DeleteAppGateway {
+    pub fn delete_app_gateway(&self) -> super::builder::app_gateways_service::DeleteAppGateway {
         super::builder::app_gateways_service::DeleteAppGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::app_gateways_service::ListLocations {
         super::builder::app_gateways_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::app_gateways_service::GetLocation {
         super::builder::app_gateways_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -212,22 +188,14 @@ impl AppGatewaysService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::app_gateways_service::SetIamPolicy {
         super::builder::app_gateways_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::app_gateways_service::GetIamPolicy {
         super::builder::app_gateways_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -237,55 +205,35 @@ impl AppGatewaysService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::app_gateways_service::TestIamPermissions {
         super::builder::app_gateways_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::app_gateways_service::ListOperations {
         super::builder::app_gateways_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::app_gateways_service::GetOperation {
         super::builder::app_gateways_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::app_gateways_service::DeleteOperation {
         super::builder::app_gateways_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::app_gateways_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::app_gateways_service::CancelOperation {
         super::builder::app_gateways_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAppGatewaysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/appGateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/appGateways", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppGateway>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/appGateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/appGateways", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,9 +131,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -137,9 +159,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +188,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,12 +214,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,12 +238,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +274,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,9 +298,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -272,9 +327,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,9 +353,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,9 +383,16 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
@@ -133,23 +133,19 @@ impl ClientConnectorServicesService {
     /// Lists ClientConnectorServices in a given project and location.
     pub fn list_client_connector_services(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::ListClientConnectorServices {
         super::builder::client_connector_services_service::ListClientConnectorServices::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single ClientConnectorService.
     pub fn get_client_connector_service(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::GetClientConnectorService {
         super::builder::client_connector_services_service::GetClientConnectorService::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a new ClientConnectorService in a given project and location.
@@ -165,12 +161,10 @@ impl ClientConnectorServicesService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_client_connector_service(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::CreateClientConnectorService {
         super::builder::client_connector_services_service::CreateClientConnectorService::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ClientConnectorService.
@@ -186,12 +180,10 @@ impl ClientConnectorServicesService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_client_connector_service(
         &self,
-        client_connector_service: impl Into<crate::model::ClientConnectorService>,
     ) -> super::builder::client_connector_services_service::UpdateClientConnectorService {
         super::builder::client_connector_services_service::UpdateClientConnectorService::new(
             self.inner.clone(),
         )
-        .set_client_connector_service(client_connector_service.into())
     }
 
     /// Deletes a single ClientConnectorService.
@@ -207,30 +199,22 @@ impl ClientConnectorServicesService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_client_connector_service(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::DeleteClientConnectorService {
         super::builder::client_connector_services_service::DeleteClientConnectorService::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::ListLocations {
         super::builder::client_connector_services_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_connector_services_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::client_connector_services_service::GetLocation {
         super::builder::client_connector_services_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -240,20 +224,16 @@ impl ClientConnectorServicesService {
     /// errors.
     pub fn set_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::SetIamPolicy {
         super::builder::client_connector_services_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
     pub fn get_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::GetIamPolicy {
         super::builder::client_connector_services_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -265,12 +245,10 @@ impl ClientConnectorServicesService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::TestIamPermissions {
         super::builder::client_connector_services_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -278,21 +256,15 @@ impl ClientConnectorServicesService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::ListOperations {
         super::builder::client_connector_services_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_connector_services_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::client_connector_services_service::GetOperation {
         super::builder::client_connector_services_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -300,10 +272,8 @@ impl ClientConnectorServicesService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::DeleteOperation {
         super::builder::client_connector_services_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -311,9 +281,7 @@ impl ClientConnectorServicesService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_connector_services_service::CancelOperation {
         super::builder::client_connector_services_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -133,10 +133,17 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.client_connector_service
+            let arg = &req
+                .client_connector_service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("client_connector_service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "client_connector_service.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClientConnectorServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clientConnectorServices", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/clientConnectorServices", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ClientConnectorService>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clientConnectorServices", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clientConnectorServices", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -117,18 +132,15 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.client_connector_service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("client_connector_service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.client_connector_service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("client_connector_service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -154,9 +166,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +194,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +223,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,12 +249,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,12 +273,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -268,12 +309,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,9 +333,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +362,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +388,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,9 +418,16 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
@@ -133,19 +133,13 @@ impl ClientGatewaysService {
     /// Lists ClientGateways in a given project and location.
     pub fn list_client_gateways(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::client_gateways_service::ListClientGateways {
         super::builder::client_gateways_service::ListClientGateways::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ClientGateway.
-    pub fn get_client_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::GetClientGateway {
+    pub fn get_client_gateway(&self) -> super::builder::client_gateways_service::GetClientGateway {
         super::builder::client_gateways_service::GetClientGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ClientGateway in a given project and location.
@@ -161,10 +155,8 @@ impl ClientGatewaysService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_client_gateway(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::client_gateways_service::CreateClientGateway {
         super::builder::client_gateways_service::CreateClientGateway::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single ClientGateway.
@@ -180,28 +172,18 @@ impl ClientGatewaysService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_client_gateway(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::client_gateways_service::DeleteClientGateway {
         super::builder::client_gateways_service::DeleteClientGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::client_gateways_service::ListLocations {
         super::builder::client_gateways_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::client_gateways_service::GetLocation {
         super::builder::client_gateways_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -209,22 +191,14 @@ impl ClientGatewaysService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::client_gateways_service::SetIamPolicy {
         super::builder::client_gateways_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::client_gateways_service::GetIamPolicy {
         super::builder::client_gateways_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -236,53 +210,35 @@ impl ClientGatewaysService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::client_gateways_service::TestIamPermissions {
         super::builder::client_gateways_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::client_gateways_service::ListOperations {
         super::builder::client_gateways_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::client_gateways_service::GetOperation {
         super::builder::client_gateways_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::client_gateways_service::DeleteOperation {
         super::builder::client_gateways_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::client_gateways_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::client_gateways_service::CancelOperation {
         super::builder::client_gateways_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClientGatewaysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clientGateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/clientGateways", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ClientGateway>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clientGateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clientGateways", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,9 +131,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -137,9 +159,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +188,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,12 +214,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,12 +238,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +274,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,9 +298,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -272,9 +327,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,9 +353,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,9 +383,16 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
@@ -126,103 +126,67 @@ impl AnalyticsHubService {
     }
 
     /// Lists all data exchanges in a given project and location.
-    pub fn list_data_exchanges(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::ListDataExchanges {
+    pub fn list_data_exchanges(&self) -> super::builder::analytics_hub_service::ListDataExchanges {
         super::builder::analytics_hub_service::ListDataExchanges::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all data exchanges from projects in a given organization and
     /// location.
     pub fn list_org_data_exchanges(
         &self,
-        organization: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::ListOrgDataExchanges {
         super::builder::analytics_hub_service::ListOrgDataExchanges::new(self.inner.clone())
-            .set_organization(organization.into())
     }
 
     /// Gets the details of a data exchange.
-    pub fn get_data_exchange(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::GetDataExchange {
+    pub fn get_data_exchange(&self) -> super::builder::analytics_hub_service::GetDataExchange {
         super::builder::analytics_hub_service::GetDataExchange::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new data exchange.
     pub fn create_data_exchange(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::CreateDataExchange {
         super::builder::analytics_hub_service::CreateDataExchange::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing data exchange.
     pub fn update_data_exchange(
         &self,
-        data_exchange: impl Into<crate::model::DataExchange>,
     ) -> super::builder::analytics_hub_service::UpdateDataExchange {
         super::builder::analytics_hub_service::UpdateDataExchange::new(self.inner.clone())
-            .set_data_exchange(data_exchange.into())
     }
 
     /// Deletes an existing data exchange.
     pub fn delete_data_exchange(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::DeleteDataExchange {
         super::builder::analytics_hub_service::DeleteDataExchange::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all listings in a given project and location.
-    pub fn list_listings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::ListListings {
+    pub fn list_listings(&self) -> super::builder::analytics_hub_service::ListListings {
         super::builder::analytics_hub_service::ListListings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a listing.
-    pub fn get_listing(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::GetListing {
+    pub fn get_listing(&self) -> super::builder::analytics_hub_service::GetListing {
         super::builder::analytics_hub_service::GetListing::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new listing.
-    pub fn create_listing(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::CreateListing {
+    pub fn create_listing(&self) -> super::builder::analytics_hub_service::CreateListing {
         super::builder::analytics_hub_service::CreateListing::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing listing.
-    pub fn update_listing(
-        &self,
-        listing: impl Into<crate::model::Listing>,
-    ) -> super::builder::analytics_hub_service::UpdateListing {
+    pub fn update_listing(&self) -> super::builder::analytics_hub_service::UpdateListing {
         super::builder::analytics_hub_service::UpdateListing::new(self.inner.clone())
-            .set_listing(listing.into())
     }
 
     /// Deletes a listing.
-    pub fn delete_listing(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::DeleteListing {
+    pub fn delete_listing(&self) -> super::builder::analytics_hub_service::DeleteListing {
         super::builder::analytics_hub_service::DeleteListing::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Subscribes to a listing.
@@ -231,12 +195,8 @@ impl AnalyticsHubService {
     /// reference only BigQuery datasets.
     /// Upon subscription to a listing for a BigQuery dataset, Analytics Hub
     /// creates a linked dataset in the subscriber's project.
-    pub fn subscribe_listing(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::SubscribeListing {
+    pub fn subscribe_listing(&self) -> super::builder::analytics_hub_service::SubscribeListing {
         super::builder::analytics_hub_service::SubscribeListing::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Subscription to a Data Clean Room. This is a long-running
@@ -253,10 +213,8 @@ impl AnalyticsHubService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn subscribe_data_exchange(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::SubscribeDataExchange {
         super::builder::analytics_hub_service::SubscribeDataExchange::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Refreshes a Subscription to a Data Exchange. A Data Exchange can become
@@ -274,48 +232,32 @@ impl AnalyticsHubService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn refresh_subscription(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::RefreshSubscription {
         super::builder::analytics_hub_service::RefreshSubscription::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the details of a Subscription.
-    pub fn get_subscription(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::GetSubscription {
+    pub fn get_subscription(&self) -> super::builder::analytics_hub_service::GetSubscription {
         super::builder::analytics_hub_service::GetSubscription::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all subscriptions in a given project and location.
-    pub fn list_subscriptions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::ListSubscriptions {
+    pub fn list_subscriptions(&self) -> super::builder::analytics_hub_service::ListSubscriptions {
         super::builder::analytics_hub_service::ListSubscriptions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all subscriptions on a given Data Exchange or Listing.
     pub fn list_shared_resource_subscriptions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::ListSharedResourceSubscriptions {
         super::builder::analytics_hub_service::ListSharedResourceSubscriptions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Revokes a given subscription.
-    pub fn revoke_subscription(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::RevokeSubscription {
+    pub fn revoke_subscription(&self) -> super::builder::analytics_hub_service::RevokeSubscription {
         super::builder::analytics_hub_service::RevokeSubscription::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a subscription.
@@ -329,49 +271,31 @@ impl AnalyticsHubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_subscription(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::DeleteSubscription {
+    pub fn delete_subscription(&self) -> super::builder::analytics_hub_service::DeleteSubscription {
         super::builder::analytics_hub_service::DeleteSubscription::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the IAM policy.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::analytics_hub_service::GetIamPolicy {
         super::builder::analytics_hub_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::analytics_hub_service::SetIamPolicy {
         super::builder::analytics_hub_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the permissions that a caller has.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::analytics_hub_service::TestIamPermissions {
         super::builder::analytics_hub_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_hub_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::analytics_hub_service::GetOperation {
         super::builder::analytics_hub_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataExchangesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataExchanges", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataExchanges", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,12 +74,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOrgDataExchangesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataExchanges", {
+            let arg = &req.organization;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("organization"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataExchanges", req.organization),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -94,9 +102,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataExchange>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,12 +128,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataExchange>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataExchanges", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataExchanges", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,18 +155,15 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataExchange>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_exchange
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_exchange"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_exchange
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_exchange"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +186,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +216,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListListingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/listings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/listings", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -214,9 +244,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Listing>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -233,12 +270,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Listing>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/listings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/listings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,18 +297,15 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Listing>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.listing
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("listing"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.listing
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("listing"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +328,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -313,9 +358,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SubscribeListingResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:subscribe", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:subscribe", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -330,9 +382,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:subscribe", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:subscribe", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +406,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:refresh", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:refresh", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -364,9 +430,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Subscription>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -383,12 +456,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSubscriptionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/subscriptions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/subscriptions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,12 +486,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
     ) -> Result<gax::response::Response<crate::model::ListSharedResourceSubscriptionsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listSubscriptions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listSubscriptions", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -437,9 +518,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RevokeSubscriptionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,9 +542,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -473,12 +568,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -493,12 +592,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -513,12 +616,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -533,9 +640,16 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -156,10 +156,15 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
     ) -> Result<gax::response::Response<crate::model::DataExchange>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_exchange
+            let arg = &req
+                .data_exchange
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_exchange"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_exchange.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -298,10 +303,15 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
     ) -> Result<gax::response::Response<crate::model::Listing>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.listing
+            let arg = &req
+                .listing
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("listing"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("listing.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/bigquery/connection/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/client.rs
@@ -121,72 +121,44 @@ impl ConnectionService {
     }
 
     /// Creates a new connection.
-    pub fn create_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::CreateConnection {
+    pub fn create_connection(&self) -> super::builder::connection_service::CreateConnection {
         super::builder::connection_service::CreateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns specified connection.
-    pub fn get_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::GetConnection {
+    pub fn get_connection(&self) -> super::builder::connection_service::GetConnection {
         super::builder::connection_service::GetConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of connections in the given project.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::ListConnections {
+    pub fn list_connections(&self) -> super::builder::connection_service::ListConnections {
         super::builder::connection_service::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified connection. For security reasons, also resets
     /// credential if connection properties are in the update field mask.
-    pub fn update_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::UpdateConnection {
+    pub fn update_connection(&self) -> super::builder::connection_service::UpdateConnection {
         super::builder::connection_service::UpdateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes connection and associated credential.
-    pub fn delete_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::DeleteConnection {
+    pub fn delete_connection(&self) -> super::builder::connection_service::DeleteConnection {
         super::builder::connection_service::DeleteConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::connection_service::GetIamPolicy {
         super::builder::connection_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces any
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::connection_service::SetIamPolicy {
         super::builder::connection_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource.
@@ -196,11 +168,7 @@ impl ConnectionService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connection_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::connection_service::TestIamPermissions {
         super::builder::connection_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 }

--- a/src/generated/cloud/bigquery/connection/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +73,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +99,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +127,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -137,9 +159,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,12 +189,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,12 +213,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,12 +237,16 @@ impl super::stub::ConnectionService for ConnectionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
@@ -122,84 +122,48 @@ impl DataPolicyService {
 
     /// Creates a new data policy under a project with the given `dataPolicyId`
     /// (used as the display name), policy tag, and data policy type.
-    pub fn create_data_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::CreateDataPolicy {
+    pub fn create_data_policy(&self) -> super::builder::data_policy_service::CreateDataPolicy {
         super::builder::data_policy_service::CreateDataPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the metadata for an existing data policy. The target data policy
     /// can be specified by the resource name.
-    pub fn update_data_policy(
-        &self,
-        data_policy: impl Into<crate::model::DataPolicy>,
-    ) -> super::builder::data_policy_service::UpdateDataPolicy {
+    pub fn update_data_policy(&self) -> super::builder::data_policy_service::UpdateDataPolicy {
         super::builder::data_policy_service::UpdateDataPolicy::new(self.inner.clone())
-            .set_data_policy(data_policy.into())
     }
 
     /// Renames the id (display name) of the specified data policy.
-    pub fn rename_data_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::RenameDataPolicy {
+    pub fn rename_data_policy(&self) -> super::builder::data_policy_service::RenameDataPolicy {
         super::builder::data_policy_service::RenameDataPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the data policy specified by its resource name.
-    pub fn delete_data_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::DeleteDataPolicy {
+    pub fn delete_data_policy(&self) -> super::builder::data_policy_service::DeleteDataPolicy {
         super::builder::data_policy_service::DeleteDataPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the data policy specified by its resource name.
-    pub fn get_data_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::GetDataPolicy {
+    pub fn get_data_policy(&self) -> super::builder::data_policy_service::GetDataPolicy {
         super::builder::data_policy_service::GetDataPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List all of the data policies in the specified parent project.
-    pub fn list_data_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::ListDataPolicies {
+    pub fn list_data_policies(&self) -> super::builder::data_policy_service::ListDataPolicies {
         super::builder::data_policy_service::ListDataPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the IAM policy for the specified data policy.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::data_policy_service::GetIamPolicy {
         super::builder::data_policy_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM policy for the specified data policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::data_policy_service::SetIamPolicy {
         super::builder::data_policy_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the caller's permission on the specified data policy resource.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_policy_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::data_policy_service::TestIamPermissions {
         super::builder::data_policy_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,18 +72,15 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -102,9 +103,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -119,9 +127,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -142,9 +157,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,12 +183,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -186,12 +212,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,12 +236,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,12 +260,16 @@ impl super::stub::DataPolicyService for DataPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -73,10 +73,15 @@ impl super::stub::DataPolicyService for DataPolicyService {
     ) -> Result<gax::response::Response<crate::model::DataPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_policy
+            let arg = &req
+                .data_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
@@ -121,69 +121,49 @@ impl DataTransferService {
     }
 
     /// Retrieves a supported data source and returns its settings.
-    pub fn get_data_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::GetDataSource {
+    pub fn get_data_source(&self) -> super::builder::data_transfer_service::GetDataSource {
         super::builder::data_transfer_service::GetDataSource::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists supported data sources and returns their settings.
-    pub fn list_data_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::ListDataSources {
+    pub fn list_data_sources(&self) -> super::builder::data_transfer_service::ListDataSources {
         super::builder::data_transfer_service::ListDataSources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new data transfer configuration.
     pub fn create_transfer_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::CreateTransferConfig {
         super::builder::data_transfer_service::CreateTransferConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a data transfer configuration.
     /// All fields must be set, even if they are not updated.
     pub fn update_transfer_config(
         &self,
-        transfer_config: impl Into<crate::model::TransferConfig>,
     ) -> super::builder::data_transfer_service::UpdateTransferConfig {
         super::builder::data_transfer_service::UpdateTransferConfig::new(self.inner.clone())
-            .set_transfer_config(transfer_config.into())
     }
 
     /// Deletes a data transfer configuration, including any associated transfer
     /// runs and logs.
     pub fn delete_transfer_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::DeleteTransferConfig {
         super::builder::data_transfer_service::DeleteTransferConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns information about a data transfer config.
-    pub fn get_transfer_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::GetTransferConfig {
+    pub fn get_transfer_config(&self) -> super::builder::data_transfer_service::GetTransferConfig {
         super::builder::data_transfer_service::GetTransferConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns information about all transfer configs owned by a project in the
     /// specified location.
     pub fn list_transfer_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::ListTransferConfigs {
         super::builder::data_transfer_service::ListTransferConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates transfer runs for a time range [start_time, end_time].
@@ -194,10 +174,8 @@ impl DataTransferService {
     #[deprecated]
     pub fn schedule_transfer_runs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::ScheduleTransferRuns {
         super::builder::data_transfer_service::ScheduleTransferRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Start manual transfer runs to be executed now with schedule_time equal to
@@ -206,56 +184,34 @@ impl DataTransferService {
     /// a specific run_time.
     pub fn start_manual_transfer_runs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::StartManualTransferRuns {
         super::builder::data_transfer_service::StartManualTransferRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns information about the particular transfer run.
-    pub fn get_transfer_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::GetTransferRun {
+    pub fn get_transfer_run(&self) -> super::builder::data_transfer_service::GetTransferRun {
         super::builder::data_transfer_service::GetTransferRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified transfer run.
-    pub fn delete_transfer_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::DeleteTransferRun {
+    pub fn delete_transfer_run(&self) -> super::builder::data_transfer_service::DeleteTransferRun {
         super::builder::data_transfer_service::DeleteTransferRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns information about running and completed transfer runs.
-    pub fn list_transfer_runs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::ListTransferRuns {
+    pub fn list_transfer_runs(&self) -> super::builder::data_transfer_service::ListTransferRuns {
         super::builder::data_transfer_service::ListTransferRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns log messages for the transfer run.
-    pub fn list_transfer_logs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::ListTransferLogs {
+    pub fn list_transfer_logs(&self) -> super::builder::data_transfer_service::ListTransferLogs {
         super::builder::data_transfer_service::ListTransferLogs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns true if valid credentials exist for the given data source and
     /// requesting user.
-    pub fn check_valid_creds(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::CheckValidCreds {
+    pub fn check_valid_creds(&self) -> super::builder::data_transfer_service::CheckValidCreds {
         super::builder::data_transfer_service::CheckValidCreds::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Enroll data sources in a user project. This allows users to create transfer
@@ -266,12 +222,8 @@ impl DataTransferService {
     /// [BigQuery Web UI](https://cloud.google.com/bigquery/bigquery-web-ui) and
     /// [Data Transfer
     /// Service](https://cloud.google.com/bigquery/docs/working-with-transfers).
-    pub fn enroll_data_sources(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::EnrollDataSources {
+    pub fn enroll_data_sources(&self) -> super::builder::data_transfer_service::EnrollDataSources {
         super::builder::data_transfer_service::EnrollDataSources::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Unenroll data sources in a user project. This allows users to remove
@@ -281,27 +233,17 @@ impl DataTransferService {
     /// configurations of unenrolled data sources will not be scheduled.
     pub fn unenroll_data_sources(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_transfer_service::UnenrollDataSources {
         super::builder::data_transfer_service::UnenrollDataSources::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::data_transfer_service::ListLocations {
         super::builder::data_transfer_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_transfer_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::data_transfer_service::GetLocation {
         super::builder::data_transfer_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataSource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,12 +72,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataSources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataSources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/transferConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/transferConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.transfer_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("transfer_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.transfer_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("transfer_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -151,9 +163,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +193,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,12 +219,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTransferConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/transferConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/transferConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -221,12 +251,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScheduleTransferRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:scheduleRuns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:scheduleRuns", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,12 +275,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StartManualTransferRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:startManualRuns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:startManualRuns", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -261,9 +299,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -280,9 +325,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -303,9 +355,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTransferRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,12 +388,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTransferLogsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/transferLogs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/transferLogs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,12 +420,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckValidCredsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:checkValidCreds", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:checkValidCreds", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,12 +444,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enrollDataSources", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:enrollDataSources", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,12 +473,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:unenrollDataSources", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:unenrollDataSources", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -427,9 +502,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -449,9 +531,16 @@ impl super::stub::DataTransferService for DataTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::DataTransferService for DataTransferService {
     ) -> Result<gax::response::Response<crate::model::TransferConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.transfer_config
+            let arg = &req
+                .transfer_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("transfer_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("transfer_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/bigquery/migration/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/client.rs
@@ -123,37 +123,29 @@ impl MigrationService {
     /// Creates a migration workflow.
     pub fn create_migration_workflow(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_service::CreateMigrationWorkflow {
         super::builder::migration_service::CreateMigrationWorkflow::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a previously created migration workflow.
     pub fn get_migration_workflow(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::migration_service::GetMigrationWorkflow {
         super::builder::migration_service::GetMigrationWorkflow::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists previously created migration workflow.
     pub fn list_migration_workflows(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_service::ListMigrationWorkflows {
         super::builder::migration_service::ListMigrationWorkflows::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a migration workflow by name.
     pub fn delete_migration_workflow(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::migration_service::DeleteMigrationWorkflow {
         super::builder::migration_service::DeleteMigrationWorkflow::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts a previously created migration workflow. I.e., the state transitions
@@ -162,27 +154,19 @@ impl MigrationService {
     /// RUNNING.
     pub fn start_migration_workflow(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::migration_service::StartMigrationWorkflow {
         super::builder::migration_service::StartMigrationWorkflow::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a previously created migration subtask.
-    pub fn get_migration_subtask(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_service::GetMigrationSubtask {
+    pub fn get_migration_subtask(&self) -> super::builder::migration_service::GetMigrationSubtask {
         super::builder::migration_service::GetMigrationSubtask::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists previously created migration subtasks.
     pub fn list_migration_subtasks(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_service::ListMigrationSubtasks {
         super::builder::migration_service::ListMigrationSubtasks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/bigquery/migration/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationWorkflow>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/workflows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/workflows", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationWorkflow>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,12 +104,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMigrationWorkflowsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/workflows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/workflows", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,9 +138,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -146,9 +168,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +197,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationSubtask>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +229,16 @@ impl super::stub::MigrationService for MigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMigrationSubtasksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/subtasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/subtasks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -135,50 +135,30 @@ impl ReservationService {
     }
 
     /// Creates a new reservation resource.
-    pub fn create_reservation(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::CreateReservation {
+    pub fn create_reservation(&self) -> super::builder::reservation_service::CreateReservation {
         super::builder::reservation_service::CreateReservation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all the reservations for the project in the specified location.
-    pub fn list_reservations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::ListReservations {
+    pub fn list_reservations(&self) -> super::builder::reservation_service::ListReservations {
         super::builder::reservation_service::ListReservations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns information about the reservation.
-    pub fn get_reservation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::GetReservation {
+    pub fn get_reservation(&self) -> super::builder::reservation_service::GetReservation {
         super::builder::reservation_service::GetReservation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a reservation.
     /// Returns `google.rpc.Code.FAILED_PRECONDITION` when reservation has
     /// assignments.
-    pub fn delete_reservation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::DeleteReservation {
+    pub fn delete_reservation(&self) -> super::builder::reservation_service::DeleteReservation {
         super::builder::reservation_service::DeleteReservation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an existing reservation resource.
-    pub fn update_reservation(
-        &self,
-        reservation: impl Into<crate::model::Reservation>,
-    ) -> super::builder::reservation_service::UpdateReservation {
+    pub fn update_reservation(&self) -> super::builder::reservation_service::UpdateReservation {
         super::builder::reservation_service::UpdateReservation::new(self.inner.clone())
-            .set_reservation(reservation.into())
     }
 
     /// Fail over a reservation to the secondary location. The operation should be
@@ -186,39 +166,29 @@ impl ReservationService {
     /// new primary location for the reservation.
     /// Attempting to failover a reservation in the current primary location will
     /// fail with the error code `google.rpc.Code.FAILED_PRECONDITION`.
-    pub fn failover_reservation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::FailoverReservation {
+    pub fn failover_reservation(&self) -> super::builder::reservation_service::FailoverReservation {
         super::builder::reservation_service::FailoverReservation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new capacity commitment resource.
     pub fn create_capacity_commitment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::CreateCapacityCommitment {
         super::builder::reservation_service::CreateCapacityCommitment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all the capacity commitments for the admin project.
     pub fn list_capacity_commitments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::ListCapacityCommitments {
         super::builder::reservation_service::ListCapacityCommitments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns information about the capacity commitment.
     pub fn get_capacity_commitment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::GetCapacityCommitment {
         super::builder::reservation_service::GetCapacityCommitment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a capacity commitment. Attempting to delete capacity commitment
@@ -226,10 +196,8 @@ impl ReservationService {
     /// `google.rpc.Code.FAILED_PRECONDITION`.
     pub fn delete_capacity_commitment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::DeleteCapacityCommitment {
         super::builder::reservation_service::DeleteCapacityCommitment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an existing capacity commitment.
@@ -241,10 +209,8 @@ impl ReservationService {
     /// with the error code `google.rpc.Code.FAILED_PRECONDITION`.
     pub fn update_capacity_commitment(
         &self,
-        capacity_commitment: impl Into<crate::model::CapacityCommitment>,
     ) -> super::builder::reservation_service::UpdateCapacityCommitment {
         super::builder::reservation_service::UpdateCapacityCommitment::new(self.inner.clone())
-            .set_capacity_commitment(capacity_commitment.into())
     }
 
     /// Splits capacity commitment to two commitments of the same plan and
@@ -257,10 +223,8 @@ impl ReservationService {
     /// you delete the first one after the commitment end time passes.
     pub fn split_capacity_commitment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::SplitCapacityCommitment {
         super::builder::reservation_service::SplitCapacityCommitment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Merges capacity commitments of the same plan into a single commitment.
@@ -272,10 +236,8 @@ impl ReservationService {
     /// with the error code `google.rpc.Code.FAILED_PRECONDITION`.
     pub fn merge_capacity_commitments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::MergeCapacityCommitments {
         super::builder::reservation_service::MergeCapacityCommitments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an assignment object which allows the given project to submit jobs
@@ -313,12 +275,8 @@ impl ReservationService {
     ///
     /// Returns `google.rpc.Code.INVALID_ARGUMENT` when location of the assignment
     /// does not match location of the reservation.
-    pub fn create_assignment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::CreateAssignment {
+    pub fn create_assignment(&self) -> super::builder::reservation_service::CreateAssignment {
         super::builder::reservation_service::CreateAssignment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists assignments.
@@ -342,12 +300,8 @@ impl ReservationService {
     /// specified project and location will be listed.
     ///
     /// **Note** "-" cannot be used for projects nor locations.
-    pub fn list_assignments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::ListAssignments {
+    pub fn list_assignments(&self) -> super::builder::reservation_service::ListAssignments {
         super::builder::reservation_service::ListAssignments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a assignment. No expansion will happen.
@@ -365,12 +319,8 @@ impl ReservationService {
     /// affect the other assignment `<project1, res1>`. After said deletion,
     /// queries from `project1` will still use `res1` while queries from
     /// `project2` will switch to use on-demand mode.
-    pub fn delete_assignment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::DeleteAssignment {
+    pub fn delete_assignment(&self) -> super::builder::reservation_service::DeleteAssignment {
         super::builder::reservation_service::DeleteAssignment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deprecated: Looks up assignments for a specified resource for a particular
@@ -397,12 +347,8 @@ impl ReservationService {
     /// **Note** "-" cannot be used for projects
     /// nor locations.
     #[deprecated]
-    pub fn search_assignments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::SearchAssignments {
+    pub fn search_assignments(&self) -> super::builder::reservation_service::SearchAssignments {
         super::builder::reservation_service::SearchAssignments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Looks up assignments for a specified resource for a particular region.
@@ -427,10 +373,8 @@ impl ReservationService {
     ///   `projects/*/locations/*reservations/*`.
     pub fn search_all_assignments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reservation_service::SearchAllAssignments {
         super::builder::reservation_service::SearchAllAssignments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Moves an assignment under a new reservation.
@@ -438,32 +382,20 @@ impl ReservationService {
     /// This differs from removing an existing assignment and recreating a new one
     /// by providing a transactional change that ensures an assignee always has an
     /// associated reservation.
-    pub fn move_assignment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::MoveAssignment {
+    pub fn move_assignment(&self) -> super::builder::reservation_service::MoveAssignment {
         super::builder::reservation_service::MoveAssignment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an existing assignment.
     ///
     /// Only the `priority` field can be updated.
-    pub fn update_assignment(
-        &self,
-        assignment: impl Into<crate::model::Assignment>,
-    ) -> super::builder::reservation_service::UpdateAssignment {
+    pub fn update_assignment(&self) -> super::builder::reservation_service::UpdateAssignment {
         super::builder::reservation_service::UpdateAssignment::new(self.inner.clone())
-            .set_assignment(assignment.into())
     }
 
     /// Retrieves a BI reservation.
-    pub fn get_bi_reservation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reservation_service::GetBiReservation {
+    pub fn get_bi_reservation(&self) -> super::builder::reservation_service::GetBiReservation {
         super::builder::reservation_service::GetBiReservation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a BI reservation.
@@ -476,9 +408,7 @@ impl ReservationService {
     /// must be set to 0.
     pub fn update_bi_reservation(
         &self,
-        bi_reservation: impl Into<crate::model::BiReservation>,
     ) -> super::builder::reservation_service::UpdateBiReservation {
         super::builder::reservation_service::UpdateBiReservation::new(self.inner.clone())
-            .set_bi_reservation(bi_reservation.into())
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -158,10 +158,15 @@ impl super::stub::ReservationService for ReservationService {
     ) -> Result<gax::response::Response<crate::model::Reservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.reservation
+            let arg = &req
+                .reservation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("reservation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("reservation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -329,10 +334,15 @@ impl super::stub::ReservationService for ReservationService {
     ) -> Result<gax::response::Response<crate::model::CapacityCommitment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.capacity_commitment
+            let arg = &req
+                .capacity_commitment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("capacity_commitment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("capacity_commitment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -575,10 +585,15 @@ impl super::stub::ReservationService for ReservationService {
     ) -> Result<gax::response::Response<crate::model::Assignment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.assignment
+            let arg = &req
+                .assignment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("assignment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("assignment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -632,10 +647,15 @@ impl super::stub::ReservationService for ReservationService {
     ) -> Result<gax::response::Response<crate::model::BiReservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.bi_reservation
+            let arg = &req
+                .bi_reservation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("bi_reservation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("bi_reservation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Reservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/reservations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/reservations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +73,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReservationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reservations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/reservations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,9 +101,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Reservation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +127,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,18 +157,15 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Reservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.reservation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("reservation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.reservation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("reservation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +188,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Reservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:failoverReservation", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:failoverReservation", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,12 +212,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CapacityCommitment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/capacityCommitments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/capacityCommitments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,12 +243,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCapacityCommitmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/capacityCommitments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/capacityCommitments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,9 +271,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CapacityCommitment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,9 +297,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -283,18 +328,15 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CapacityCommitment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.capacity_commitment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("capacity_commitment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.capacity_commitment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("capacity_commitment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -317,9 +359,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SplitCapacityCommitmentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:split", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:split", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -334,12 +383,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CapacityCommitment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/capacityCommitments:merge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/capacityCommitments:merge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -354,12 +407,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Assignment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assignments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,12 +434,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAssignmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/assignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/assignments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -401,9 +462,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -424,12 +492,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchAssignmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchAssignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchAssignments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -449,12 +521,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchAllAssignmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchAllAssignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchAllAssignments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -474,9 +550,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Assignment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:move", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -491,18 +574,15 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Assignment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.assignment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("assignment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.assignment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("assignment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -525,9 +605,16 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BiReservation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -544,18 +631,15 @@ impl super::stub::ReservationService for ReservationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BiReservation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.bi_reservation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("bi_reservation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.bi_reservation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("bi_reservation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/bigquery/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/v2/src/client.rs
@@ -119,87 +119,49 @@ impl DatasetService {
     }
 
     /// Returns the dataset specified by datasetID.
-    pub fn get_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::GetDataset {
+    pub fn get_dataset(&self) -> super::builder::dataset_service::GetDataset {
         super::builder::dataset_service::GetDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Creates a new empty dataset.
-    pub fn insert_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::InsertDataset {
+    pub fn insert_dataset(&self) -> super::builder::dataset_service::InsertDataset {
         super::builder::dataset_service::InsertDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Updates information in an existing dataset. The update method replaces the
     /// entire dataset resource, whereas the patch method only replaces fields that
     /// are provided in the submitted dataset resource.
     /// This method supports RFC5789 patch semantics.
-    pub fn patch_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::PatchDataset {
+    pub fn patch_dataset(&self) -> super::builder::dataset_service::PatchDataset {
         super::builder::dataset_service::PatchDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Updates information in an existing dataset. The update method replaces the
     /// entire dataset resource, whereas the patch method only replaces fields that
     /// are provided in the submitted dataset resource.
-    pub fn update_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::UpdateDataset {
+    pub fn update_dataset(&self) -> super::builder::dataset_service::UpdateDataset {
         super::builder::dataset_service::UpdateDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Deletes the dataset specified by the datasetId value. Before you can delete
     /// a dataset, you must delete all its tables, either manually or by specifying
     /// deleteContents. Immediately after deletion, you can create another dataset
     /// with the same name.
-    pub fn delete_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::DeleteDataset {
+    pub fn delete_dataset(&self) -> super::builder::dataset_service::DeleteDataset {
         super::builder::dataset_service::DeleteDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Lists all datasets in the specified project to which the user has been
     /// granted the READER dataset role.
-    pub fn list_datasets(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::ListDatasets {
+    pub fn list_datasets(&self) -> super::builder::dataset_service::ListDatasets {
         super::builder::dataset_service::ListDatasets::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Undeletes a dataset which is within time travel window based on datasetId.
     /// If a time is specified, the dataset version deleted at that time is
     /// undeleted, else the last live version is undeleted.
-    pub fn undelete_dataset(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::dataset_service::UndeleteDataset {
+    pub fn undelete_dataset(&self) -> super::builder::dataset_service::UndeleteDataset {
         super::builder::dataset_service::UndeleteDataset::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 }
 
@@ -304,55 +266,25 @@ impl ModelService {
     }
 
     /// Gets the specified model resource by model ID.
-    pub fn get_model(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        model_id: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetModel {
+    pub fn get_model(&self) -> super::builder::model_service::GetModel {
         super::builder::model_service::GetModel::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_model_id(model_id.into())
     }
 
     /// Lists all models in the specified dataset. Requires the READER dataset
     /// role. After retrieving the list of models, you can get information about a
     /// particular model by calling the models.get method.
-    pub fn list_models(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListModels {
+    pub fn list_models(&self) -> super::builder::model_service::ListModels {
         super::builder::model_service::ListModels::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Patch specific fields in the specified model.
-    pub fn patch_model(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        model_id: impl Into<std::string::String>,
-    ) -> super::builder::model_service::PatchModel {
+    pub fn patch_model(&self) -> super::builder::model_service::PatchModel {
         super::builder::model_service::PatchModel::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_model_id(model_id.into())
     }
 
     /// Deletes the model specified by modelId from the dataset.
-    pub fn delete_model(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        model_id: impl Into<std::string::String>,
-    ) -> super::builder::model_service::DeleteModel {
+    pub fn delete_model(&self) -> super::builder::model_service::DeleteModel {
         super::builder::model_service::DeleteModel::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_model_id(model_id.into())
     }
 }
 
@@ -458,12 +390,8 @@ impl ProjectService {
 
     /// RPC to get the service account for a project used for interactions with
     /// Google Cloud KMS
-    pub fn get_service_account(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::project_service::GetServiceAccount {
+    pub fn get_service_account(&self) -> super::builder::project_service::GetServiceAccount {
         super::builder::project_service::GetServiceAccount::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 }
 
@@ -568,66 +496,30 @@ impl RoutineService {
     }
 
     /// Gets the specified routine resource by routine ID.
-    pub fn get_routine(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        routine_id: impl Into<std::string::String>,
-    ) -> super::builder::routine_service::GetRoutine {
+    pub fn get_routine(&self) -> super::builder::routine_service::GetRoutine {
         super::builder::routine_service::GetRoutine::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_routine_id(routine_id.into())
     }
 
     /// Creates a new routine in the dataset.
-    pub fn insert_routine(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::routine_service::InsertRoutine {
+    pub fn insert_routine(&self) -> super::builder::routine_service::InsertRoutine {
         super::builder::routine_service::InsertRoutine::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Updates information in an existing routine. The update method replaces the
     /// entire Routine resource.
-    pub fn update_routine(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        routine_id: impl Into<std::string::String>,
-    ) -> super::builder::routine_service::UpdateRoutine {
+    pub fn update_routine(&self) -> super::builder::routine_service::UpdateRoutine {
         super::builder::routine_service::UpdateRoutine::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_routine_id(routine_id.into())
     }
 
     /// Deletes the routine specified by routineId from the dataset.
-    pub fn delete_routine(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        routine_id: impl Into<std::string::String>,
-    ) -> super::builder::routine_service::DeleteRoutine {
+    pub fn delete_routine(&self) -> super::builder::routine_service::DeleteRoutine {
         super::builder::routine_service::DeleteRoutine::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_routine_id(routine_id.into())
     }
 
     /// Lists all routines in the specified dataset. Requires the READER dataset
     /// role.
-    pub fn list_routines(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::routine_service::ListRoutines {
+    pub fn list_routines(&self) -> super::builder::routine_service::ListRoutines {
         super::builder::routine_service::ListRoutines::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 }
 
@@ -736,87 +628,45 @@ impl RowAccessPolicyService {
     /// Lists all row access policies on the specified table.
     pub fn list_row_access_policies(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::ListRowAccessPolicies {
         super::builder::row_access_policy_service::ListRowAccessPolicies::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Gets the specified row access policy by policy ID.
     pub fn get_row_access_policy(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-        policy_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::GetRowAccessPolicy {
         super::builder::row_access_policy_service::GetRowAccessPolicy::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
-            .set_policy_id(policy_id.into())
     }
 
     /// Creates a row access policy.
     pub fn create_row_access_policy(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::CreateRowAccessPolicy {
         super::builder::row_access_policy_service::CreateRowAccessPolicy::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Updates a row access policy.
     pub fn update_row_access_policy(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-        policy_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::UpdateRowAccessPolicy {
         super::builder::row_access_policy_service::UpdateRowAccessPolicy::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
-            .set_policy_id(policy_id.into())
     }
 
     /// Deletes a row access policy.
     pub fn delete_row_access_policy(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-        policy_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::DeleteRowAccessPolicy {
         super::builder::row_access_policy_service::DeleteRowAccessPolicy::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
-            .set_policy_id(policy_id.into())
     }
 
     /// Deletes provided row access policies.
     pub fn batch_delete_row_access_policies(
         &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
     ) -> super::builder::row_access_policy_service::BatchDeleteRowAccessPolicies {
         super::builder::row_access_policy_service::BatchDeleteRowAccessPolicies::new(
             self.inner.clone(),
         )
-        .set_project_id(project_id.into())
-        .set_dataset_id(dataset_id.into())
-        .set_table_id(table_id.into())
     }
 }
 
@@ -924,83 +774,39 @@ impl TableService {
     /// Gets the specified table resource by table ID.
     /// This method does not return the data in the table, it only returns the
     /// table resource, which describes the structure of this table.
-    pub fn get_table(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::GetTable {
+    pub fn get_table(&self) -> super::builder::table_service::GetTable {
         super::builder::table_service::GetTable::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Creates a new, empty table in the dataset.
-    pub fn insert_table(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::InsertTable {
+    pub fn insert_table(&self) -> super::builder::table_service::InsertTable {
         super::builder::table_service::InsertTable::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 
     /// Updates information in an existing table. The update method replaces the
     /// entire table resource, whereas the patch method only replaces fields that
     /// are provided in the submitted table resource.
     /// This method supports RFC5789 patch semantics.
-    pub fn patch_table(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::PatchTable {
+    pub fn patch_table(&self) -> super::builder::table_service::PatchTable {
         super::builder::table_service::PatchTable::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Updates information in an existing table. The update method replaces the
     /// entire Table resource, whereas the patch method only replaces fields that
     /// are provided in the submitted Table resource.
-    pub fn update_table(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::UpdateTable {
+    pub fn update_table(&self) -> super::builder::table_service::UpdateTable {
         super::builder::table_service::UpdateTable::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Deletes the table specified by tableId from the dataset.
     /// If the table contains data, all the data will be deleted.
-    pub fn delete_table(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-        table_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::DeleteTable {
+    pub fn delete_table(&self) -> super::builder::table_service::DeleteTable {
         super::builder::table_service::DeleteTable::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
-            .set_table_id(table_id.into())
     }
 
     /// Lists all tables in the specified dataset. Requires the READER dataset
     /// role.
-    pub fn list_tables(
-        &self,
-        project_id: impl Into<std::string::String>,
-        dataset_id: impl Into<std::string::String>,
-    ) -> super::builder::table_service::ListTables {
+    pub fn list_tables(&self) -> super::builder::table_service::ListTables {
         super::builder::table_service::ListTables::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_dataset_id(dataset_id.into())
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/v2/src/transport.rs
@@ -46,15 +46,26 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -73,12 +84,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/bigquery/v2/projects/{}/datasets", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/bigquery/v2/projects/{}/datasets", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -96,15 +111,26 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,15 +149,26 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,15 +187,26 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,12 +228,16 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatasetList>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/bigquery/v2/projects/{}/datasets", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/bigquery/v2/projects/{}/datasets", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -215,15 +267,26 @@ impl super::stub::DatasetService for DatasetService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}:undelete",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}:undelete",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -261,15 +324,33 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/models/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.model_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("model_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/models/{}",
-                    req.project_id, req.dataset_id, req.model_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -286,15 +367,26 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/models",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/models",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,15 +414,33 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/models/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.model_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("model_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/models/{}",
-                    req.project_id, req.dataset_id, req.model_id
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -345,15 +455,33 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/models/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.model_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("model_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/models/{}",
-                    req.project_id, req.dataset_id, req.model_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,12 +525,16 @@ impl super::stub::ProjectService for ProjectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetServiceAccountResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/bigquery/v2/projects/{}/serviceAccount", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/bigquery/v2/projects/{}/serviceAccount", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -442,15 +574,33 @@ impl super::stub::RoutineService for RoutineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Routine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.routine_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("routine_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
-                    req.project_id, req.dataset_id, req.routine_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -467,15 +617,26 @@ impl super::stub::RoutineService for RoutineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Routine>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/routines",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/routines",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -492,15 +653,33 @@ impl super::stub::RoutineService for RoutineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Routine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.routine_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("routine_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
-                    req.project_id, req.dataset_id, req.routine_id
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -517,15 +696,33 @@ impl super::stub::RoutineService for RoutineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.routine_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("routine_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/routines/{}",
-                    req.project_id, req.dataset_id, req.routine_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,15 +743,26 @@ impl super::stub::RoutineService for RoutineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoutinesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/routines",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/routines",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -606,15 +814,33 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRowAccessPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -633,15 +859,40 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RowAccessPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.policy_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("policy_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
-                    req.project_id, req.dataset_id, req.table_id, req.policy_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -658,15 +909,33 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RowAccessPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -683,15 +952,40 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RowAccessPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.policy_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("policy_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
-                    req.project_id, req.dataset_id, req.table_id, req.policy_id
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -708,15 +1002,40 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.policy_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("policy_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies/{}",
-                    req.project_id, req.dataset_id, req.table_id, req.policy_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,15 +1060,33 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies:batchDelete",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}/rowAccessPolicies:batchDelete",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -792,15 +1129,33 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -819,15 +1174,26 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -842,15 +1208,33 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -866,15 +1250,33 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Table>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -890,15 +1292,33 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.table_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("table_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables/{}",
-                    req.project_id, req.dataset_id, req.table_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -919,15 +1339,26 @@ impl super::stub::TableService for TableService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TableList>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/bigquery/v2/projects/{}/datasets/{}/tables",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.dataset_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("dataset_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/bigquery/v2/projects/{}/datasets/{}/tables",
-                    req.project_id, req.dataset_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/billing/v1/src/client.rs
+++ b/src/generated/cloud/billing/v1/src/client.rs
@@ -122,12 +122,8 @@ impl CloudBilling {
     /// Gets information about a billing account. The current authenticated user
     /// must be a [viewer of the billing
     /// account](https://cloud.google.com/billing/docs/how-to/billing-access).
-    pub fn get_billing_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::GetBillingAccount {
+    pub fn get_billing_account(&self) -> super::builder::cloud_billing::GetBillingAccount {
         super::builder::cloud_billing::GetBillingAccount::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the billing accounts that the current authenticated user has
@@ -143,12 +139,8 @@ impl CloudBilling {
     /// IAM permission, which is typically given to the
     /// [administrator](https://cloud.google.com/billing/docs/how-to/billing-access)
     /// of the billing account.
-    pub fn update_billing_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::UpdateBillingAccount {
+    pub fn update_billing_account(&self) -> super::builder::cloud_billing::UpdateBillingAccount {
         super::builder::cloud_billing::UpdateBillingAccount::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// This method creates [billing
@@ -176,10 +168,8 @@ impl CloudBilling {
     /// [viewers](https://cloud.google.com/billing/docs/how-to/billing-access).
     pub fn list_project_billing_info(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_billing::ListProjectBillingInfo {
         super::builder::cloud_billing::ListProjectBillingInfo::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the billing information for a project. The current authenticated user
@@ -187,12 +177,8 @@ impl CloudBilling {
     /// which can be granted by assigning the [Project
     /// Viewer](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)
     /// role.
-    pub fn get_project_billing_info(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::GetProjectBillingInfo {
+    pub fn get_project_billing_info(&self) -> super::builder::cloud_billing::GetProjectBillingInfo {
         super::builder::cloud_billing::GetProjectBillingInfo::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets or updates the billing account associated with a project. You specify
@@ -229,22 +215,16 @@ impl CloudBilling {
     /// *open* billing account.
     pub fn update_project_billing_info(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_billing::UpdateProjectBillingInfo {
         super::builder::cloud_billing::UpdateProjectBillingInfo::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the access control policy for a billing account.
     /// The caller must have the `billing.accounts.getIamPolicy` permission on the
     /// account, which is often given to billing account
     /// [viewers](https://cloud.google.com/billing/docs/how-to/billing-access).
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cloud_billing::GetIamPolicy {
         super::builder::cloud_billing::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy for a billing account. Replaces any existing
@@ -252,32 +232,20 @@ impl CloudBilling {
     /// The caller must have the `billing.accounts.setIamPolicy` permission on the
     /// account, which is often given to billing account
     /// [administrators](https://cloud.google.com/billing/docs/how-to/billing-access).
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cloud_billing::SetIamPolicy {
         super::builder::cloud_billing::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Tests the access control policy for a billing account. This method takes
     /// the resource and a set of permissions as input and returns the subset of
     /// the input permissions that the caller is allowed for that resource.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::cloud_billing::TestIamPermissions {
         super::builder::cloud_billing::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Changes which parent organization a billing account belongs to.
-    pub fn move_billing_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_billing::MoveBillingAccount {
+    pub fn move_billing_account(&self) -> super::builder::cloud_billing::MoveBillingAccount {
         super::builder::cloud_billing::MoveBillingAccount::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -389,10 +357,7 @@ impl CloudCatalog {
     }
 
     /// Lists all publicly available SKUs for a given cloud service.
-    pub fn list_skus(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_catalog::ListSkus {
-        super::builder::cloud_catalog::ListSkus::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_skus(&self) -> super::builder::cloud_catalog::ListSkus {
+        super::builder::cloud_catalog::ListSkus::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/billing/v1/src/transport.rs
+++ b/src/generated/cloud/billing/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BillingAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,10 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBillingAccountsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/billingAccounts".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/billingAccounts".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +96,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BillingAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,9 +128,10 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BillingAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/billingAccounts".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/billingAccounts".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,9 +149,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProjectBillingInfoResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/projects", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/projects", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -154,12 +177,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProjectBillingInfo>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/billingInfo", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/billingInfo", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,12 +203,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProjectBillingInfo>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/billingInfo", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!("/v1/{}/billingInfo", req.name),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,12 +229,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +265,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,12 +289,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +313,16 @@ impl super::stub::CloudBilling for CloudBilling {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BillingAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:move", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +360,10 @@ impl super::stub::CloudCatalog for CloudCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/services".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/services".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -331,9 +382,16 @@ impl super::stub::CloudCatalog for CloudCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSkusResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/skus", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/skus", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/binaryauthorization/v1/src/client.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/client.rs
@@ -139,12 +139,8 @@ impl BinauthzManagementServiceV1 {
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
     /// [google.cloud.binaryauthorization.v1.Policy]: crate::model::Policy
-    pub fn get_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::binauthz_management_service_v_1::GetPolicy {
+    pub fn get_policy(&self) -> super::builder::binauthz_management_service_v_1::GetPolicy {
         super::builder::binauthz_management_service_v_1::GetPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates or updates a project's [policy][google.cloud.binaryauthorization.v1.Policy], and returns a copy of the
@@ -154,12 +150,8 @@ impl BinauthzManagementServiceV1 {
     /// if the request is malformed.
     ///
     /// [google.cloud.binaryauthorization.v1.Policy]: crate::model::Policy
-    pub fn update_policy(
-        &self,
-        policy: impl Into<crate::model::Policy>,
-    ) -> super::builder::binauthz_management_service_v_1::UpdatePolicy {
+    pub fn update_policy(&self) -> super::builder::binauthz_management_service_v_1::UpdatePolicy {
         super::builder::binauthz_management_service_v_1::UpdatePolicy::new(self.inner.clone())
-            .set_policy(policy.into())
     }
 
     /// Creates an [attestor][google.cloud.binaryauthorization.v1.Attestor], and returns a copy of the new
@@ -170,22 +162,16 @@ impl BinauthzManagementServiceV1 {
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
     pub fn create_attestor(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::binauthz_management_service_v_1::CreateAttestor {
         super::builder::binauthz_management_service_v_1::CreateAttestor::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an [attestor][google.cloud.binaryauthorization.v1.Attestor].
     /// Returns NOT_FOUND if the [attestor][google.cloud.binaryauthorization.v1.Attestor] does not exist.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
-    pub fn get_attestor(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::binauthz_management_service_v_1::GetAttestor {
+    pub fn get_attestor(&self) -> super::builder::binauthz_management_service_v_1::GetAttestor {
         super::builder::binauthz_management_service_v_1::GetAttestor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -194,22 +180,16 @@ impl BinauthzManagementServiceV1 {
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
     pub fn update_attestor(
         &self,
-        attestor: impl Into<crate::model::Attestor>,
     ) -> super::builder::binauthz_management_service_v_1::UpdateAttestor {
         super::builder::binauthz_management_service_v_1::UpdateAttestor::new(self.inner.clone())
-            .set_attestor(attestor.into())
     }
 
     /// Lists [attestors][google.cloud.binaryauthorization.v1.Attestor].
     /// Returns INVALID_ARGUMENT if the project does not exist.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
-    pub fn list_attestors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::binauthz_management_service_v_1::ListAttestors {
+    pub fn list_attestors(&self) -> super::builder::binauthz_management_service_v_1::ListAttestors {
         super::builder::binauthz_management_service_v_1::ListAttestors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an [attestor][google.cloud.binaryauthorization.v1.Attestor]. Returns NOT_FOUND if the
@@ -218,10 +198,8 @@ impl BinauthzManagementServiceV1 {
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
     pub fn delete_attestor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::binauthz_management_service_v_1::DeleteAttestor {
         super::builder::binauthz_management_service_v_1::DeleteAttestor::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -328,12 +306,8 @@ impl SystemPolicyV1 {
     }
 
     /// Gets the current system policy in the specified location.
-    pub fn get_system_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::system_policy_v_1::GetSystemPolicy {
+    pub fn get_system_policy(&self) -> super::builder::system_policy_v_1::GetSystemPolicy {
         super::builder::system_policy_v_1::GetSystemPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -443,11 +417,9 @@ impl ValidationHelperV1 {
     /// was signed by the given Attestor
     pub fn validate_attestation_occurrence(
         &self,
-        attestor: impl Into<std::string::String>,
     ) -> super::builder::validation_helper_v_1::ValidateAttestationOccurrence {
         super::builder::validation_helper_v_1::ValidateAttestationOccurrence::new(
             self.inner.clone(),
         )
-        .set_attestor(attestor.into())
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -73,10 +73,15 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.policy
+            let arg = &req
+                .policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -149,10 +154,15 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
     ) -> Result<gax::response::Response<crate::model::Attestor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.attestor
+            let arg = &req
+                .attestor
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("attestor"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attestor.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,18 +72,15 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +95,16 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attestor>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attestors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attestors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,9 +122,16 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attestor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,18 +148,15 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attestor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.attestor
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("attestor"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.attestor
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("attestor"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,12 +173,16 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttestorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/attestors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/attestors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -185,9 +201,16 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,9 +254,16 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,12 +303,16 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ValidateAttestationOccurrenceResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:validateAttestationOccurrence", {
+            let arg = &req.attestor;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attestor"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:validateAttestationOccurrence", req.attestor),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/certificatemanager/v1/src/client.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/client.rs
@@ -147,21 +147,13 @@ impl CertificateManager {
     }
 
     /// Lists Certificates in a given project and location.
-    pub fn list_certificates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::ListCertificates {
+    pub fn list_certificates(&self) -> super::builder::certificate_manager::ListCertificates {
         super::builder::certificate_manager::ListCertificates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Certificate.
-    pub fn get_certificate(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::GetCertificate {
+    pub fn get_certificate(&self) -> super::builder::certificate_manager::GetCertificate {
         super::builder::certificate_manager::GetCertificate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Certificate in a given project and location.
@@ -175,12 +167,8 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_certificate(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::CreateCertificate {
+    pub fn create_certificate(&self) -> super::builder::certificate_manager::CreateCertificate {
         super::builder::certificate_manager::CreateCertificate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a Certificate.
@@ -194,12 +182,8 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_certificate(
-        &self,
-        certificate: impl Into<crate::model::Certificate>,
-    ) -> super::builder::certificate_manager::UpdateCertificate {
+    pub fn update_certificate(&self) -> super::builder::certificate_manager::UpdateCertificate {
         super::builder::certificate_manager::UpdateCertificate::new(self.inner.clone())
-            .set_certificate(certificate.into())
     }
 
     /// Deletes a single Certificate.
@@ -213,30 +197,20 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_certificate(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::DeleteCertificate {
+    pub fn delete_certificate(&self) -> super::builder::certificate_manager::DeleteCertificate {
         super::builder::certificate_manager::DeleteCertificate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists CertificateMaps in a given project and location.
     pub fn list_certificate_maps(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::ListCertificateMaps {
         super::builder::certificate_manager::ListCertificateMaps::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CertificateMap.
-    pub fn get_certificate_map(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::GetCertificateMap {
+    pub fn get_certificate_map(&self) -> super::builder::certificate_manager::GetCertificateMap {
         super::builder::certificate_manager::GetCertificateMap::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new CertificateMap in a given project and location.
@@ -252,10 +226,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_certificate_map(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::CreateCertificateMap {
         super::builder::certificate_manager::CreateCertificateMap::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a CertificateMap.
@@ -271,10 +243,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_certificate_map(
         &self,
-        certificate_map: impl Into<crate::model::CertificateMap>,
     ) -> super::builder::certificate_manager::UpdateCertificateMap {
         super::builder::certificate_manager::UpdateCertificateMap::new(self.inner.clone())
-            .set_certificate_map(certificate_map.into())
     }
 
     /// Deletes a single CertificateMap. A Certificate Map can't be deleted
@@ -292,28 +262,22 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_certificate_map(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::DeleteCertificateMap {
         super::builder::certificate_manager::DeleteCertificateMap::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists CertificateMapEntries in a given project and location.
     pub fn list_certificate_map_entries(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::ListCertificateMapEntries {
         super::builder::certificate_manager::ListCertificateMapEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CertificateMapEntry.
     pub fn get_certificate_map_entry(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::GetCertificateMapEntry {
         super::builder::certificate_manager::GetCertificateMapEntry::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new CertificateMapEntry in a given project and location.
@@ -329,10 +293,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_certificate_map_entry(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::CreateCertificateMapEntry {
         super::builder::certificate_manager::CreateCertificateMapEntry::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a CertificateMapEntry.
@@ -348,10 +310,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_certificate_map_entry(
         &self,
-        certificate_map_entry: impl Into<crate::model::CertificateMapEntry>,
     ) -> super::builder::certificate_manager::UpdateCertificateMapEntry {
         super::builder::certificate_manager::UpdateCertificateMapEntry::new(self.inner.clone())
-            .set_certificate_map_entry(certificate_map_entry.into())
     }
 
     /// Deletes a single CertificateMapEntry.
@@ -367,28 +327,22 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_certificate_map_entry(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::DeleteCertificateMapEntry {
         super::builder::certificate_manager::DeleteCertificateMapEntry::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DnsAuthorizations in a given project and location.
     pub fn list_dns_authorizations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::ListDnsAuthorizations {
         super::builder::certificate_manager::ListDnsAuthorizations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single DnsAuthorization.
     pub fn get_dns_authorization(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::GetDnsAuthorization {
         super::builder::certificate_manager::GetDnsAuthorization::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new DnsAuthorization in a given project and location.
@@ -404,10 +358,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_dns_authorization(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::CreateDnsAuthorization {
         super::builder::certificate_manager::CreateDnsAuthorization::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DnsAuthorization.
@@ -423,10 +375,8 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_dns_authorization(
         &self,
-        dns_authorization: impl Into<crate::model::DnsAuthorization>,
     ) -> super::builder::certificate_manager::UpdateDnsAuthorization {
         super::builder::certificate_manager::UpdateDnsAuthorization::new(self.inner.clone())
-            .set_dns_authorization(dns_authorization.into())
     }
 
     /// Deletes a single DnsAuthorization.
@@ -442,28 +392,22 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_dns_authorization(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::DeleteDnsAuthorization {
         super::builder::certificate_manager::DeleteDnsAuthorization::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists CertificateIssuanceConfigs in a given project and location.
     pub fn list_certificate_issuance_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::ListCertificateIssuanceConfigs {
         super::builder::certificate_manager::ListCertificateIssuanceConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CertificateIssuanceConfig.
     pub fn get_certificate_issuance_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::GetCertificateIssuanceConfig {
         super::builder::certificate_manager::GetCertificateIssuanceConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new CertificateIssuanceConfig in a given project and location.
@@ -479,12 +423,10 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_certificate_issuance_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::CreateCertificateIssuanceConfig {
         super::builder::certificate_manager::CreateCertificateIssuanceConfig::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Deletes a single CertificateIssuanceConfig.
@@ -500,30 +442,20 @@ impl CertificateManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_certificate_issuance_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_manager::DeleteCertificateIssuanceConfig {
         super::builder::certificate_manager::DeleteCertificateIssuanceConfig::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists TrustConfigs in a given project and location.
-    pub fn list_trust_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::ListTrustConfigs {
+    pub fn list_trust_configs(&self) -> super::builder::certificate_manager::ListTrustConfigs {
         super::builder::certificate_manager::ListTrustConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single TrustConfig.
-    pub fn get_trust_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::GetTrustConfig {
+    pub fn get_trust_config(&self) -> super::builder::certificate_manager::GetTrustConfig {
         super::builder::certificate_manager::GetTrustConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new TrustConfig in a given project and location.
@@ -537,12 +469,8 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_trust_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::CreateTrustConfig {
+    pub fn create_trust_config(&self) -> super::builder::certificate_manager::CreateTrustConfig {
         super::builder::certificate_manager::CreateTrustConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a TrustConfig.
@@ -556,12 +484,8 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_trust_config(
-        &self,
-        trust_config: impl Into<crate::model::TrustConfig>,
-    ) -> super::builder::certificate_manager::UpdateTrustConfig {
+    pub fn update_trust_config(&self) -> super::builder::certificate_manager::UpdateTrustConfig {
         super::builder::certificate_manager::UpdateTrustConfig::new(self.inner.clone())
-            .set_trust_config(trust_config.into())
     }
 
     /// Deletes a single TrustConfig.
@@ -575,73 +499,45 @@ impl CertificateManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_trust_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::DeleteTrustConfig {
+    pub fn delete_trust_config(&self) -> super::builder::certificate_manager::DeleteTrustConfig {
         super::builder::certificate_manager::DeleteTrustConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::certificate_manager::ListLocations {
         super::builder::certificate_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::GetLocation {
+    pub fn get_location(&self) -> super::builder::certificate_manager::GetLocation {
         super::builder::certificate_manager::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::certificate_manager::ListOperations {
         super::builder::certificate_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::certificate_manager::GetOperation {
         super::builder::certificate_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::certificate_manager::DeleteOperation {
         super::builder::certificate_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::certificate_manager::CancelOperation {
         super::builder::certificate_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::CertificateManager for CertificateManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate
+            let arg = &req
+                .certificate
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -270,10 +275,15 @@ impl super::stub::CertificateManager for CertificateManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate_map
+            let arg = &req
+                .certificate_map
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate_map"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate_map.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -410,10 +420,15 @@ impl super::stub::CertificateManager for CertificateManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate_map_entry
+            let arg = &req
+                .certificate_map_entry
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate_map_entry"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate_map_entry.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -550,10 +565,15 @@ impl super::stub::CertificateManager for CertificateManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dns_authorization
+            let arg = &req
+                .dns_authorization
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dns_authorization"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dns_authorization.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -802,10 +822,15 @@ impl super::stub::CertificateManager for CertificateManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.trust_config
+            let arg = &req
+                .trust_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("trust_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("trust_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,12 +186,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateMapsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateMaps", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +216,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateMap>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +242,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificateMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificateMaps", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,18 +269,15 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate_map
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate_map"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate_map
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate_map"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -269,9 +300,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,12 +326,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateMapEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateMapEntries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateMapEntries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,9 +356,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateMapEntry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -333,12 +382,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificateMapEntries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificateMapEntries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -356,18 +409,15 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate_map_entry
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate_map_entry"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate_map_entry
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate_map_entry"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -390,9 +440,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,12 +466,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDnsAuthorizationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dnsAuthorizations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dnsAuthorizations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -435,9 +496,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DnsAuthorization>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,12 +522,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dnsAuthorizations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dnsAuthorizations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,18 +549,15 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dns_authorization
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dns_authorization"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dns_authorization
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dns_authorization"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -511,9 +580,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -530,12 +606,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateIssuanceConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateIssuanceConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateIssuanceConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -556,9 +636,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateIssuanceConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -575,12 +662,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificateIssuanceConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificateIssuanceConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -601,9 +692,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -620,12 +718,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTrustConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/trustConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/trustConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -646,9 +748,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TrustConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -665,12 +774,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/trustConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/trustConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -688,18 +801,15 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.trust_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("trust_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.trust_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("trust_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -722,9 +832,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -742,9 +859,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -764,9 +888,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -783,9 +914,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -805,9 +943,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -824,9 +969,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -847,9 +999,16 @@ impl super::stub::CertificateManager for CertificateManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/chronicle/v1/src/client.rs
+++ b/src/generated/cloud/chronicle/v1/src/client.rs
@@ -129,37 +129,29 @@ impl DataAccessControlService {
     /// to UDM queries over event data.
     pub fn create_data_access_label(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::CreateDataAccessLabel {
         super::builder::data_access_control_service::CreateDataAccessLabel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a data access label.
     pub fn get_data_access_label(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::GetDataAccessLabel {
         super::builder::data_access_control_service::GetDataAccessLabel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all data access labels for the customer.
     pub fn list_data_access_labels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::ListDataAccessLabels {
         super::builder::data_access_control_service::ListDataAccessLabels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a data access label.
     pub fn update_data_access_label(
         &self,
-        data_access_label: impl Into<crate::model::DataAccessLabel>,
     ) -> super::builder::data_access_control_service::UpdateDataAccessLabel {
         super::builder::data_access_control_service::UpdateDataAccessLabel::new(self.inner.clone())
-            .set_data_access_label(data_access_label.into())
     }
 
     /// Deletes a data access label. When a label is deleted, new
@@ -167,10 +159,8 @@ impl DataAccessControlService {
     /// will not be removed from old data that still refers to it.
     pub fn delete_data_access_label(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::DeleteDataAccessLabel {
         super::builder::data_access_control_service::DeleteDataAccessLabel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a data access scope.
@@ -181,90 +171,64 @@ impl DataAccessControlService {
     /// not labeled with either C or D.
     pub fn create_data_access_scope(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::CreateDataAccessScope {
         super::builder::data_access_control_service::CreateDataAccessScope::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves an existing data access scope.
     pub fn get_data_access_scope(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::GetDataAccessScope {
         super::builder::data_access_control_service::GetDataAccessScope::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all existing data access scopes for the customer.
     pub fn list_data_access_scopes(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::ListDataAccessScopes {
         super::builder::data_access_control_service::ListDataAccessScopes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a data access scope.
     pub fn update_data_access_scope(
         &self,
-        data_access_scope: impl Into<crate::model::DataAccessScope>,
     ) -> super::builder::data_access_control_service::UpdateDataAccessScope {
         super::builder::data_access_control_service::UpdateDataAccessScope::new(self.inner.clone())
-            .set_data_access_scope(data_access_scope.into())
     }
 
     /// Deletes a data access scope.
     pub fn delete_data_access_scope(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_access_control_service::DeleteDataAccessScope {
         super::builder::data_access_control_service::DeleteDataAccessScope::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_access_control_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::data_access_control_service::ListOperations {
         super::builder::data_access_control_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_access_control_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::data_access_control_service::GetOperation {
         super::builder::data_access_control_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_access_control_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::data_access_control_service::DeleteOperation {
         super::builder::data_access_control_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_access_control_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::data_access_control_service::CancelOperation {
         super::builder::data_access_control_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -369,91 +333,57 @@ impl EntityService {
     }
 
     /// Gets watchlist details for the given watchlist ID.
-    pub fn get_watchlist(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::GetWatchlist {
-        super::builder::entity_service::GetWatchlist::new(self.inner.clone()).set_name(name.into())
+    pub fn get_watchlist(&self) -> super::builder::entity_service::GetWatchlist {
+        super::builder::entity_service::GetWatchlist::new(self.inner.clone())
     }
 
     /// Lists all watchlists for the given instance.
-    pub fn list_watchlists(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::ListWatchlists {
+    pub fn list_watchlists(&self) -> super::builder::entity_service::ListWatchlists {
         super::builder::entity_service::ListWatchlists::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a watchlist for the given instance.
     /// Note that there can be at most 200 watchlists per instance.
-    pub fn create_watchlist(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::CreateWatchlist {
+    pub fn create_watchlist(&self) -> super::builder::entity_service::CreateWatchlist {
         super::builder::entity_service::CreateWatchlist::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the watchlist for the given instance.
-    pub fn update_watchlist(
-        &self,
-        watchlist: impl Into<crate::model::Watchlist>,
-    ) -> super::builder::entity_service::UpdateWatchlist {
+    pub fn update_watchlist(&self) -> super::builder::entity_service::UpdateWatchlist {
         super::builder::entity_service::UpdateWatchlist::new(self.inner.clone())
-            .set_watchlist(watchlist.into())
     }
 
     /// Deletes the watchlist for the given instance.
-    pub fn delete_watchlist(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::DeleteWatchlist {
+    pub fn delete_watchlist(&self) -> super::builder::entity_service::DeleteWatchlist {
         super::builder::entity_service::DeleteWatchlist::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::entity_service::ListOperations {
         super::builder::entity_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::GetOperation {
-        super::builder::entity_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::entity_service::GetOperation {
+        super::builder::entity_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::entity_service::DeleteOperation {
         super::builder::entity_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::entity_service::CancelOperation {
         super::builder::entity_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -560,55 +490,36 @@ impl InstanceService {
     }
 
     /// Gets a Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_service::GetInstance {
-        super::builder::instance_service::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::instance_service::GetInstance {
+        super::builder::instance_service::GetInstance::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::instance_service::ListOperations {
         super::builder::instance_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::instance_service::GetOperation {
         super::builder::instance_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::instance_service::DeleteOperation {
         super::builder::instance_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::instance_service::CancelOperation {
         super::builder::instance_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -715,83 +626,57 @@ impl ReferenceListService {
     }
 
     /// Gets a single reference list.
-    pub fn get_reference_list(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reference_list_service::GetReferenceList {
+    pub fn get_reference_list(&self) -> super::builder::reference_list_service::GetReferenceList {
         super::builder::reference_list_service::GetReferenceList::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists a collection of reference lists.
     pub fn list_reference_lists(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reference_list_service::ListReferenceLists {
         super::builder::reference_list_service::ListReferenceLists::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new reference list.
     pub fn create_reference_list(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reference_list_service::CreateReferenceList {
         super::builder::reference_list_service::CreateReferenceList::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing reference list.
     pub fn update_reference_list(
         &self,
-        reference_list: impl Into<crate::model::ReferenceList>,
     ) -> super::builder::reference_list_service::UpdateReferenceList {
         super::builder::reference_list_service::UpdateReferenceList::new(self.inner.clone())
-            .set_reference_list(reference_list.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reference_list_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::reference_list_service::ListOperations {
         super::builder::reference_list_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reference_list_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::reference_list_service::GetOperation {
         super::builder::reference_list_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reference_list_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::reference_list_service::DeleteOperation {
         super::builder::reference_list_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reference_list_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::reference_list_service::CancelOperation {
         super::builder::reference_list_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -896,52 +781,33 @@ impl RuleService {
     }
 
     /// Creates a new Rule.
-    pub fn create_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::CreateRule {
-        super::builder::rule_service::CreateRule::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_rule(&self) -> super::builder::rule_service::CreateRule {
+        super::builder::rule_service::CreateRule::new(self.inner.clone())
     }
 
     /// Gets a Rule.
-    pub fn get_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::GetRule {
-        super::builder::rule_service::GetRule::new(self.inner.clone()).set_name(name.into())
+    pub fn get_rule(&self) -> super::builder::rule_service::GetRule {
+        super::builder::rule_service::GetRule::new(self.inner.clone())
     }
 
     /// Lists Rules.
-    pub fn list_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::ListRules {
-        super::builder::rule_service::ListRules::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_rules(&self) -> super::builder::rule_service::ListRules {
+        super::builder::rule_service::ListRules::new(self.inner.clone())
     }
 
     /// Updates a Rule.
-    pub fn update_rule(
-        &self,
-        rule: impl Into<crate::model::Rule>,
-    ) -> super::builder::rule_service::UpdateRule {
-        super::builder::rule_service::UpdateRule::new(self.inner.clone()).set_rule(rule.into())
+    pub fn update_rule(&self) -> super::builder::rule_service::UpdateRule {
+        super::builder::rule_service::UpdateRule::new(self.inner.clone())
     }
 
     /// Deletes a Rule.
-    pub fn delete_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::DeleteRule {
-        super::builder::rule_service::DeleteRule::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_rule(&self) -> super::builder::rule_service::DeleteRule {
+        super::builder::rule_service::DeleteRule::new(self.inner.clone())
     }
 
     /// Lists all revisions of the rule.
-    pub fn list_rule_revisions(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::ListRuleRevisions {
+    pub fn list_rule_revisions(&self) -> super::builder::rule_service::ListRuleRevisions {
         super::builder::rule_service::ListRuleRevisions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a Retrohunt.
@@ -955,98 +821,63 @@ impl RuleService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_retrohunt(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::CreateRetrohunt {
+    pub fn create_retrohunt(&self) -> super::builder::rule_service::CreateRetrohunt {
         super::builder::rule_service::CreateRetrohunt::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a Retrohunt.
-    pub fn get_retrohunt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::GetRetrohunt {
-        super::builder::rule_service::GetRetrohunt::new(self.inner.clone()).set_name(name.into())
+    pub fn get_retrohunt(&self) -> super::builder::rule_service::GetRetrohunt {
+        super::builder::rule_service::GetRetrohunt::new(self.inner.clone())
     }
 
     /// List Retrohunts.
-    pub fn list_retrohunts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::ListRetrohunts {
+    pub fn list_retrohunts(&self) -> super::builder::rule_service::ListRetrohunts {
         super::builder::rule_service::ListRetrohunts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a RuleDeployment.
-    pub fn get_rule_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::GetRuleDeployment {
+    pub fn get_rule_deployment(&self) -> super::builder::rule_service::GetRuleDeployment {
         super::builder::rule_service::GetRuleDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists RuleDeployments across all Rules.
-    pub fn list_rule_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::ListRuleDeployments {
+    pub fn list_rule_deployments(&self) -> super::builder::rule_service::ListRuleDeployments {
         super::builder::rule_service::ListRuleDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a RuleDeployment.
     /// Failures are not necessarily atomic. If there is a request to update
     /// multiple fields, and any update to a single field fails, an error will be
     /// returned, but other fields may remain successfully updated.
-    pub fn update_rule_deployment(
-        &self,
-        rule_deployment: impl Into<crate::model::RuleDeployment>,
-    ) -> super::builder::rule_service::UpdateRuleDeployment {
+    pub fn update_rule_deployment(&self) -> super::builder::rule_service::UpdateRuleDeployment {
         super::builder::rule_service::UpdateRuleDeployment::new(self.inner.clone())
-            .set_rule_deployment(rule_deployment.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::ListOperations {
-        super::builder::rule_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::rule_service::ListOperations {
+        super::builder::rule_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::GetOperation {
-        super::builder::rule_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::rule_service::GetOperation {
+        super::builder::rule_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::DeleteOperation {
-        super::builder::rule_service::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::rule_service::DeleteOperation {
+        super::builder::rule_service::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rule_service::CancelOperation {
-        super::builder::rule_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::rule_service::CancelOperation {
+        super::builder::rule_service::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/chronicle/v1/src/transport.rs
+++ b/src/generated/cloud/chronicle/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataAccessLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataAccessLabels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +73,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +99,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataAccessLabelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataAccessLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataAccessLabels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,18 +128,15 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_access_label
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_access_label"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_access_label
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_access_label"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -147,9 +159,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessScope>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataAccessScopes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataAccessScopes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +216,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessScope>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +242,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataAccessScopesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataAccessScopes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataAccessScopes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -237,18 +271,15 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAccessScope>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_access_scope
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_access_scope"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_access_scope
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_access_scope"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,9 +302,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,9 +332,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +361,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,9 +387,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,9 +417,16 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -403,9 +469,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Watchlist>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,12 +495,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWatchlistsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/watchlists", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/watchlists", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,12 +524,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Watchlist>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/watchlists", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/watchlists", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,18 +551,15 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Watchlist>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.watchlist
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("watchlist"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.watchlist
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("watchlist"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,9 +582,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -528,9 +613,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -550,9 +642,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -569,9 +668,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -592,9 +698,16 @@ impl super::stub::EntityService for EntityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -637,9 +750,16 @@ impl super::stub::InstanceService for InstanceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,9 +776,16 @@ impl super::stub::InstanceService for InstanceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -678,9 +805,16 @@ impl super::stub::InstanceService for InstanceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -697,9 +831,16 @@ impl super::stub::InstanceService for InstanceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -720,9 +861,16 @@ impl super::stub::InstanceService for InstanceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -765,9 +913,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReferenceList>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -785,12 +940,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReferenceListsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/referenceLists", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/referenceLists", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -810,12 +969,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReferenceList>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/referenceLists", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/referenceLists", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -833,18 +996,15 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReferenceList>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.reference_list
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("reference_list"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.reference_list
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("reference_list"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -867,9 +1027,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -889,9 +1056,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -908,9 +1082,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -931,9 +1112,16 @@ impl super::stub::ReferenceListService for ReferenceListService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -976,9 +1164,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/rules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/rules", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -993,9 +1188,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1013,9 +1215,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/rules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/rules", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1036,18 +1245,15 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1068,9 +1274,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1092,12 +1305,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuleRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1117,12 +1334,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/retrohunts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/retrohunts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1139,9 +1360,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Retrohunt>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1158,12 +1386,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRetrohuntsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/retrohunts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/retrohunts", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1183,9 +1415,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuleDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1202,12 +1441,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuleDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1227,18 +1470,15 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuleDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.rule_deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("rule_deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.rule_deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("rule_deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1261,9 +1501,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1283,9 +1530,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1302,9 +1556,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1325,9 +1586,16 @@ impl super::stub::RuleService for RuleService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/chronicle/v1/src/transport.rs
+++ b/src/generated/cloud/chronicle/v1/src/transport.rs
@@ -129,10 +129,15 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
     ) -> Result<gax::response::Response<crate::model::DataAccessLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_access_label
+            let arg = &req
+                .data_access_label
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_access_label"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_access_label.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -272,10 +277,15 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
     ) -> Result<gax::response::Response<crate::model::DataAccessScope>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_access_scope
+            let arg = &req
+                .data_access_scope
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_access_scope"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_access_scope.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -552,10 +562,15 @@ impl super::stub::EntityService for EntityService {
     ) -> Result<gax::response::Response<crate::model::Watchlist>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.watchlist
+            let arg = &req
+                .watchlist
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("watchlist"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("watchlist.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -997,10 +1012,15 @@ impl super::stub::ReferenceListService for ReferenceListService {
     ) -> Result<gax::response::Response<crate::model::ReferenceList>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.reference_list
+            let arg = &req
+                .reference_list
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("reference_list"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("reference_list.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1246,10 +1266,15 @@ impl super::stub::RuleService for RuleService {
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.rule
+            let arg = &req
+                .rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1471,10 +1496,15 @@ impl super::stub::RuleService for RuleService {
     ) -> Result<gax::response::Response<crate::model::RuleDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.rule_deployment
+            let arg = &req
+                .rule_deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("rule_deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rule_deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
@@ -121,57 +121,37 @@ impl CloudControlsPartnerCore {
     }
 
     /// Gets details of a single workload
-    pub fn get_workload(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::GetWorkload {
+    pub fn get_workload(&self) -> super::builder::cloud_controls_partner_core::GetWorkload {
         super::builder::cloud_controls_partner_core::GetWorkload::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists customer workloads for a given customer org id
-    pub fn list_workloads(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::ListWorkloads {
+    pub fn list_workloads(&self) -> super::builder::cloud_controls_partner_core::ListWorkloads {
         super::builder::cloud_controls_partner_core::ListWorkloads::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single customer
-    pub fn get_customer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::GetCustomer {
+    pub fn get_customer(&self) -> super::builder::cloud_controls_partner_core::GetCustomer {
         super::builder::cloud_controls_partner_core::GetCustomer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists customers of a partner identified by its Google Cloud organization ID
-    pub fn list_customers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::ListCustomers {
+    pub fn list_customers(&self) -> super::builder::cloud_controls_partner_core::ListCustomers {
         super::builder::cloud_controls_partner_core::ListCustomers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the EKM connections associated with a workload
     pub fn get_ekm_connections(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_controls_partner_core::GetEkmConnections {
         super::builder::cloud_controls_partner_core::GetEkmConnections::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the partner permissions granted for a workload
     pub fn get_partner_permissions(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_controls_partner_core::GetPartnerPermissions {
         super::builder::cloud_controls_partner_core::GetPartnerPermissions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deprecated: Only returns access approval requests directly associated with
@@ -179,48 +159,30 @@ impl CloudControlsPartnerCore {
     #[deprecated]
     pub fn list_access_approval_requests(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cloud_controls_partner_core::ListAccessApprovalRequests {
         super::builder::cloud_controls_partner_core::ListAccessApprovalRequests::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get details of a Partner.
-    pub fn get_partner(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::GetPartner {
+    pub fn get_partner(&self) -> super::builder::cloud_controls_partner_core::GetPartner {
         super::builder::cloud_controls_partner_core::GetPartner::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new customer.
-    pub fn create_customer(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::CreateCustomer {
+    pub fn create_customer(&self) -> super::builder::cloud_controls_partner_core::CreateCustomer {
         super::builder::cloud_controls_partner_core::CreateCustomer::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update details of a single customer
-    pub fn update_customer(
-        &self,
-        customer: impl Into<crate::model::Customer>,
-    ) -> super::builder::cloud_controls_partner_core::UpdateCustomer {
+    pub fn update_customer(&self) -> super::builder::cloud_controls_partner_core::UpdateCustomer {
         super::builder::cloud_controls_partner_core::UpdateCustomer::new(self.inner.clone())
-            .set_customer(customer.into())
     }
 
     /// Delete details of a single customer
-    pub fn delete_customer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_core::DeleteCustomer {
+    pub fn delete_customer(&self) -> super::builder::cloud_controls_partner_core::DeleteCustomer {
         super::builder::cloud_controls_partner_core::DeleteCustomer::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -335,18 +297,12 @@ impl CloudControlsPartnerMonitoring {
     /// `organizations/{organization}/locations/{location}/customers/{customer}/workloads/{workload}`
     pub fn list_violations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cloud_controls_partner_monitoring::ListViolations {
         super::builder::cloud_controls_partner_monitoring::ListViolations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Violation.
-    pub fn get_violation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_controls_partner_monitoring::GetViolation {
+    pub fn get_violation(&self) -> super::builder::cloud_controls_partner_monitoring::GetViolation {
         super::builder::cloud_controls_partner_monitoring::GetViolation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workload>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,12 +72,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkloadsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +102,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Customer>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,12 +128,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/customers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/customers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,9 +158,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConnections>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,9 +184,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PartnerPermissions>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +210,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAccessApprovalRequestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/accessApprovalRequests", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/accessApprovalRequests", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,9 +240,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Partner>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,12 +266,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Customer>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/customers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/customers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,18 +293,15 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Customer>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.customer
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("customer"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.customer
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("customer"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,9 +324,16 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,12 +377,16 @@ impl super::stub::CloudControlsPartnerMonitoring for CloudControlsPartnerMonitor
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListViolationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/violations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/violations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,9 +417,16 @@ impl super::stub::CloudControlsPartnerMonitoring for CloudControlsPartnerMonitor
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Violation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
@@ -294,10 +294,15 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
     ) -> Result<gax::response::Response<crate::model::Customer>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.customer
+            let arg = &req
+                .customer
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("customer"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("customer.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/clouddms/v1/src/client.rs
+++ b/src/generated/cloud/clouddms/v1/src/client.rs
@@ -121,21 +121,13 @@ impl DataMigrationService {
     }
 
     /// Lists migration jobs in a given project and location.
-    pub fn list_migration_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::ListMigrationJobs {
+    pub fn list_migration_jobs(&self) -> super::builder::data_migration_service::ListMigrationJobs {
         super::builder::data_migration_service::ListMigrationJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single migration job.
-    pub fn get_migration_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GetMigrationJob {
+    pub fn get_migration_job(&self) -> super::builder::data_migration_service::GetMigrationJob {
         super::builder::data_migration_service::GetMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new migration job in a given project and location.
@@ -151,10 +143,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_migration_job(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::CreateMigrationJob {
         super::builder::data_migration_service::CreateMigrationJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single migration job.
@@ -170,10 +160,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_migration_job(
         &self,
-        migration_job: impl Into<crate::model::MigrationJob>,
     ) -> super::builder::data_migration_service::UpdateMigrationJob {
         super::builder::data_migration_service::UpdateMigrationJob::new(self.inner.clone())
-            .set_migration_job(migration_job.into())
     }
 
     /// Deletes a single migration job.
@@ -189,10 +177,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_migration_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DeleteMigrationJob {
         super::builder::data_migration_service::DeleteMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Start an already created migration job.
@@ -206,12 +192,8 @@ impl DataMigrationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_migration_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::StartMigrationJob {
+    pub fn start_migration_job(&self) -> super::builder::data_migration_service::StartMigrationJob {
         super::builder::data_migration_service::StartMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stops a running migration job.
@@ -225,12 +207,8 @@ impl DataMigrationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_migration_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::StopMigrationJob {
+    pub fn stop_migration_job(&self) -> super::builder::data_migration_service::StopMigrationJob {
         super::builder::data_migration_service::StopMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resume a migration job that is currently stopped and is resumable (was
@@ -247,10 +225,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn resume_migration_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ResumeMigrationJob {
         super::builder::data_migration_service::ResumeMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Promote a migration job, stopping replication to the destination and
@@ -267,10 +243,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn promote_migration_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::PromoteMigrationJob {
         super::builder::data_migration_service::PromoteMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Verify a migration job, making sure the destination can reach the source
@@ -287,10 +261,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn verify_migration_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::VerifyMigrationJob {
         super::builder::data_migration_service::VerifyMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restart a stopped or failed migration job, resetting the destination
@@ -308,49 +280,37 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn restart_migration_job(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::RestartMigrationJob {
         super::builder::data_migration_service::RestartMigrationJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generate a SSH configuration script to configure the reverse SSH
     /// connectivity.
-    pub fn generate_ssh_script(
-        &self,
-        migration_job: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GenerateSshScript {
+    pub fn generate_ssh_script(&self) -> super::builder::data_migration_service::GenerateSshScript {
         super::builder::data_migration_service::GenerateSshScript::new(self.inner.clone())
-            .set_migration_job(migration_job.into())
     }
 
     /// Generate a TCP Proxy configuration script to configure a cloud-hosted VM
     /// running a TCP Proxy.
     pub fn generate_tcp_proxy_script(
         &self,
-        migration_job: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::GenerateTcpProxyScript {
         super::builder::data_migration_service::GenerateTcpProxyScript::new(self.inner.clone())
-            .set_migration_job(migration_job.into())
     }
 
     /// Retrieves a list of all connection profiles in a given project and
     /// location.
     pub fn list_connection_profiles(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ListConnectionProfiles {
         super::builder::data_migration_service::ListConnectionProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single connection profile.
     pub fn get_connection_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::GetConnectionProfile {
         super::builder::data_migration_service::GetConnectionProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new connection profile in a given project and location.
@@ -366,10 +326,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_connection_profile(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::CreateConnectionProfile {
         super::builder::data_migration_service::CreateConnectionProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update the configuration of a single connection profile.
@@ -385,10 +343,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_connection_profile(
         &self,
-        connection_profile: impl Into<crate::model::ConnectionProfile>,
     ) -> super::builder::data_migration_service::UpdateConnectionProfile {
         super::builder::data_migration_service::UpdateConnectionProfile::new(self.inner.clone())
-            .set_connection_profile(connection_profile.into())
     }
 
     /// Deletes a single Database Migration Service connection profile.
@@ -406,10 +362,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_connection_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DeleteConnectionProfile {
         super::builder::data_migration_service::DeleteConnectionProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new private connection in a given project and location.
@@ -425,28 +379,22 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_private_connection(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::CreatePrivateConnection {
         super::builder::data_migration_service::CreatePrivateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single private connection.
     pub fn get_private_connection(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::GetPrivateConnection {
         super::builder::data_migration_service::GetPrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves a list of private connections in a given project and location.
     pub fn list_private_connections(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ListPrivateConnections {
         super::builder::data_migration_service::ListPrivateConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Database Migration Service private connection.
@@ -462,28 +410,22 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_private_connection(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DeletePrivateConnection {
         super::builder::data_migration_service::DeletePrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets details of a single conversion workspace.
     pub fn get_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::GetConversionWorkspace {
         super::builder::data_migration_service::GetConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists conversion workspaces in a given project and location.
     pub fn list_conversion_workspaces(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ListConversionWorkspaces {
         super::builder::data_migration_service::ListConversionWorkspaces::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new conversion workspace in a given project and location.
@@ -499,10 +441,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_conversion_workspace(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::CreateConversionWorkspace {
         super::builder::data_migration_service::CreateConversionWorkspace::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single conversion workspace.
@@ -518,10 +458,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_conversion_workspace(
         &self,
-        conversion_workspace: impl Into<crate::model::ConversionWorkspace>,
     ) -> super::builder::data_migration_service::UpdateConversionWorkspace {
         super::builder::data_migration_service::UpdateConversionWorkspace::new(self.inner.clone())
-            .set_conversion_workspace(conversion_workspace.into())
     }
 
     /// Deletes a single conversion workspace.
@@ -537,46 +475,28 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DeleteConversionWorkspace {
         super::builder::data_migration_service::DeleteConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new mapping rule for a given conversion workspace.
-    pub fn create_mapping_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::CreateMappingRule {
+    pub fn create_mapping_rule(&self) -> super::builder::data_migration_service::CreateMappingRule {
         super::builder::data_migration_service::CreateMappingRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single mapping rule.
-    pub fn delete_mapping_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::DeleteMappingRule {
+    pub fn delete_mapping_rule(&self) -> super::builder::data_migration_service::DeleteMappingRule {
         super::builder::data_migration_service::DeleteMappingRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the mapping rules for a specific conversion workspace.
-    pub fn list_mapping_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::ListMappingRules {
+    pub fn list_mapping_rules(&self) -> super::builder::data_migration_service::ListMappingRules {
         super::builder::data_migration_service::ListMappingRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a mapping rule.
-    pub fn get_mapping_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GetMappingRule {
+    pub fn get_mapping_rule(&self) -> super::builder::data_migration_service::GetMappingRule {
         super::builder::data_migration_service::GetMappingRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports a snapshot of the source database into the
@@ -593,10 +513,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn seed_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::SeedConversionWorkspace {
         super::builder::data_migration_service::SeedConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports the mapping rules for a given conversion workspace.
@@ -613,10 +531,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_mapping_rules(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ImportMappingRules {
         super::builder::data_migration_service::ImportMappingRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a draft tree schema for the destination database.
@@ -632,10 +548,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn convert_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ConvertConversionWorkspace {
         super::builder::data_migration_service::ConvertConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Marks all the data in the conversion workspace as committed.
@@ -651,10 +565,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn commit_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::CommitConversionWorkspace {
         super::builder::data_migration_service::CommitConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rolls back a conversion workspace to the last committed snapshot.
@@ -670,10 +582,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn rollback_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::RollbackConversionWorkspace {
         super::builder::data_migration_service::RollbackConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Applies draft tree onto a specific destination database.
@@ -689,10 +599,8 @@ impl DataMigrationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn apply_conversion_workspace(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::ApplyConversionWorkspace {
         super::builder::data_migration_service::ApplyConversionWorkspace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Describes the database entities tree for a specific conversion workspace
@@ -703,10 +611,8 @@ impl DataMigrationService {
     /// simple data objects describing the structure of the client database.
     pub fn describe_database_entities(
         &self,
-        conversion_workspace: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DescribeDatabaseEntities {
         super::builder::data_migration_service::DescribeDatabaseEntities::new(self.inner.clone())
-            .set_conversion_workspace(conversion_workspace.into())
     }
 
     /// Searches/lists the background jobs for a specific
@@ -717,50 +623,34 @@ impl DataMigrationService {
     /// Instead, they are a way to expose the data plane jobs log.
     pub fn search_background_jobs(
         &self,
-        conversion_workspace: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::SearchBackgroundJobs {
         super::builder::data_migration_service::SearchBackgroundJobs::new(self.inner.clone())
-            .set_conversion_workspace(conversion_workspace.into())
     }
 
     /// Retrieves a list of committed revisions of a specific conversion
     /// workspace.
     pub fn describe_conversion_workspace_revisions(
         &self,
-        conversion_workspace: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::DescribeConversionWorkspaceRevisions {
         super::builder::data_migration_service::DescribeConversionWorkspaceRevisions::new(
             self.inner.clone(),
         )
-        .set_conversion_workspace(conversion_workspace.into())
     }
 
     /// Fetches a set of static IP addresses that need to be allowlisted by the
     /// customer when using the static-IP connectivity method.
-    pub fn fetch_static_ips(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::FetchStaticIps {
+    pub fn fetch_static_ips(&self) -> super::builder::data_migration_service::FetchStaticIps {
         super::builder::data_migration_service::FetchStaticIps::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::data_migration_service::ListLocations {
         super::builder::data_migration_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::data_migration_service::GetLocation {
         super::builder::data_migration_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -768,22 +658,14 @@ impl DataMigrationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::data_migration_service::SetIamPolicy {
         super::builder::data_migration_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::data_migration_service::GetIamPolicy {
         super::builder::data_migration_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -795,53 +677,35 @@ impl DataMigrationService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::data_migration_service::TestIamPermissions {
         super::builder::data_migration_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::data_migration_service::ListOperations {
         super::builder::data_migration_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::data_migration_service::GetOperation {
         super::builder::data_migration_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::data_migration_service::DeleteOperation {
         super::builder::data_migration_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_migration_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::data_migration_service::CancelOperation {
         super::builder::data_migration_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.migration_job
+            let arg = &req
+                .migration_job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("migration_job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migration_job.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -469,10 +474,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.connection_profile
+            let arg = &req
+                .connection_profile
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection_profile.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -726,10 +736,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.conversion_workspace
+            let arg = &req
+                .conversion_workspace
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("conversion_workspace"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversion_workspace.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMigrationJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/migrationJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/migrationJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/migrationJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/migrationJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.migration_job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("migration_job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.migration_job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("migration_job"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -171,9 +190,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -188,9 +214,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -205,9 +238,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,9 +262,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:promote", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:promote", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,9 +286,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:verify", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:verify", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,9 +310,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restart", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,12 +334,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SshScript>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateSshScript", {
+            let arg = &req.migration_job;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migration_job"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateSshScript", req.migration_job),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -293,12 +358,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TcpProxyScript>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateTcpProxyScript", {
+            let arg = &req.migration_job;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migration_job"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateTcpProxyScript", req.migration_job),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -313,12 +382,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectionProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectionProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -339,9 +412,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectionProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,12 +438,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connectionProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connectionProfiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,18 +468,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.connection_profile
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.connection_profile
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,9 +502,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -442,12 +530,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -467,9 +559,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PrivateConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,12 +585,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPrivateConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -512,9 +615,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,9 +642,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversionWorkspace>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -551,12 +668,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversionWorkspacesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/conversionWorkspaces", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/conversionWorkspaces", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -576,12 +697,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversionWorkspaces", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversionWorkspaces", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -600,18 +725,15 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.conversion_workspace
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("conversion_workspace"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.conversion_workspace
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("conversion_workspace"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -635,9 +757,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,12 +785,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MappingRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/mappingRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/mappingRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -680,9 +813,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -704,12 +844,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMappingRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/mappingRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/mappingRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -728,9 +872,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MappingRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -747,9 +898,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:seed", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:seed", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -764,12 +922,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/mappingRules:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/mappingRules:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -784,9 +946,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:convert", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:convert", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -801,9 +970,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:commit", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:commit", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -818,9 +994,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rollback", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -835,9 +1018,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:apply", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -852,12 +1042,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DescribeDatabaseEntitiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:describeDatabaseEntities", {
+            let arg = &req.conversion_workspace;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversion_workspace"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:describeDatabaseEntities", req.conversion_workspace),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -881,12 +1075,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchBackgroundJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:searchBackgroundJobs", {
+            let arg = &req.conversion_workspace;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversion_workspace"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:searchBackgroundJobs", req.conversion_workspace),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -919,15 +1117,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
     ) -> Result<gax::response::Response<crate::model::DescribeConversionWorkspaceRevisionsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:describeConversionWorkspaceRevisions", {
+            let arg = &req.conversion_workspace;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversion_workspace"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/{}:describeConversionWorkspaceRevisions",
-                    req.conversion_workspace
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -945,12 +1144,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchStaticIpsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchStaticIps", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchStaticIps", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -969,9 +1172,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -991,9 +1201,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1010,12 +1227,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1030,12 +1251,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1062,12 +1287,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1082,9 +1311,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1104,9 +1340,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1123,9 +1366,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1396,16 @@ impl super::stub::DataMigrationService for DataMigrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
@@ -121,59 +121,39 @@ impl LicenseManagementService {
     }
 
     /// Gets the license pool.
-    pub fn get_license_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_management_service::GetLicensePool {
+    pub fn get_license_pool(&self) -> super::builder::license_management_service::GetLicensePool {
         super::builder::license_management_service::GetLicensePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the license pool if one exists for this Order.
     pub fn update_license_pool(
         &self,
-        license_pool: impl Into<crate::model::LicensePool>,
     ) -> super::builder::license_management_service::UpdateLicensePool {
         super::builder::license_management_service::UpdateLicensePool::new(self.inner.clone())
-            .set_license_pool(license_pool.into())
     }
 
     /// Assigns a license to a user.
-    pub fn assign(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_management_service::Assign {
+    pub fn assign(&self) -> super::builder::license_management_service::Assign {
         super::builder::license_management_service::Assign::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Unassigns a license from a user.
-    pub fn unassign(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_management_service::Unassign {
+    pub fn unassign(&self) -> super::builder::license_management_service::Unassign {
         super::builder::license_management_service::Unassign::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Enumerates all users assigned a license.
     pub fn enumerate_licensed_users(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::license_management_service::EnumerateLicensedUsers {
         super::builder::license_management_service::EnumerateLicensedUsers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_management_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::license_management_service::GetOperation {
         super::builder::license_management_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -310,24 +290,16 @@ impl ConsumerProcurementService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn place_order(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::PlaceOrder {
+    pub fn place_order(&self) -> super::builder::consumer_procurement_service::PlaceOrder {
         super::builder::consumer_procurement_service::PlaceOrder::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the requested
     /// [Order][google.cloud.commerce.consumer.procurement.v1.Order] resource.
     ///
     /// [google.cloud.commerce.consumer.procurement.v1.Order]: crate::model::Order
-    pub fn get_order(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::GetOrder {
+    pub fn get_order(&self) -> super::builder::consumer_procurement_service::GetOrder {
         super::builder::consumer_procurement_service::GetOrder::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists [Order][google.cloud.commerce.consumer.procurement.v1.Order]
@@ -335,12 +307,8 @@ impl ConsumerProcurementService {
     /// resource.
     ///
     /// [google.cloud.commerce.consumer.procurement.v1.Order]: crate::model::Order
-    pub fn list_orders(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::ListOrders {
+    pub fn list_orders(&self) -> super::builder::consumer_procurement_service::ListOrders {
         super::builder::consumer_procurement_service::ListOrders::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies an existing
@@ -357,12 +325,8 @@ impl ConsumerProcurementService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn modify_order(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::ModifyOrder {
+    pub fn modify_order(&self) -> super::builder::consumer_procurement_service::ModifyOrder {
         super::builder::consumer_procurement_service::ModifyOrder::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels an existing
@@ -380,22 +344,14 @@ impl ConsumerProcurementService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn cancel_order(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::CancelOrder {
+    pub fn cancel_order(&self) -> super::builder::consumer_procurement_service::CancelOrder {
         super::builder::consumer_procurement_service::CancelOrder::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::consumer_procurement_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::consumer_procurement_service::GetOperation {
         super::builder::consumer_procurement_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -73,10 +73,15 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
     ) -> Result<gax::response::Response<crate::model::LicensePool>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.license_pool
+            let arg = &req
+                .license_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("license_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("license_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LicensePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,18 +72,15 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LicensePool>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.license_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("license_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.license_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("license_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -99,9 +103,16 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AssignResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:assign", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:assign", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,12 +127,16 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UnassignResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:unassign", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:unassign", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,12 +151,16 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumerateLicensedUsersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:enumerateLicensedUsers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:enumerateLicensedUsers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,9 +179,16 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,12 +228,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/orders:place", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/orders:place", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,9 +252,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Order>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,9 +278,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOrdersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/orders", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/orders", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -263,9 +307,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:modify", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:modify", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -280,9 +331,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,9 +355,16 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/confidentialcomputing/v1/src/client.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/client.rs
@@ -121,38 +121,22 @@ impl ConfidentialComputing {
     }
 
     /// Creates a new Challenge in a given project and location.
-    pub fn create_challenge(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::confidential_computing::CreateChallenge {
+    pub fn create_challenge(&self) -> super::builder::confidential_computing::CreateChallenge {
         super::builder::confidential_computing::CreateChallenge::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Verifies the provided attestation info, returning a signed OIDC token.
-    pub fn verify_attestation(
-        &self,
-        challenge: impl Into<std::string::String>,
-    ) -> super::builder::confidential_computing::VerifyAttestation {
+    pub fn verify_attestation(&self) -> super::builder::confidential_computing::VerifyAttestation {
         super::builder::confidential_computing::VerifyAttestation::new(self.inner.clone())
-            .set_challenge(challenge.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::confidential_computing::ListLocations {
+    pub fn list_locations(&self) -> super::builder::confidential_computing::ListLocations {
         super::builder::confidential_computing::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::confidential_computing::GetLocation {
+    pub fn get_location(&self) -> super::builder::confidential_computing::GetLocation {
         super::builder::confidential_computing::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Challenge>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/challenges", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/challenges", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,12 +72,16 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyAttestationResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:verifyAttestation", {
+            let arg = &req.challenge;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("challenge"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:verifyAttestation", req.challenge),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +96,16 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,9 +125,16 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/config/v1/src/client.rs
+++ b/src/generated/cloud/config/v1/src/client.rs
@@ -123,21 +123,15 @@ impl Config {
     /// and location.
     ///
     /// [google.cloud.config.v1.Deployment]: crate::model::Deployment
-    pub fn list_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ListDeployments {
-        super::builder::config::ListDeployments::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_deployments(&self) -> super::builder::config::ListDeployments {
+        super::builder::config::ListDeployments::new(self.inner.clone())
     }
 
     /// Gets details about a [Deployment][google.cloud.config.v1.Deployment].
     ///
     /// [google.cloud.config.v1.Deployment]: crate::model::Deployment
-    pub fn get_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetDeployment {
-        super::builder::config::GetDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_deployment(&self) -> super::builder::config::GetDeployment {
+        super::builder::config::GetDeployment::new(self.inner.clone())
     }
 
     /// Creates a [Deployment][google.cloud.config.v1.Deployment].
@@ -153,11 +147,8 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_deployment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::CreateDeployment {
-        super::builder::config::CreateDeployment::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_deployment(&self) -> super::builder::config::CreateDeployment {
+        super::builder::config::CreateDeployment::new(self.inner.clone())
     }
 
     /// Updates a [Deployment][google.cloud.config.v1.Deployment].
@@ -173,12 +164,8 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_deployment(
-        &self,
-        deployment: impl Into<crate::model::Deployment>,
-    ) -> super::builder::config::UpdateDeployment {
+    pub fn update_deployment(&self) -> super::builder::config::UpdateDeployment {
         super::builder::config::UpdateDeployment::new(self.inner.clone())
-            .set_deployment(deployment.into())
     }
 
     /// Deletes a [Deployment][google.cloud.config.v1.Deployment].
@@ -194,87 +181,58 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::DeleteDeployment {
-        super::builder::config::DeleteDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_deployment(&self) -> super::builder::config::DeleteDeployment {
+        super::builder::config::DeleteDeployment::new(self.inner.clone())
     }
 
     /// Lists [Revision][google.cloud.config.v1.Revision]s of a deployment.
     ///
     /// [google.cloud.config.v1.Revision]: crate::model::Revision
-    pub fn list_revisions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ListRevisions {
-        super::builder::config::ListRevisions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_revisions(&self) -> super::builder::config::ListRevisions {
+        super::builder::config::ListRevisions::new(self.inner.clone())
     }
 
     /// Gets details about a [Revision][google.cloud.config.v1.Revision].
     ///
     /// [google.cloud.config.v1.Revision]: crate::model::Revision
-    pub fn get_revision(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetRevision {
-        super::builder::config::GetRevision::new(self.inner.clone()).set_name(name.into())
+    pub fn get_revision(&self) -> super::builder::config::GetRevision {
+        super::builder::config::GetRevision::new(self.inner.clone())
     }
 
     /// Gets details about a [Resource][google.cloud.config.v1.Resource] deployed
     /// by Infra Manager.
     ///
     /// [google.cloud.config.v1.Resource]: crate::model::Resource
-    pub fn get_resource(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetResource {
-        super::builder::config::GetResource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_resource(&self) -> super::builder::config::GetResource {
+        super::builder::config::GetResource::new(self.inner.clone())
     }
 
     /// Lists [Resources][google.cloud.config.v1.Resource] in a given revision.
     ///
     /// [google.cloud.config.v1.Resource]: crate::model::Resource
-    pub fn list_resources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ListResources {
-        super::builder::config::ListResources::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_resources(&self) -> super::builder::config::ListResources {
+        super::builder::config::ListResources::new(self.inner.clone())
     }
 
     /// Exports Terraform state file from a given deployment.
-    pub fn export_deployment_statefile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ExportDeploymentStatefile {
+    pub fn export_deployment_statefile(&self) -> super::builder::config::ExportDeploymentStatefile {
         super::builder::config::ExportDeploymentStatefile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Exports Terraform state file from a given revision.
-    pub fn export_revision_statefile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ExportRevisionStatefile {
+    pub fn export_revision_statefile(&self) -> super::builder::config::ExportRevisionStatefile {
         super::builder::config::ExportRevisionStatefile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports Terraform state file in a given deployment. The state file does not
     /// take effect until the Deployment has been unlocked.
-    pub fn import_statefile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ImportStatefile {
-        super::builder::config::ImportStatefile::new(self.inner.clone()).set_parent(parent.into())
+    pub fn import_statefile(&self) -> super::builder::config::ImportStatefile {
+        super::builder::config::ImportStatefile::new(self.inner.clone())
     }
 
     /// Deletes Terraform state file in a given deployment.
-    pub fn delete_statefile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::DeleteStatefile {
-        super::builder::config::DeleteStatefile::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_statefile(&self) -> super::builder::config::DeleteStatefile {
+        super::builder::config::DeleteStatefile::new(self.inner.clone())
     }
 
     /// Locks a deployment.
@@ -288,11 +246,8 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn lock_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::LockDeployment {
-        super::builder::config::LockDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn lock_deployment(&self) -> super::builder::config::LockDeployment {
+        super::builder::config::LockDeployment::new(self.inner.clone())
     }
 
     /// Unlocks a locked deployment.
@@ -306,19 +261,13 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn unlock_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::UnlockDeployment {
-        super::builder::config::UnlockDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn unlock_deployment(&self) -> super::builder::config::UnlockDeployment {
+        super::builder::config::UnlockDeployment::new(self.inner.clone())
     }
 
     /// Exports the lock info on a locked deployment.
-    pub fn export_lock_info(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::ExportLockInfo {
-        super::builder::config::ExportLockInfo::new(self.inner.clone()).set_name(name.into())
+    pub fn export_lock_info(&self) -> super::builder::config::ExportLockInfo {
+        super::builder::config::ExportLockInfo::new(self.inner.clone())
     }
 
     /// Creates a [Preview][google.cloud.config.v1.Preview].
@@ -334,32 +283,23 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_preview(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::CreatePreview {
-        super::builder::config::CreatePreview::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_preview(&self) -> super::builder::config::CreatePreview {
+        super::builder::config::CreatePreview::new(self.inner.clone())
     }
 
     /// Gets details about a [Preview][google.cloud.config.v1.Preview].
     ///
     /// [google.cloud.config.v1.Preview]: crate::model::Preview
-    pub fn get_preview(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetPreview {
-        super::builder::config::GetPreview::new(self.inner.clone()).set_name(name.into())
+    pub fn get_preview(&self) -> super::builder::config::GetPreview {
+        super::builder::config::GetPreview::new(self.inner.clone())
     }
 
     /// Lists [Preview][google.cloud.config.v1.Preview]s in a given project and
     /// location.
     ///
     /// [google.cloud.config.v1.Preview]: crate::model::Preview
-    pub fn list_previews(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ListPreviews {
-        super::builder::config::ListPreviews::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_previews(&self) -> super::builder::config::ListPreviews {
+        super::builder::config::ListPreviews::new(self.inner.clone())
     }
 
     /// Deletes a [Preview][google.cloud.config.v1.Preview].
@@ -375,61 +315,41 @@ impl Config {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_preview(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::DeletePreview {
-        super::builder::config::DeletePreview::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_preview(&self) -> super::builder::config::DeletePreview {
+        super::builder::config::DeletePreview::new(self.inner.clone())
     }
 
     /// Export [Preview][google.cloud.config.v1.Preview] results.
     ///
     /// [google.cloud.config.v1.Preview]: crate::model::Preview
-    pub fn export_preview_result(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ExportPreviewResult {
+    pub fn export_preview_result(&self) -> super::builder::config::ExportPreviewResult {
         super::builder::config::ExportPreviewResult::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists [TerraformVersion][google.cloud.config.v1.TerraformVersion]s in a
     /// given project and location.
     ///
     /// [google.cloud.config.v1.TerraformVersion]: crate::model::TerraformVersion
-    pub fn list_terraform_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config::ListTerraformVersions {
+    pub fn list_terraform_versions(&self) -> super::builder::config::ListTerraformVersions {
         super::builder::config::ListTerraformVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details about a
     /// [TerraformVersion][google.cloud.config.v1.TerraformVersion].
     ///
     /// [google.cloud.config.v1.TerraformVersion]: crate::model::TerraformVersion
-    pub fn get_terraform_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetTerraformVersion {
-        super::builder::config::GetTerraformVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_terraform_version(&self) -> super::builder::config::GetTerraformVersion {
+        super::builder::config::GetTerraformVersion::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::ListLocations {
-        super::builder::config::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::config::ListLocations {
+        super::builder::config::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetLocation {
-        super::builder::config::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::config::GetLocation {
+        super::builder::config::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -437,20 +357,14 @@ impl Config {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::config::SetIamPolicy {
-        super::builder::config::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::config::SetIamPolicy {
+        super::builder::config::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::config::GetIamPolicy {
-        super::builder::config::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::config::GetIamPolicy {
+        super::builder::config::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -460,51 +374,35 @@ impl Config {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::config::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::config::TestIamPermissions {
         super::builder::config::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::ListOperations {
-        super::builder::config::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::config::ListOperations {
+        super::builder::config::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::GetOperation {
-        super::builder::config::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::config::GetOperation {
+        super::builder::config::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::DeleteOperation {
-        super::builder::config::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::config::DeleteOperation {
+        super::builder::config::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config::CancelOperation {
-        super::builder::config::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::config::CancelOperation {
+        super::builder::config::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::Config for Config {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.deployment
+            let arg = &req
+                .deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -172,12 +191,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/revisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/revisions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,9 +221,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Revision>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -217,9 +247,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Resource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,12 +273,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/resources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/resources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -262,12 +303,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Statefile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportState", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportState", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,12 +327,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Statefile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportState", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportState", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -302,12 +351,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Statefile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importState", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importState", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,12 +375,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deleteState", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:deleteState", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +404,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:lock", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:lock", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -364,9 +428,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:unlock", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:unlock", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -381,9 +452,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LockInfo>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:exportLock", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:exportLock", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -400,12 +478,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/previews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/previews", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -424,9 +506,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Preview>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,9 +532,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPreviewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/previews", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/previews", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -466,9 +562,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,9 +589,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExportPreviewResultResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -503,12 +613,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTerraformVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/terraformVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/terraformVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -529,9 +643,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TerraformVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -548,9 +669,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -570,9 +698,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -589,12 +724,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -609,12 +748,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -641,12 +784,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -661,9 +808,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -683,9 +837,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -702,9 +863,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -725,9 +893,16 @@ impl super::stub::Config for Config {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/connectors/v1/src/client.rs
+++ b/src/generated/cloud/connectors/v1/src/client.rs
@@ -119,20 +119,13 @@ impl Connectors {
     }
 
     /// Lists Connections in a given project and location.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListConnections {
+    pub fn list_connections(&self) -> super::builder::connectors::ListConnections {
         super::builder::connectors::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Connection.
-    pub fn get_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetConnection {
-        super::builder::connectors::GetConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn get_connection(&self) -> super::builder::connectors::GetConnection {
+        super::builder::connectors::GetConnection::new(self.inner.clone())
     }
 
     /// Creates a new Connection in a given project and location.
@@ -146,12 +139,8 @@ impl Connectors {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connectors::CreateConnection {
+    pub fn create_connection(&self) -> super::builder::connectors::CreateConnection {
         super::builder::connectors::CreateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Connection.
@@ -165,12 +154,8 @@ impl Connectors {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_connection(
-        &self,
-        connection: impl Into<crate::model::Connection>,
-    ) -> super::builder::connectors::UpdateConnection {
+    pub fn update_connection(&self) -> super::builder::connectors::UpdateConnection {
         super::builder::connectors::UpdateConnection::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// Deletes a single Connection.
@@ -184,72 +169,46 @@ impl Connectors {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::DeleteConnection {
-        super::builder::connectors::DeleteConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_connection(&self) -> super::builder::connectors::DeleteConnection {
+        super::builder::connectors::DeleteConnection::new(self.inner.clone())
     }
 
     /// Lists Providers in a given project and location.
-    pub fn list_providers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListProviders {
-        super::builder::connectors::ListProviders::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_providers(&self) -> super::builder::connectors::ListProviders {
+        super::builder::connectors::ListProviders::new(self.inner.clone())
     }
 
     /// Gets details of a provider.
-    pub fn get_provider(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetProvider {
-        super::builder::connectors::GetProvider::new(self.inner.clone()).set_name(name.into())
+    pub fn get_provider(&self) -> super::builder::connectors::GetProvider {
+        super::builder::connectors::GetProvider::new(self.inner.clone())
     }
 
     /// Lists Connectors in a given project and location.
-    pub fn list_connectors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListConnectors {
+    pub fn list_connectors(&self) -> super::builder::connectors::ListConnectors {
         super::builder::connectors::ListConnectors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Connector.
-    pub fn get_connector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetConnector {
-        super::builder::connectors::GetConnector::new(self.inner.clone()).set_name(name.into())
+    pub fn get_connector(&self) -> super::builder::connectors::GetConnector {
+        super::builder::connectors::GetConnector::new(self.inner.clone())
     }
 
     /// Lists Connector Versions in a given project and location.
-    pub fn list_connector_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListConnectorVersions {
+    pub fn list_connector_versions(&self) -> super::builder::connectors::ListConnectorVersions {
         super::builder::connectors::ListConnectorVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single connector version.
-    pub fn get_connector_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetConnectorVersion {
+    pub fn get_connector_version(&self) -> super::builder::connectors::GetConnectorVersion {
         super::builder::connectors::GetConnectorVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets schema metadata of a connection.
     /// SchemaMetadata is a singleton resource for each connection.
     pub fn get_connection_schema_metadata(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::connectors::GetConnectionSchemaMetadata {
         super::builder::connectors::GetConnectionSchemaMetadata::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Refresh runtime schema of a connection.
@@ -265,62 +224,44 @@ impl Connectors {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn refresh_connection_schema_metadata(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::connectors::RefreshConnectionSchemaMetadata {
         super::builder::connectors::RefreshConnectionSchemaMetadata::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List schema of a runtime entities filtered by entity name.
     pub fn list_runtime_entity_schemas(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::connectors::ListRuntimeEntitySchemas {
         super::builder::connectors::ListRuntimeEntitySchemas::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List schema of a runtime actions filtered by action name.
     pub fn list_runtime_action_schemas(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::connectors::ListRuntimeActionSchemas {
         super::builder::connectors::ListRuntimeActionSchemas::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the runtimeConfig of a location.
     /// RuntimeConfig is a singleton resource for each location.
-    pub fn get_runtime_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetRuntimeConfig {
-        super::builder::connectors::GetRuntimeConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_runtime_config(&self) -> super::builder::connectors::GetRuntimeConfig {
+        super::builder::connectors::GetRuntimeConfig::new(self.inner.clone())
     }
 
     /// GetGlobalSettings gets settings of a project.
     /// GlobalSettings is a singleton resource.
-    pub fn get_global_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetGlobalSettings {
-        super::builder::connectors::GetGlobalSettings::new(self.inner.clone()).set_name(name.into())
+    pub fn get_global_settings(&self) -> super::builder::connectors::GetGlobalSettings {
+        super::builder::connectors::GetGlobalSettings::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListLocations {
-        super::builder::connectors::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::connectors::ListLocations {
+        super::builder::connectors::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetLocation {
-        super::builder::connectors::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::connectors::GetLocation {
+        super::builder::connectors::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -328,22 +269,14 @@ impl Connectors {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connectors::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::connectors::SetIamPolicy {
         super::builder::connectors::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::connectors::GetIamPolicy {
         super::builder::connectors::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -353,50 +286,34 @@ impl Connectors {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::connectors::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::connectors::TestIamPermissions {
         super::builder::connectors::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists operations that match the specified filter in the request. If
     /// the server doesn't support this method, it returns `UNIMPLEMENTED`.
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::ListOperations {
-        super::builder::connectors::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::connectors::ListOperations {
+        super::builder::connectors::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::GetOperation {
-        super::builder::connectors::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::connectors::GetOperation {
+        super::builder::connectors::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::DeleteOperation {
-        super::builder::connectors::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::connectors::DeleteOperation {
+        super::builder::connectors::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::connectors::CancelOperation {
-        super::builder::connectors::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::connectors::CancelOperation {
+        super::builder::connectors::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::Connectors for Connectors {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.connection
+            let arg = &req
+                .connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -73,9 +77,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,12 +104,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +188,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProvidersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/providers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/providers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +216,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Provider>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +242,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,9 +270,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connector>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,9 +296,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectorVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,9 +325,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectorVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,9 +352,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectionSchemaMetadata>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +378,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:refresh", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:refresh", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -333,12 +402,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuntimeEntitySchemasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runtimeEntitySchemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/runtimeEntitySchemas", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,12 +431,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuntimeActionSchemasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runtimeActionSchemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/runtimeActionSchemas", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -383,9 +460,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuntimeConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,9 +486,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,9 +512,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,9 +541,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -462,12 +567,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -482,12 +591,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -514,12 +627,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -534,9 +651,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -556,9 +680,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -575,9 +706,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -598,9 +736,16 @@ impl super::stub::Connectors for Connectors {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/contactcenterinsights/v1/src/client.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/client.rs
@@ -125,10 +125,8 @@ impl ContactCenterInsights {
     /// Use `conversations.upload` instead.
     pub fn create_conversation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreateConversation {
         super::builder::contact_center_insights::CreateConversation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a long-running conversation upload operation. This method differs
@@ -146,46 +144,32 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn upload_conversation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::UploadConversation {
         super::builder::contact_center_insights::UploadConversation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a conversation.
     pub fn update_conversation(
         &self,
-        conversation: impl Into<crate::model::Conversation>,
     ) -> super::builder::contact_center_insights::UpdateConversation {
         super::builder::contact_center_insights::UpdateConversation::new(self.inner.clone())
-            .set_conversation(conversation.into())
     }
 
     /// Gets a conversation.
-    pub fn get_conversation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetConversation {
+    pub fn get_conversation(&self) -> super::builder::contact_center_insights::GetConversation {
         super::builder::contact_center_insights::GetConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists conversations.
-    pub fn list_conversations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListConversations {
+    pub fn list_conversations(&self) -> super::builder::contact_center_insights::ListConversations {
         super::builder::contact_center_insights::ListConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a conversation.
     pub fn delete_conversation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeleteConversation {
         super::builder::contact_center_insights::DeleteConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an analysis. The long running operation is done when the analysis
@@ -200,39 +184,23 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_analysis(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CreateAnalysis {
+    pub fn create_analysis(&self) -> super::builder::contact_center_insights::CreateAnalysis {
         super::builder::contact_center_insights::CreateAnalysis::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an analysis.
-    pub fn get_analysis(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetAnalysis {
+    pub fn get_analysis(&self) -> super::builder::contact_center_insights::GetAnalysis {
         super::builder::contact_center_insights::GetAnalysis::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists analyses.
-    pub fn list_analyses(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListAnalyses {
+    pub fn list_analyses(&self) -> super::builder::contact_center_insights::ListAnalyses {
         super::builder::contact_center_insights::ListAnalyses::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an analysis.
-    pub fn delete_analysis(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeleteAnalysis {
+    pub fn delete_analysis(&self) -> super::builder::contact_center_insights::DeleteAnalysis {
         super::builder::contact_center_insights::DeleteAnalysis::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Analyzes multiple conversations in a single request.
@@ -248,10 +216,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn bulk_analyze_conversations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::BulkAnalyzeConversations {
         super::builder::contact_center_insights::BulkAnalyzeConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes multiple conversations in a single request.
@@ -267,10 +233,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn bulk_delete_conversations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::BulkDeleteConversations {
         super::builder::contact_center_insights::BulkDeleteConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports conversations and processes them according to the user's
@@ -287,10 +251,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn ingest_conversations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::IngestConversations {
         super::builder::contact_center_insights::IngestConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Export insights data to a destination defined in the request body.
@@ -306,10 +268,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn export_insights_data(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ExportInsightsData {
         super::builder::contact_center_insights::ExportInsightsData::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an issue model.
@@ -323,39 +283,23 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_issue_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CreateIssueModel {
+    pub fn create_issue_model(&self) -> super::builder::contact_center_insights::CreateIssueModel {
         super::builder::contact_center_insights::CreateIssueModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an issue model.
-    pub fn update_issue_model(
-        &self,
-        issue_model: impl Into<crate::model::IssueModel>,
-    ) -> super::builder::contact_center_insights::UpdateIssueModel {
+    pub fn update_issue_model(&self) -> super::builder::contact_center_insights::UpdateIssueModel {
         super::builder::contact_center_insights::UpdateIssueModel::new(self.inner.clone())
-            .set_issue_model(issue_model.into())
     }
 
     /// Gets an issue model.
-    pub fn get_issue_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetIssueModel {
+    pub fn get_issue_model(&self) -> super::builder::contact_center_insights::GetIssueModel {
         super::builder::contact_center_insights::GetIssueModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists issue models.
-    pub fn list_issue_models(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListIssueModels {
+    pub fn list_issue_models(&self) -> super::builder::contact_center_insights::ListIssueModels {
         super::builder::contact_center_insights::ListIssueModels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an issue model.
@@ -369,12 +313,8 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_issue_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeleteIssueModel {
+    pub fn delete_issue_model(&self) -> super::builder::contact_center_insights::DeleteIssueModel {
         super::builder::contact_center_insights::DeleteIssueModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deploys an issue model. Returns an error if a model is already deployed.
@@ -389,12 +329,8 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn deploy_issue_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeployIssueModel {
+    pub fn deploy_issue_model(&self) -> super::builder::contact_center_insights::DeployIssueModel {
         super::builder::contact_center_insights::DeployIssueModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Undeploys an issue model.
@@ -411,10 +347,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn undeploy_issue_model(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::UndeployIssueModel {
         super::builder::contact_center_insights::UndeployIssueModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Exports an issue model to the provided destination.
@@ -428,12 +362,8 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_issue_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ExportIssueModel {
+    pub fn export_issue_model(&self) -> super::builder::contact_center_insights::ExportIssueModel {
         super::builder::contact_center_insights::ExportIssueModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports an issue model from a Cloud Storage bucket.
@@ -447,183 +377,123 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_issue_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ImportIssueModel {
+    pub fn import_issue_model(&self) -> super::builder::contact_center_insights::ImportIssueModel {
         super::builder::contact_center_insights::ImportIssueModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an issue.
-    pub fn get_issue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetIssue {
+    pub fn get_issue(&self) -> super::builder::contact_center_insights::GetIssue {
         super::builder::contact_center_insights::GetIssue::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists issues.
-    pub fn list_issues(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListIssues {
+    pub fn list_issues(&self) -> super::builder::contact_center_insights::ListIssues {
         super::builder::contact_center_insights::ListIssues::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an issue.
-    pub fn update_issue(
-        &self,
-        issue: impl Into<crate::model::Issue>,
-    ) -> super::builder::contact_center_insights::UpdateIssue {
+    pub fn update_issue(&self) -> super::builder::contact_center_insights::UpdateIssue {
         super::builder::contact_center_insights::UpdateIssue::new(self.inner.clone())
-            .set_issue(issue.into())
     }
 
     /// Deletes an issue.
-    pub fn delete_issue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeleteIssue {
+    pub fn delete_issue(&self) -> super::builder::contact_center_insights::DeleteIssue {
         super::builder::contact_center_insights::DeleteIssue::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets an issue model's statistics.
     pub fn calculate_issue_model_stats(
         &self,
-        issue_model: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CalculateIssueModelStats {
         super::builder::contact_center_insights::CalculateIssueModelStats::new(self.inner.clone())
-            .set_issue_model(issue_model.into())
     }
 
     /// Creates a phrase matcher.
     pub fn create_phrase_matcher(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreatePhraseMatcher {
         super::builder::contact_center_insights::CreatePhraseMatcher::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a phrase matcher.
-    pub fn get_phrase_matcher(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetPhraseMatcher {
+    pub fn get_phrase_matcher(&self) -> super::builder::contact_center_insights::GetPhraseMatcher {
         super::builder::contact_center_insights::GetPhraseMatcher::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists phrase matchers.
     pub fn list_phrase_matchers(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ListPhraseMatchers {
         super::builder::contact_center_insights::ListPhraseMatchers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a phrase matcher.
     pub fn delete_phrase_matcher(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeletePhraseMatcher {
         super::builder::contact_center_insights::DeletePhraseMatcher::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a phrase matcher.
     pub fn update_phrase_matcher(
         &self,
-        phrase_matcher: impl Into<crate::model::PhraseMatcher>,
     ) -> super::builder::contact_center_insights::UpdatePhraseMatcher {
         super::builder::contact_center_insights::UpdatePhraseMatcher::new(self.inner.clone())
-            .set_phrase_matcher(phrase_matcher.into())
     }
 
     /// Gets conversation statistics.
-    pub fn calculate_stats(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CalculateStats {
+    pub fn calculate_stats(&self) -> super::builder::contact_center_insights::CalculateStats {
         super::builder::contact_center_insights::CalculateStats::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Gets project-level settings.
-    pub fn get_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetSettings {
+    pub fn get_settings(&self) -> super::builder::contact_center_insights::GetSettings {
         super::builder::contact_center_insights::GetSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates project-level settings.
-    pub fn update_settings(
-        &self,
-        settings: impl Into<crate::model::Settings>,
-    ) -> super::builder::contact_center_insights::UpdateSettings {
+    pub fn update_settings(&self) -> super::builder::contact_center_insights::UpdateSettings {
         super::builder::contact_center_insights::UpdateSettings::new(self.inner.clone())
-            .set_settings(settings.into())
     }
 
     /// Creates a analysis rule.
     pub fn create_analysis_rule(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreateAnalysisRule {
         super::builder::contact_center_insights::CreateAnalysisRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a analysis rule.
-    pub fn get_analysis_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetAnalysisRule {
+    pub fn get_analysis_rule(&self) -> super::builder::contact_center_insights::GetAnalysisRule {
         super::builder::contact_center_insights::GetAnalysisRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists analysis rules.
     pub fn list_analysis_rules(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ListAnalysisRules {
         super::builder::contact_center_insights::ListAnalysisRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a analysis rule.
     pub fn update_analysis_rule(
         &self,
-        analysis_rule: impl Into<crate::model::AnalysisRule>,
     ) -> super::builder::contact_center_insights::UpdateAnalysisRule {
         super::builder::contact_center_insights::UpdateAnalysisRule::new(self.inner.clone())
-            .set_analysis_rule(analysis_rule.into())
     }
 
     /// Deletes a analysis rule.
     pub fn delete_analysis_rule(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeleteAnalysisRule {
         super::builder::contact_center_insights::DeleteAnalysisRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets location-level encryption key specification.
     pub fn get_encryption_spec(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::GetEncryptionSpec {
         super::builder::contact_center_insights::GetEncryptionSpec::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Initializes a location-level encryption key specification. An error will
@@ -643,55 +513,33 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn initialize_encryption_spec(
         &self,
-        encryption_spec: impl Into<crate::model::EncryptionSpec>,
     ) -> super::builder::contact_center_insights::InitializeEncryptionSpec {
         super::builder::contact_center_insights::InitializeEncryptionSpec::new(self.inner.clone())
-            .set_encryption_spec(encryption_spec.into())
     }
 
     /// Creates a view.
-    pub fn create_view(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CreateView {
+    pub fn create_view(&self) -> super::builder::contact_center_insights::CreateView {
         super::builder::contact_center_insights::CreateView::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a view.
-    pub fn get_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetView {
+    pub fn get_view(&self) -> super::builder::contact_center_insights::GetView {
         super::builder::contact_center_insights::GetView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists views.
-    pub fn list_views(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListViews {
+    pub fn list_views(&self) -> super::builder::contact_center_insights::ListViews {
         super::builder::contact_center_insights::ListViews::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a view.
-    pub fn update_view(
-        &self,
-        view: impl Into<crate::model::View>,
-    ) -> super::builder::contact_center_insights::UpdateView {
+    pub fn update_view(&self) -> super::builder::contact_center_insights::UpdateView {
         super::builder::contact_center_insights::UpdateView::new(self.inner.clone())
-            .set_view(view.into())
     }
 
     /// Deletes a view.
-    pub fn delete_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeleteView {
+    pub fn delete_view(&self) -> super::builder::contact_center_insights::DeleteView {
         super::builder::contact_center_insights::DeleteView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Query metrics.
@@ -705,120 +553,78 @@ impl ContactCenterInsights {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn query_metrics(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::QueryMetrics {
+    pub fn query_metrics(&self) -> super::builder::contact_center_insights::QueryMetrics {
         super::builder::contact_center_insights::QueryMetrics::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Create a QaQuestion.
-    pub fn create_qa_question(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CreateQaQuestion {
+    pub fn create_qa_question(&self) -> super::builder::contact_center_insights::CreateQaQuestion {
         super::builder::contact_center_insights::CreateQaQuestion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a QaQuestion.
-    pub fn get_qa_question(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetQaQuestion {
+    pub fn get_qa_question(&self) -> super::builder::contact_center_insights::GetQaQuestion {
         super::builder::contact_center_insights::GetQaQuestion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a QaQuestion.
-    pub fn update_qa_question(
-        &self,
-        qa_question: impl Into<crate::model::QaQuestion>,
-    ) -> super::builder::contact_center_insights::UpdateQaQuestion {
+    pub fn update_qa_question(&self) -> super::builder::contact_center_insights::UpdateQaQuestion {
         super::builder::contact_center_insights::UpdateQaQuestion::new(self.inner.clone())
-            .set_qa_question(qa_question.into())
     }
 
     /// Deletes a QaQuestion.
-    pub fn delete_qa_question(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::DeleteQaQuestion {
+    pub fn delete_qa_question(&self) -> super::builder::contact_center_insights::DeleteQaQuestion {
         super::builder::contact_center_insights::DeleteQaQuestion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists QaQuestions.
-    pub fn list_qa_questions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListQaQuestions {
+    pub fn list_qa_questions(&self) -> super::builder::contact_center_insights::ListQaQuestions {
         super::builder::contact_center_insights::ListQaQuestions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a QaScorecard.
     pub fn create_qa_scorecard(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreateQaScorecard {
         super::builder::contact_center_insights::CreateQaScorecard::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a QaScorecard.
-    pub fn get_qa_scorecard(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetQaScorecard {
+    pub fn get_qa_scorecard(&self) -> super::builder::contact_center_insights::GetQaScorecard {
         super::builder::contact_center_insights::GetQaScorecard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a QaScorecard.
     pub fn update_qa_scorecard(
         &self,
-        qa_scorecard: impl Into<crate::model::QaScorecard>,
     ) -> super::builder::contact_center_insights::UpdateQaScorecard {
         super::builder::contact_center_insights::UpdateQaScorecard::new(self.inner.clone())
-            .set_qa_scorecard(qa_scorecard.into())
     }
 
     /// Deletes a QaScorecard.
     pub fn delete_qa_scorecard(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeleteQaScorecard {
         super::builder::contact_center_insights::DeleteQaScorecard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists QaScorecards.
-    pub fn list_qa_scorecards(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListQaScorecards {
+    pub fn list_qa_scorecards(&self) -> super::builder::contact_center_insights::ListQaScorecards {
         super::builder::contact_center_insights::ListQaScorecards::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a QaScorecardRevision.
     pub fn create_qa_scorecard_revision(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreateQaScorecardRevision {
         super::builder::contact_center_insights::CreateQaScorecardRevision::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a QaScorecardRevision.
     pub fn get_qa_scorecard_revision(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::GetQaScorecardRevision {
         super::builder::contact_center_insights::GetQaScorecardRevision::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fine tune one or more QaModels.
@@ -834,102 +640,78 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn tune_qa_scorecard_revision(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::TuneQaScorecardRevision {
         super::builder::contact_center_insights::TuneQaScorecardRevision::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deploy a QaScorecardRevision.
     pub fn deploy_qa_scorecard_revision(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeployQaScorecardRevision {
         super::builder::contact_center_insights::DeployQaScorecardRevision::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Undeploy a QaScorecardRevision.
     pub fn undeploy_qa_scorecard_revision(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::UndeployQaScorecardRevision {
         super::builder::contact_center_insights::UndeployQaScorecardRevision::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Deletes a QaScorecardRevision.
     pub fn delete_qa_scorecard_revision(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeleteQaScorecardRevision {
         super::builder::contact_center_insights::DeleteQaScorecardRevision::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all revisions under the parent QaScorecard.
     pub fn list_qa_scorecard_revisions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ListQaScorecardRevisions {
         super::builder::contact_center_insights::ListQaScorecardRevisions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create feedback label.
     pub fn create_feedback_label(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::CreateFeedbackLabel {
         super::builder::contact_center_insights::CreateFeedbackLabel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List feedback labels.
     pub fn list_feedback_labels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ListFeedbackLabels {
         super::builder::contact_center_insights::ListFeedbackLabels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get feedback label.
-    pub fn get_feedback_label(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetFeedbackLabel {
+    pub fn get_feedback_label(&self) -> super::builder::contact_center_insights::GetFeedbackLabel {
         super::builder::contact_center_insights::GetFeedbackLabel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update feedback label.
     pub fn update_feedback_label(
         &self,
-        feedback_label: impl Into<crate::model::FeedbackLabel>,
     ) -> super::builder::contact_center_insights::UpdateFeedbackLabel {
         super::builder::contact_center_insights::UpdateFeedbackLabel::new(self.inner.clone())
-            .set_feedback_label(feedback_label.into())
     }
 
     /// Delete feedback label.
     pub fn delete_feedback_label(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::DeleteFeedbackLabel {
         super::builder::contact_center_insights::DeleteFeedbackLabel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List all feedback labels by project number.
     pub fn list_all_feedback_labels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::ListAllFeedbackLabels {
         super::builder::contact_center_insights::ListAllFeedbackLabels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Upload feedback labels in bulk.
@@ -945,10 +727,8 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn bulk_upload_feedback_labels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::BulkUploadFeedbackLabels {
         super::builder::contact_center_insights::BulkUploadFeedbackLabels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Download feedback labels in bulk.
@@ -964,42 +744,28 @@ impl ContactCenterInsights {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn bulk_download_feedback_labels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::contact_center_insights::BulkDownloadFeedbackLabels {
         super::builder::contact_center_insights::BulkDownloadFeedbackLabels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::ListOperations {
+    pub fn list_operations(&self) -> super::builder::contact_center_insights::ListOperations {
         super::builder::contact_center_insights::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::GetOperation {
+    pub fn get_operation(&self) -> super::builder::contact_center_insights::GetOperation {
         super::builder::contact_center_insights::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contact_center_insights::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::contact_center_insights::CancelOperation {
         super::builder::contact_center_insights::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +73,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations:upload", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations:upload", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,18 +97,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.conversation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.conversation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,9 +128,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -143,12 +155,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +186,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,12 +217,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/analyses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/analyses", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,9 +243,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Analysis>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,9 +269,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAnalysesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/analyses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/analyses", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -257,9 +298,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -280,12 +328,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations:bulkAnalyze", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations:bulkAnalyze", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,12 +352,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations:bulkDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations:bulkDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -320,12 +376,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations:ingest", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations:ingest", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -340,12 +400,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/insightsdata:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/insightsdata:export", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -360,12 +424,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/issueModels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/issueModels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -382,18 +450,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IssueModel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.issue_model
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("issue_model"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.issue_model
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("issue_model"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,9 +481,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IssueModel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -435,12 +507,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIssueModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/issueModels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/issueModels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -457,9 +533,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,9 +559,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -493,9 +583,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undeploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -510,9 +607,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -527,12 +631,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/issueModels:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/issueModels:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -547,9 +655,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Issue>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -566,9 +681,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIssuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/issues", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/issues", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -585,18 +707,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Issue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.issue
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("issue"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.issue
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("issue"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -617,9 +736,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -640,12 +766,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CalculateIssueModelStatsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:calculateIssueModelStats", {
+            let arg = &req.issue_model;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("issue_model"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:calculateIssueModelStats", req.issue_model),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -662,12 +792,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PhraseMatcher>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/phraseMatchers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/phraseMatchers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -684,9 +818,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PhraseMatcher>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -703,12 +844,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPhraseMatchersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/phraseMatchers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/phraseMatchers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -728,9 +873,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -751,18 +903,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PhraseMatcher>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.phrase_matcher
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("phrase_matcher"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.phrase_matcher
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("phrase_matcher"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -785,12 +934,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CalculateStatsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/conversations:calculateStats", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/conversations:calculateStats", req.location),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -808,9 +961,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -827,18 +987,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -861,12 +1018,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalysisRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/analysisRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/analysisRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -883,9 +1044,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalysisRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -902,12 +1070,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAnalysisRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/analysisRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/analysisRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -926,18 +1098,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalysisRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.analysis_rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("analysis_rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.analysis_rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("analysis_rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -960,9 +1129,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -983,9 +1159,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EncryptionSpec>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1002,18 +1185,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:initialize", {
+            &req.encryption_spec
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:initialize",
-                    req.encryption_spec
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1028,9 +1208,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::View>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/views", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/views", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1045,9 +1232,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::View>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1064,9 +1258,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/views", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/views", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1085,18 +1286,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::View>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.view
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("view"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.view
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("view"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1117,9 +1315,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1140,12 +1345,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:queryMetrics", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:queryMetrics", req.location),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1160,12 +1369,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaQuestion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/qaQuestions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/qaQuestions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1183,9 +1396,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaQuestion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1202,18 +1422,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaQuestion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.qa_question
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("qa_question"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.qa_question
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("qa_question"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1236,9 +1453,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1259,12 +1483,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQaQuestionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/qaQuestions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/qaQuestions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1283,12 +1511,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/qaScorecards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/qaScorecards", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1306,9 +1538,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecard>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1325,18 +1564,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.qa_scorecard
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("qa_scorecard"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.qa_scorecard
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("qa_scorecard"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1359,9 +1595,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1383,12 +1626,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQaScorecardsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/qaScorecards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/qaScorecards", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1407,12 +1654,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecardRevision>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/revisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/revisions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1430,9 +1681,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecardRevision>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1449,12 +1707,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:tuneQaScorecardRevision", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:tuneQaScorecardRevision", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1469,9 +1731,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecardRevision>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1486,9 +1755,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QaScorecardRevision>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undeploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1503,9 +1779,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1527,12 +1810,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQaScorecardRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/revisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/revisions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1552,12 +1839,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeedbackLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/feedbackLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/feedbackLabels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1575,12 +1866,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeedbackLabelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/feedbackLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/feedbackLabels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1600,9 +1895,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeedbackLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1619,18 +1921,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FeedbackLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.feedback_label
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("feedback_label"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.feedback_label
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("feedback_label"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1653,9 +1952,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1676,12 +1982,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAllFeedbackLabelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listAllFeedbackLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listAllFeedbackLabels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1701,12 +2011,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:bulkUploadFeedbackLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:bulkUploadFeedbackLabels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1721,12 +2035,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:bulkDownloadFeedbackLabels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:bulkDownloadFeedbackLabels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1741,9 +2059,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1763,9 +2088,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1782,9 +2114,16 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -98,10 +98,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.conversation
+            let arg = &req
+                .conversation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -451,10 +456,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::IssueModel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.issue_model
+            let arg = &req
+                .issue_model
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("issue_model"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("issue_model.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -708,10 +718,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::Issue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.issue
+            let arg = &req
+                .issue
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("issue"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("issue.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -904,10 +919,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::PhraseMatcher>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.phrase_matcher
+            let arg = &req
+                .phrase_matcher
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("phrase_matcher"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("phrase_matcher.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -988,10 +1008,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.settings
+            let arg = &req
+                .settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1099,10 +1124,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::AnalysisRule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.analysis_rule
+            let arg = &req
+                .analysis_rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("analysis_rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("analysis_rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1186,10 +1216,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}:initialize", {
-            &req.encryption_spec
+            let arg = &req
+                .encryption_spec
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("encryption_spec.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1287,10 +1322,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::View>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.view
+            let arg = &req
+                .view
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("view"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("view.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1423,10 +1463,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::QaQuestion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.qa_question
+            let arg = &req
+                .qa_question
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("qa_question"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("qa_question.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1565,10 +1610,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::QaScorecard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.qa_scorecard
+            let arg = &req
+                .qa_scorecard
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("qa_scorecard"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("qa_scorecard.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1922,10 +1972,15 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
     ) -> Result<gax::response::Response<crate::model::FeedbackLabel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.feedback_label
+            let arg = &req
+                .feedback_label
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("feedback_label"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("feedback_label.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
@@ -129,43 +129,29 @@ impl Lineage {
     /// <https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json>.
     pub fn process_open_lineage_run_event(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::lineage::ProcessOpenLineageRunEvent {
         super::builder::lineage::ProcessOpenLineageRunEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new process.
-    pub fn create_process(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::CreateProcess {
-        super::builder::lineage::CreateProcess::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_process(&self) -> super::builder::lineage::CreateProcess {
+        super::builder::lineage::CreateProcess::new(self.inner.clone())
     }
 
     /// Updates a process.
-    pub fn update_process(
-        &self,
-        process: impl Into<crate::model::Process>,
-    ) -> super::builder::lineage::UpdateProcess {
-        super::builder::lineage::UpdateProcess::new(self.inner.clone()).set_process(process.into())
+    pub fn update_process(&self) -> super::builder::lineage::UpdateProcess {
+        super::builder::lineage::UpdateProcess::new(self.inner.clone())
     }
 
     /// Gets the details of the specified process.
-    pub fn get_process(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::GetProcess {
-        super::builder::lineage::GetProcess::new(self.inner.clone()).set_name(name.into())
+    pub fn get_process(&self) -> super::builder::lineage::GetProcess {
+        super::builder::lineage::GetProcess::new(self.inner.clone())
     }
 
     /// List processes in the given project and location. List order is descending
     /// by insertion time.
-    pub fn list_processes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::ListProcesses {
-        super::builder::lineage::ListProcesses::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_processes(&self) -> super::builder::lineage::ListProcesses {
+        super::builder::lineage::ListProcesses::new(self.inner.clone())
     }
 
     /// Deletes the process with the specified name.
@@ -179,41 +165,29 @@ impl Lineage {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_process(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::DeleteProcess {
-        super::builder::lineage::DeleteProcess::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_process(&self) -> super::builder::lineage::DeleteProcess {
+        super::builder::lineage::DeleteProcess::new(self.inner.clone())
     }
 
     /// Creates a new run.
-    pub fn create_run(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::CreateRun {
-        super::builder::lineage::CreateRun::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_run(&self) -> super::builder::lineage::CreateRun {
+        super::builder::lineage::CreateRun::new(self.inner.clone())
     }
 
     /// Updates a run.
-    pub fn update_run(
-        &self,
-        run: impl Into<crate::model::Run>,
-    ) -> super::builder::lineage::UpdateRun {
-        super::builder::lineage::UpdateRun::new(self.inner.clone()).set_run(run.into())
+    pub fn update_run(&self) -> super::builder::lineage::UpdateRun {
+        super::builder::lineage::UpdateRun::new(self.inner.clone())
     }
 
     /// Gets the details of the specified run.
-    pub fn get_run(&self, name: impl Into<std::string::String>) -> super::builder::lineage::GetRun {
-        super::builder::lineage::GetRun::new(self.inner.clone()).set_name(name.into())
+    pub fn get_run(&self) -> super::builder::lineage::GetRun {
+        super::builder::lineage::GetRun::new(self.inner.clone())
     }
 
     /// Lists runs in the given project and location. List order is descending by
     /// `start_time`.
-    pub fn list_runs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::ListRuns {
-        super::builder::lineage::ListRuns::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_runs(&self) -> super::builder::lineage::ListRuns {
+        super::builder::lineage::ListRuns::new(self.inner.clone())
     }
 
     /// Deletes the run with the specified name.
@@ -227,46 +201,29 @@ impl Lineage {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::DeleteRun {
-        super::builder::lineage::DeleteRun::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_run(&self) -> super::builder::lineage::DeleteRun {
+        super::builder::lineage::DeleteRun::new(self.inner.clone())
     }
 
     /// Creates a new lineage event.
-    pub fn create_lineage_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::CreateLineageEvent {
+    pub fn create_lineage_event(&self) -> super::builder::lineage::CreateLineageEvent {
         super::builder::lineage::CreateLineageEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a specified lineage event.
-    pub fn get_lineage_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::GetLineageEvent {
-        super::builder::lineage::GetLineageEvent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_lineage_event(&self) -> super::builder::lineage::GetLineageEvent {
+        super::builder::lineage::GetLineageEvent::new(self.inner.clone())
     }
 
     /// Lists lineage events in the given project and location. The list order is
     /// not defined.
-    pub fn list_lineage_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::ListLineageEvents {
+    pub fn list_lineage_events(&self) -> super::builder::lineage::ListLineageEvents {
         super::builder::lineage::ListLineageEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the lineage event with the specified name.
-    pub fn delete_lineage_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::DeleteLineageEvent {
-        super::builder::lineage::DeleteLineageEvent::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_lineage_event(&self) -> super::builder::lineage::DeleteLineageEvent {
+        super::builder::lineage::DeleteLineageEvent::new(self.inner.clone())
     }
 
     /// Retrieve a list of links connected to a specific asset.
@@ -278,11 +235,8 @@ impl Lineage {
     /// You can retrieve links in every project where you have the
     /// `datalineage.events.get` permission. The project provided in the URL
     /// is used for Billing and Quota.
-    pub fn search_links(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::SearchLinks {
-        super::builder::lineage::SearchLinks::new(self.inner.clone()).set_parent(parent.into())
+    pub fn search_links(&self) -> super::builder::lineage::SearchLinks {
+        super::builder::lineage::SearchLinks::new(self.inner.clone())
     }
 
     /// Retrieve information about LineageProcesses associated with specific
@@ -301,51 +255,35 @@ impl Lineage {
     /// URL is used for Billing and Quota.
     ///
     /// [google.cloud.datacatalog.lineage.v1.Lineage.SearchLinks]: crate::client::Lineage::search_links
-    pub fn batch_search_link_processes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lineage::BatchSearchLinkProcesses {
+    pub fn batch_search_link_processes(&self) -> super::builder::lineage::BatchSearchLinkProcesses {
         super::builder::lineage::BatchSearchLinkProcesses::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::ListOperations {
-        super::builder::lineage::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::lineage::ListOperations {
+        super::builder::lineage::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::GetOperation {
-        super::builder::lineage::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::lineage::GetOperation {
+        super::builder::lineage::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::DeleteOperation {
-        super::builder::lineage::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::lineage::DeleteOperation {
+        super::builder::lineage::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lineage::CancelOperation {
-        super::builder::lineage::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::lineage::CancelOperation {
+        super::builder::lineage::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProcessOpenLineageRunEventResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:processOpenLineageRunEvent", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:processOpenLineageRunEvent", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +73,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Process>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/processes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/processes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,18 +100,15 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Process>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.process
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("process"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.process
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("process"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,9 +132,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Process>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -146,12 +158,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProcessesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/processes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/processes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +186,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,9 +213,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Run>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/runs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/runs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,18 +238,15 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Run>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.run
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("run"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.run
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("run"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,9 +268,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Run>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,9 +294,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/runs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/runs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -281,9 +322,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,12 +349,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LineageEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/lineageEvents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/lineageEvents", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,9 +376,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LineageEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -343,12 +402,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLineageEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/lineageEvents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/lineageEvents", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -367,9 +430,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -391,12 +461,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchLinksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchLinks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:searchLinks", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -411,12 +485,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchSearchLinkProcessesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchSearchLinkProcesses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchSearchLinkProcesses", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -431,9 +509,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -453,9 +538,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -472,9 +564,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -495,9 +594,16 @@ impl super::stub::Lineage for Lineage {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -101,10 +101,15 @@ impl super::stub::Lineage for Lineage {
     ) -> Result<gax::response::Response<crate::model::Process>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.process
+            let arg = &req
+                .process
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("process"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("process.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -239,10 +244,15 @@ impl super::stub::Lineage for Lineage {
     ) -> Result<gax::response::Response<crate::model::Run>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.run
+            let arg = &req
+                .run
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("run"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("run.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/datacatalog/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/v1/src/client.rs
@@ -170,21 +170,14 @@ impl DataCatalog {
     /// the `parent` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn create_entry_group(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::CreateEntryGroup {
+    pub fn create_entry_group(&self) -> super::builder::data_catalog::CreateEntryGroup {
         super::builder::data_catalog::CreateEntryGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an entry group.
     #[deprecated]
-    pub fn get_entry_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::GetEntryGroup {
-        super::builder::data_catalog::GetEntryGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entry_group(&self) -> super::builder::data_catalog::GetEntryGroup {
+        super::builder::data_catalog::GetEntryGroup::new(self.inner.clone())
     }
 
     /// Updates an entry group.
@@ -194,12 +187,8 @@ impl DataCatalog {
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn update_entry_group(
-        &self,
-        entry_group: impl Into<crate::model::EntryGroup>,
-    ) -> super::builder::data_catalog::UpdateEntryGroup {
+    pub fn update_entry_group(&self) -> super::builder::data_catalog::UpdateEntryGroup {
         super::builder::data_catalog::UpdateEntryGroup::new(self.inner.clone())
-            .set_entry_group(entry_group.into())
     }
 
     /// Deletes an entry group.
@@ -209,22 +198,14 @@ impl DataCatalog {
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn delete_entry_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::DeleteEntryGroup {
+    pub fn delete_entry_group(&self) -> super::builder::data_catalog::DeleteEntryGroup {
         super::builder::data_catalog::DeleteEntryGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists entry groups.
     #[deprecated]
-    pub fn list_entry_groups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ListEntryGroups {
+    pub fn list_entry_groups(&self) -> super::builder::data_catalog::ListEntryGroups {
         super::builder::data_catalog::ListEntryGroups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an entry.
@@ -239,11 +220,8 @@ impl DataCatalog {
     ///
     /// An entry group can have a maximum of 100,000 entries.
     #[deprecated]
-    pub fn create_entry(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::CreateEntry {
-        super::builder::data_catalog::CreateEntry::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_entry(&self) -> super::builder::data_catalog::CreateEntry {
+        super::builder::data_catalog::CreateEntry::new(self.inner.clone())
     }
 
     /// Updates an existing entry.
@@ -253,11 +231,8 @@ impl DataCatalog {
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn update_entry(
-        &self,
-        entry: impl Into<crate::model::Entry>,
-    ) -> super::builder::data_catalog::UpdateEntry {
-        super::builder::data_catalog::UpdateEntry::new(self.inner.clone()).set_entry(entry.into())
+    pub fn update_entry(&self) -> super::builder::data_catalog::UpdateEntry {
+        super::builder::data_catalog::UpdateEntry::new(self.inner.clone())
     }
 
     /// Deletes an existing entry.
@@ -273,20 +248,14 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.DataCatalog.CreateEntry]: crate::client::DataCatalog::create_entry
     #[deprecated]
-    pub fn delete_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::DeleteEntry {
-        super::builder::data_catalog::DeleteEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_entry(&self) -> super::builder::data_catalog::DeleteEntry {
+        super::builder::data_catalog::DeleteEntry::new(self.inner.clone())
     }
 
     /// Gets an entry.
     #[deprecated]
-    pub fn get_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::GetEntry {
-        super::builder::data_catalog::GetEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entry(&self) -> super::builder::data_catalog::GetEntry {
+        super::builder::data_catalog::GetEntry::new(self.inner.clone())
     }
 
     /// Gets an entry by its target resource name.
@@ -305,11 +274,8 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.DataCatalog.SearchCatalog]: crate::client::DataCatalog::search_catalog
     #[deprecated]
-    pub fn list_entries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ListEntries {
-        super::builder::data_catalog::ListEntries::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_entries(&self) -> super::builder::data_catalog::ListEntries {
+        super::builder::data_catalog::ListEntries::new(self.inner.clone())
     }
 
     /// Modifies entry overview, part of the business context of an
@@ -320,12 +286,8 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     #[deprecated]
-    pub fn modify_entry_overview(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ModifyEntryOverview {
+    pub fn modify_entry_overview(&self) -> super::builder::data_catalog::ModifyEntryOverview {
         super::builder::data_catalog::ModifyEntryOverview::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Modifies contacts, part of the business context of an
@@ -336,12 +298,8 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     #[deprecated]
-    pub fn modify_entry_contacts(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ModifyEntryContacts {
+    pub fn modify_entry_contacts(&self) -> super::builder::data_catalog::ModifyEntryContacts {
         super::builder::data_catalog::ModifyEntryContacts::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a tag template.
@@ -351,21 +309,14 @@ impl DataCatalog {
     /// For more information, see [Data Catalog resource project]
     /// (<https://cloud.google.com/data-catalog/docs/concepts/resource-project>).
     #[deprecated]
-    pub fn create_tag_template(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::CreateTagTemplate {
+    pub fn create_tag_template(&self) -> super::builder::data_catalog::CreateTagTemplate {
         super::builder::data_catalog::CreateTagTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a tag template.
     #[deprecated]
-    pub fn get_tag_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::GetTagTemplate {
-        super::builder::data_catalog::GetTagTemplate::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tag_template(&self) -> super::builder::data_catalog::GetTagTemplate {
+        super::builder::data_catalog::GetTagTemplate::new(self.inner.clone())
     }
 
     /// Updates a tag template.
@@ -378,12 +329,8 @@ impl DataCatalog {
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn update_tag_template(
-        &self,
-        tag_template: impl Into<crate::model::TagTemplate>,
-    ) -> super::builder::data_catalog::UpdateTagTemplate {
+    pub fn update_tag_template(&self) -> super::builder::data_catalog::UpdateTagTemplate {
         super::builder::data_catalog::UpdateTagTemplate::new(self.inner.clone())
-            .set_tag_template(tag_template.into())
     }
 
     /// Deletes a tag template and all tags that use it.
@@ -392,12 +339,8 @@ impl DataCatalog {
     /// the `name` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     #[deprecated]
-    pub fn delete_tag_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::DeleteTagTemplate {
+    pub fn delete_tag_template(&self) -> super::builder::data_catalog::DeleteTagTemplate {
         super::builder::data_catalog::DeleteTagTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a field in a tag template.
@@ -408,10 +351,8 @@ impl DataCatalog {
     #[deprecated]
     pub fn create_tag_template_field(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::CreateTagTemplateField {
         super::builder::data_catalog::CreateTagTemplateField::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a field in a tag template.
@@ -425,10 +366,8 @@ impl DataCatalog {
     #[deprecated]
     pub fn update_tag_template_field(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::UpdateTagTemplateField {
         super::builder::data_catalog::UpdateTagTemplateField::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Renames a field in a tag template.
@@ -439,10 +378,8 @@ impl DataCatalog {
     #[deprecated]
     pub fn rename_tag_template_field(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::RenameTagTemplateField {
         super::builder::data_catalog::RenameTagTemplateField::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Renames an enum value in a tag template.
@@ -451,10 +388,8 @@ impl DataCatalog {
     #[deprecated]
     pub fn rename_tag_template_field_enum_value(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::RenameTagTemplateFieldEnumValue {
         super::builder::data_catalog::RenameTagTemplateFieldEnumValue::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a field in a tag template and all uses of this field from the tags
@@ -466,10 +401,8 @@ impl DataCatalog {
     #[deprecated]
     pub fn delete_tag_template_field(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::DeleteTagTemplateField {
         super::builder::data_catalog::DeleteTagTemplateField::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a tag and assigns it to:
@@ -488,29 +421,20 @@ impl DataCatalog {
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     /// [google.cloud.datacatalog.v1.EntryGroup]: crate::model::EntryGroup
     #[deprecated]
-    pub fn create_tag(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::CreateTag {
-        super::builder::data_catalog::CreateTag::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_tag(&self) -> super::builder::data_catalog::CreateTag {
+        super::builder::data_catalog::CreateTag::new(self.inner.clone())
     }
 
     /// Updates an existing tag.
     #[deprecated]
-    pub fn update_tag(
-        &self,
-        tag: impl Into<crate::model::Tag>,
-    ) -> super::builder::data_catalog::UpdateTag {
-        super::builder::data_catalog::UpdateTag::new(self.inner.clone()).set_tag(tag.into())
+    pub fn update_tag(&self) -> super::builder::data_catalog::UpdateTag {
+        super::builder::data_catalog::UpdateTag::new(self.inner.clone())
     }
 
     /// Deletes a tag.
     #[deprecated]
-    pub fn delete_tag(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::DeleteTag {
-        super::builder::data_catalog::DeleteTag::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tag(&self) -> super::builder::data_catalog::DeleteTag {
+        super::builder::data_catalog::DeleteTag::new(self.inner.clone())
     }
 
     /// Lists tags assigned to an [Entry][google.cloud.datacatalog.v1.Entry].
@@ -520,11 +444,8 @@ impl DataCatalog {
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     /// [google.cloud.datacatalog.v1.Tag.column]: crate::model::Tag::scope
     #[deprecated]
-    pub fn list_tags(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ListTags {
-        super::builder::data_catalog::ListTags::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_tags(&self) -> super::builder::data_catalog::ListTags {
+        super::builder::data_catalog::ListTags::new(self.inner.clone())
     }
 
     /// `ReconcileTags` creates or updates a list of tags on the entry.
@@ -553,12 +474,8 @@ impl DataCatalog {
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     #[deprecated]
-    pub fn reconcile_tags(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ReconcileTags {
+    pub fn reconcile_tags(&self) -> super::builder::data_catalog::ReconcileTags {
         super::builder::data_catalog::ReconcileTags::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Marks an [Entry][google.cloud.datacatalog.v1.Entry] as starred by
@@ -566,11 +483,8 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     #[deprecated]
-    pub fn star_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::StarEntry {
-        super::builder::data_catalog::StarEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn star_entry(&self) -> super::builder::data_catalog::StarEntry {
+        super::builder::data_catalog::StarEntry::new(self.inner.clone())
     }
 
     /// Marks an [Entry][google.cloud.datacatalog.v1.Entry] as NOT starred by
@@ -578,11 +492,8 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     #[deprecated]
-    pub fn unstar_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::UnstarEntry {
-        super::builder::data_catalog::UnstarEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn unstar_entry(&self) -> super::builder::data_catalog::UnstarEntry {
+        super::builder::data_catalog::UnstarEntry::new(self.inner.clone())
     }
 
     /// Sets an access control policy for a resource. Replaces any existing
@@ -603,12 +514,8 @@ impl DataCatalog {
     ///   templates.
     /// - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
     #[deprecated]
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::data_catalog::SetIamPolicy {
         super::builder::data_catalog::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource.
@@ -633,12 +540,8 @@ impl DataCatalog {
     ///   templates.
     /// - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
     #[deprecated]
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::data_catalog::GetIamPolicy {
         super::builder::data_catalog::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets your permissions on a resource.
@@ -656,12 +559,8 @@ impl DataCatalog {
     ///
     /// No Google IAM permissions are required to call this method.
     #[deprecated]
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::data_catalog::TestIamPermissions {
         super::builder::data_catalog::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Imports entries from a source, such as data previously dumped into a
@@ -697,33 +596,23 @@ impl DataCatalog {
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     #[deprecated]
-    pub fn import_entries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ImportEntries {
+    pub fn import_entries(&self) -> super::builder::data_catalog::ImportEntries {
         super::builder::data_catalog::ImportEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Sets the configuration related to the migration to Dataplex for an
     /// organization or project.
     #[deprecated]
-    pub fn set_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::SetConfig {
-        super::builder::data_catalog::SetConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn set_config(&self) -> super::builder::data_catalog::SetConfig {
+        super::builder::data_catalog::SetConfig::new(self.inner.clone())
     }
 
     /// Retrieves the configuration related to the migration from Data Catalog to
     /// Dataplex for a specific organization, including all the projects under it
     /// which have a separate configuration set.
     #[deprecated]
-    pub fn retrieve_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::RetrieveConfig {
-        super::builder::data_catalog::RetrieveConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn retrieve_config(&self) -> super::builder::data_catalog::RetrieveConfig {
+        super::builder::data_catalog::RetrieveConfig::new(self.inner.clone())
     }
 
     /// Retrieves the effective configuration related to the migration from Data
@@ -734,50 +623,36 @@ impl DataCatalog {
     #[deprecated]
     pub fn retrieve_effective_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_catalog::RetrieveEffectiveConfig {
         super::builder::data_catalog::RetrieveEffectiveConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::ListOperations {
-        super::builder::data_catalog::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::data_catalog::ListOperations {
+        super::builder::data_catalog::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::GetOperation {
-        super::builder::data_catalog::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::data_catalog::GetOperation {
+        super::builder::data_catalog::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::DeleteOperation {
-        super::builder::data_catalog::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::data_catalog::DeleteOperation {
+        super::builder::data_catalog::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_catalog::CancelOperation {
-        super::builder::data_catalog::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::data_catalog::CancelOperation {
+        super::builder::data_catalog::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -891,61 +766,37 @@ impl PolicyTagManager {
     /// Creates a taxonomy in a specified project.
     ///
     /// The taxonomy is initially empty, that is, it doesn't contain policy tags.
-    pub fn create_taxonomy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::CreateTaxonomy {
+    pub fn create_taxonomy(&self) -> super::builder::policy_tag_manager::CreateTaxonomy {
         super::builder::policy_tag_manager::CreateTaxonomy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a taxonomy, including all policy tags in this
     /// taxonomy, their associated policies, and the policy tags references from
     /// BigQuery columns.
-    pub fn delete_taxonomy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::DeleteTaxonomy {
+    pub fn delete_taxonomy(&self) -> super::builder::policy_tag_manager::DeleteTaxonomy {
         super::builder::policy_tag_manager::DeleteTaxonomy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a taxonomy, including its display name,
     /// description, and activated policy types.
-    pub fn update_taxonomy(
-        &self,
-        taxonomy: impl Into<crate::model::Taxonomy>,
-    ) -> super::builder::policy_tag_manager::UpdateTaxonomy {
+    pub fn update_taxonomy(&self) -> super::builder::policy_tag_manager::UpdateTaxonomy {
         super::builder::policy_tag_manager::UpdateTaxonomy::new(self.inner.clone())
-            .set_taxonomy(taxonomy.into())
     }
 
     /// Lists all taxonomies in a project in a particular location that you
     /// have a permission to view.
-    pub fn list_taxonomies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::ListTaxonomies {
+    pub fn list_taxonomies(&self) -> super::builder::policy_tag_manager::ListTaxonomies {
         super::builder::policy_tag_manager::ListTaxonomies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a taxonomy.
-    pub fn get_taxonomy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::GetTaxonomy {
+    pub fn get_taxonomy(&self) -> super::builder::policy_tag_manager::GetTaxonomy {
         super::builder::policy_tag_manager::GetTaxonomy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a policy tag in a taxonomy.
-    pub fn create_policy_tag(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::CreatePolicyTag {
+    pub fn create_policy_tag(&self) -> super::builder::policy_tag_manager::CreatePolicyTag {
         super::builder::policy_tag_manager::CreatePolicyTag::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a policy tag together with the following:
@@ -954,112 +805,68 @@ impl PolicyTagManager {
     /// * Policies associated with the policy tag and its descendants
     /// * References from BigQuery table schema of the policy tag and its
     ///   descendants
-    pub fn delete_policy_tag(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::DeletePolicyTag {
+    pub fn delete_policy_tag(&self) -> super::builder::policy_tag_manager::DeletePolicyTag {
         super::builder::policy_tag_manager::DeletePolicyTag::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a policy tag, including its display
     /// name, description, and parent policy tag.
-    pub fn update_policy_tag(
-        &self,
-        policy_tag: impl Into<crate::model::PolicyTag>,
-    ) -> super::builder::policy_tag_manager::UpdatePolicyTag {
+    pub fn update_policy_tag(&self) -> super::builder::policy_tag_manager::UpdatePolicyTag {
         super::builder::policy_tag_manager::UpdatePolicyTag::new(self.inner.clone())
-            .set_policy_tag(policy_tag.into())
     }
 
     /// Lists all policy tags in a taxonomy.
-    pub fn list_policy_tags(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::ListPolicyTags {
+    pub fn list_policy_tags(&self) -> super::builder::policy_tag_manager::ListPolicyTags {
         super::builder::policy_tag_manager::ListPolicyTags::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a policy tag.
-    pub fn get_policy_tag(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::GetPolicyTag {
+    pub fn get_policy_tag(&self) -> super::builder::policy_tag_manager::GetPolicyTag {
         super::builder::policy_tag_manager::GetPolicyTag::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the IAM policy for a policy tag or a taxonomy.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::policy_tag_manager::GetIamPolicy {
         super::builder::policy_tag_manager::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM policy for a policy tag or a taxonomy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::policy_tag_manager::SetIamPolicy {
         super::builder::policy_tag_manager::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns your permissions on a specified policy tag or
     /// taxonomy.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::policy_tag_manager::TestIamPermissions {
         super::builder::policy_tag_manager::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::policy_tag_manager::ListOperations {
         super::builder::policy_tag_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::policy_tag_manager::GetOperation {
         super::builder::policy_tag_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::policy_tag_manager::DeleteOperation {
         super::builder::policy_tag_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::policy_tag_manager::CancelOperation {
         super::builder::policy_tag_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1183,10 +990,8 @@ impl PolicyTagManagerSerialization {
     /// - Updates policy tags with valid resources names accordingly.
     pub fn replace_taxonomy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::ReplaceTaxonomy {
         super::builder::policy_tag_manager_serialization::ReplaceTaxonomy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates new taxonomies (including their policy tags) in a given project
@@ -1199,10 +1004,8 @@ impl PolicyTagManagerSerialization {
     /// nested protocol buffer structures.
     pub fn import_taxonomies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::ImportTaxonomies {
         super::builder::policy_tag_manager_serialization::ImportTaxonomies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Exports taxonomies in the requested type and returns them,
@@ -1213,10 +1016,8 @@ impl PolicyTagManagerSerialization {
     /// policy tags that can be used as input for `ImportTaxonomies` calls.
     pub fn export_taxonomies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::ExportTaxonomies {
         super::builder::policy_tag_manager_serialization::ExportTaxonomies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1224,21 +1025,15 @@ impl PolicyTagManagerSerialization {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::ListOperations {
         super::builder::policy_tag_manager_serialization::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_tag_manager_serialization::GetOperation {
+    pub fn get_operation(&self) -> super::builder::policy_tag_manager_serialization::GetOperation {
         super::builder::policy_tag_manager_serialization::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1246,10 +1041,8 @@ impl PolicyTagManagerSerialization {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::DeleteOperation {
         super::builder::policy_tag_manager_serialization::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1257,9 +1050,7 @@ impl PolicyTagManagerSerialization {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_tag_manager_serialization::CancelOperation {
         super::builder::policy_tag_manager_serialization::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -124,10 +124,15 @@ impl super::stub::DataCatalog for DataCatalog {
     ) -> Result<gax::response::Response<crate::model::EntryGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entry_group
+            let arg = &req
+                .entry_group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entry_group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -239,10 +244,15 @@ impl super::stub::DataCatalog for DataCatalog {
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entry
+            let arg = &req
+                .entry
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entry.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -494,10 +504,15 @@ impl super::stub::DataCatalog for DataCatalog {
     ) -> Result<gax::response::Response<crate::model::TagTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tag_template
+            let arg = &req
+                .tag_template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tag_template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tag_template.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -718,10 +733,15 @@ impl super::stub::DataCatalog for DataCatalog {
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tag
+            let arg = &req
+                .tag
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tag.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1257,10 +1277,15 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
     ) -> Result<gax::response::Response<crate::model::Taxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.taxonomy
+            let arg = &req
+                .taxonomy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("taxonomy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("taxonomy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1399,10 +1424,15 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
     ) -> Result<gax::response::Response<crate::model::PolicyTag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.policy_tag
+            let arg = &req
+                .policy_tag
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy_tag"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy_tag.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchCatalogResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/catalog:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/catalog:search".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,12 +64,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entryGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entryGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +91,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,18 +123,15 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entry_group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entry_group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,9 +154,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +185,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntryGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entryGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entryGroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +213,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/entries", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,18 +238,15 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entry
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entry
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -243,9 +267,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -266,9 +297,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,9 +323,10 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/entries:lookup".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/entries:lookup".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,9 +358,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/entries", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -346,12 +392,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryOverview>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:modifyEntryOverview", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:modifyEntryOverview", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -366,12 +416,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Contacts>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:modifyEntryContacts", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:modifyEntryContacts", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -386,12 +440,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tagTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tagTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,9 +467,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -428,18 +493,15 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tag_template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tag_template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tag_template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tag_template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -462,9 +524,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,9 +555,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplateField>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/fields", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/fields", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -506,9 +582,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplateField>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -531,9 +614,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplateField>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -548,9 +638,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagTemplateField>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rename", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rename", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -565,9 +662,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -589,9 +693,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/tags", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -606,18 +717,15 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tag
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tag
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -638,9 +746,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -661,9 +776,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/tags", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -682,12 +804,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tags:reconcile", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tags:reconcile", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -702,9 +828,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StarEntryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:star", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:star", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -719,9 +852,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UnstarEntryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:unstar", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:unstar", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -736,12 +876,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -756,12 +900,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -776,12 +924,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -796,12 +948,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entries:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entries:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -816,9 +972,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setConfig", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:setConfig", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -833,12 +996,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OrganizationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:retrieveConfig", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:retrieveConfig", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -855,12 +1022,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigrationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:retrieveEffectiveConfig", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:retrieveEffectiveConfig", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -877,9 +1048,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -899,9 +1077,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -918,9 +1103,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -941,9 +1133,16 @@ impl super::stub::DataCatalog for DataCatalog {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1001,12 +1200,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Taxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/taxonomies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/taxonomies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1023,9 +1226,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1046,18 +1256,15 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Taxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.taxonomy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("taxonomy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.taxonomy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("taxonomy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1080,12 +1287,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTaxonomiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/taxonomies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/taxonomies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1105,9 +1316,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Taxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1124,12 +1342,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PolicyTag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/policyTags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/policyTags", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1368,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1169,18 +1398,15 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PolicyTag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.policy_tag
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy_tag"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.policy_tag
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy_tag"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1203,12 +1429,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPolicyTagsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/policyTags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/policyTags", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1227,9 +1457,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PolicyTag>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1246,12 +1483,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1266,12 +1507,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1286,12 +1531,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1306,9 +1555,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1328,9 +1584,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1347,9 +1610,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1370,9 +1640,16 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1416,9 +1693,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Taxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:replace", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:replace", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1433,12 +1717,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportTaxonomiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/taxonomies:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/taxonomies:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1453,12 +1741,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExportTaxonomiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/taxonomies:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/taxonomies:export", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1485,9 +1777,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1507,9 +1806,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1526,9 +1832,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1549,9 +1862,16 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/datafusion/v1/src/client.rs
+++ b/src/generated/cloud/datafusion/v1/src/client.rs
@@ -122,29 +122,18 @@ impl DataFusion {
 
     /// Lists possible versions for Data Fusion instances in the specified project
     /// and location.
-    pub fn list_available_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::ListAvailableVersions {
+    pub fn list_available_versions(&self) -> super::builder::data_fusion::ListAvailableVersions {
         super::builder::data_fusion::ListAvailableVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Data Fusion instances in the specified project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::ListInstances {
+    pub fn list_instances(&self) -> super::builder::data_fusion::ListInstances {
         super::builder::data_fusion::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Data Fusion instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::GetInstance {
-        super::builder::data_fusion::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::data_fusion::GetInstance {
+        super::builder::data_fusion::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new Data Fusion instance in the specified project and location.
@@ -158,12 +147,8 @@ impl DataFusion {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::data_fusion::CreateInstance {
         super::builder::data_fusion::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Date Fusion instance.
@@ -177,11 +162,8 @@ impl DataFusion {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::DeleteInstance {
-        super::builder::data_fusion::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::data_fusion::DeleteInstance {
+        super::builder::data_fusion::DeleteInstance::new(self.inner.clone())
     }
 
     /// Updates a single Data Fusion instance.
@@ -195,12 +177,8 @@ impl DataFusion {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::data_fusion::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::data_fusion::UpdateInstance {
         super::builder::data_fusion::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Restart a single Data Fusion instance.
@@ -215,50 +193,35 @@ impl DataFusion {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restart_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::RestartInstance {
-        super::builder::data_fusion::RestartInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn restart_instance(&self) -> super::builder::data_fusion::RestartInstance {
+        super::builder::data_fusion::RestartInstance::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::ListOperations {
-        super::builder::data_fusion::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::data_fusion::ListOperations {
+        super::builder::data_fusion::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::GetOperation {
-        super::builder::data_fusion::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::data_fusion::GetOperation {
+        super::builder::data_fusion::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::DeleteOperation {
-        super::builder::data_fusion::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::data_fusion::DeleteOperation {
+        super::builder::data_fusion::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_fusion::CancelOperation {
-        super::builder::data_fusion::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::data_fusion::CancelOperation {
+        super::builder::data_fusion::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -185,10 +185,15 @@ impl super::stub::DataFusion for DataFusion {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAvailableVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,12 +75,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -94,9 +105,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,12 +131,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,9 +158,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,18 +184,15 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,9 +215,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restart", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,9 +239,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -228,9 +268,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,9 +294,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +324,16 @@ impl super::stub::DataFusion for DataFusion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/dataplex/v1/src/client.rs
+++ b/src/generated/cloud/dataplex/v1/src/client.rs
@@ -133,12 +133,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_entry_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CreateEntryType {
+    pub fn create_entry_type(&self) -> super::builder::catalog_service::CreateEntryType {
         super::builder::catalog_service::CreateEntryType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an EntryType.
@@ -152,12 +148,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_entry_type(
-        &self,
-        entry_type: impl Into<crate::model::EntryType>,
-    ) -> super::builder::catalog_service::UpdateEntryType {
+    pub fn update_entry_type(&self) -> super::builder::catalog_service::UpdateEntryType {
         super::builder::catalog_service::UpdateEntryType::new(self.inner.clone())
-            .set_entry_type(entry_type.into())
     }
 
     /// Deletes an EntryType.
@@ -171,29 +163,18 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_entry_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::DeleteEntryType {
+    pub fn delete_entry_type(&self) -> super::builder::catalog_service::DeleteEntryType {
         super::builder::catalog_service::DeleteEntryType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists EntryType resources in a project and location.
-    pub fn list_entry_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListEntryTypes {
+    pub fn list_entry_types(&self) -> super::builder::catalog_service::ListEntryTypes {
         super::builder::catalog_service::ListEntryTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an EntryType.
-    pub fn get_entry_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetEntryType {
-        super::builder::catalog_service::GetEntryType::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entry_type(&self) -> super::builder::catalog_service::GetEntryType {
+        super::builder::catalog_service::GetEntryType::new(self.inner.clone())
     }
 
     /// Creates an AspectType.
@@ -207,12 +188,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_aspect_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CreateAspectType {
+    pub fn create_aspect_type(&self) -> super::builder::catalog_service::CreateAspectType {
         super::builder::catalog_service::CreateAspectType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an AspectType.
@@ -226,12 +203,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_aspect_type(
-        &self,
-        aspect_type: impl Into<crate::model::AspectType>,
-    ) -> super::builder::catalog_service::UpdateAspectType {
+    pub fn update_aspect_type(&self) -> super::builder::catalog_service::UpdateAspectType {
         super::builder::catalog_service::UpdateAspectType::new(self.inner.clone())
-            .set_aspect_type(aspect_type.into())
     }
 
     /// Deletes an AspectType.
@@ -245,30 +218,18 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_aspect_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::DeleteAspectType {
+    pub fn delete_aspect_type(&self) -> super::builder::catalog_service::DeleteAspectType {
         super::builder::catalog_service::DeleteAspectType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists AspectType resources in a project and location.
-    pub fn list_aspect_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListAspectTypes {
+    pub fn list_aspect_types(&self) -> super::builder::catalog_service::ListAspectTypes {
         super::builder::catalog_service::ListAspectTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an AspectType.
-    pub fn get_aspect_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetAspectType {
+    pub fn get_aspect_type(&self) -> super::builder::catalog_service::GetAspectType {
         super::builder::catalog_service::GetAspectType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an EntryGroup.
@@ -282,12 +243,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_entry_group(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CreateEntryGroup {
+    pub fn create_entry_group(&self) -> super::builder::catalog_service::CreateEntryGroup {
         super::builder::catalog_service::CreateEntryGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an EntryGroup.
@@ -301,12 +258,8 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_entry_group(
-        &self,
-        entry_group: impl Into<crate::model::EntryGroup>,
-    ) -> super::builder::catalog_service::UpdateEntryGroup {
+    pub fn update_entry_group(&self) -> super::builder::catalog_service::UpdateEntryGroup {
         super::builder::catalog_service::UpdateEntryGroup::new(self.inner.clone())
-            .set_entry_group(entry_group.into())
     }
 
     /// Deletes an EntryGroup.
@@ -320,90 +273,53 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_entry_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::DeleteEntryGroup {
+    pub fn delete_entry_group(&self) -> super::builder::catalog_service::DeleteEntryGroup {
         super::builder::catalog_service::DeleteEntryGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists EntryGroup resources in a project and location.
-    pub fn list_entry_groups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListEntryGroups {
+    pub fn list_entry_groups(&self) -> super::builder::catalog_service::ListEntryGroups {
         super::builder::catalog_service::ListEntryGroups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an EntryGroup.
-    pub fn get_entry_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetEntryGroup {
+    pub fn get_entry_group(&self) -> super::builder::catalog_service::GetEntryGroup {
         super::builder::catalog_service::GetEntryGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an Entry.
-    pub fn create_entry(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CreateEntry {
+    pub fn create_entry(&self) -> super::builder::catalog_service::CreateEntry {
         super::builder::catalog_service::CreateEntry::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an Entry.
-    pub fn update_entry(
-        &self,
-        entry: impl Into<crate::model::Entry>,
-    ) -> super::builder::catalog_service::UpdateEntry {
+    pub fn update_entry(&self) -> super::builder::catalog_service::UpdateEntry {
         super::builder::catalog_service::UpdateEntry::new(self.inner.clone())
-            .set_entry(entry.into())
     }
 
     /// Deletes an Entry.
-    pub fn delete_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::DeleteEntry {
-        super::builder::catalog_service::DeleteEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_entry(&self) -> super::builder::catalog_service::DeleteEntry {
+        super::builder::catalog_service::DeleteEntry::new(self.inner.clone())
     }
 
     /// Lists Entries within an EntryGroup.
-    pub fn list_entries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListEntries {
+    pub fn list_entries(&self) -> super::builder::catalog_service::ListEntries {
         super::builder::catalog_service::ListEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an Entry.
-    pub fn get_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetEntry {
-        super::builder::catalog_service::GetEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entry(&self) -> super::builder::catalog_service::GetEntry {
+        super::builder::catalog_service::GetEntry::new(self.inner.clone())
     }
 
     /// Looks up an entry by name using the permission on the source system.
-    pub fn lookup_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::LookupEntry {
-        super::builder::catalog_service::LookupEntry::new(self.inner.clone()).set_name(name.into())
+    pub fn lookup_entry(&self) -> super::builder::catalog_service::LookupEntry {
+        super::builder::catalog_service::LookupEntry::new(self.inner.clone())
     }
 
     /// Searches for Entries matching the given query and scope.
-    pub fn search_entries(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::SearchEntries {
+    pub fn search_entries(&self) -> super::builder::catalog_service::SearchEntries {
         super::builder::catalog_service::SearchEntries::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a metadata job. For example, use a metadata job to import Dataplex
@@ -418,30 +334,18 @@ impl CatalogService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_metadata_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CreateMetadataJob {
+    pub fn create_metadata_job(&self) -> super::builder::catalog_service::CreateMetadataJob {
         super::builder::catalog_service::CreateMetadataJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a metadata job.
-    pub fn get_metadata_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetMetadataJob {
+    pub fn get_metadata_job(&self) -> super::builder::catalog_service::GetMetadataJob {
         super::builder::catalog_service::GetMetadataJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists metadata jobs.
-    pub fn list_metadata_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListMetadataJobs {
+    pub fn list_metadata_jobs(&self) -> super::builder::catalog_service::ListMetadataJobs {
         super::builder::catalog_service::ListMetadataJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Cancels a metadata job.
@@ -450,29 +354,18 @@ impl CatalogService {
     /// job might be partially applied. We recommend that you reset the state of
     /// the entry groups in your project by running another metadata job that
     /// reverts the changes from the canceled job.
-    pub fn cancel_metadata_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CancelMetadataJob {
+    pub fn cancel_metadata_job(&self) -> super::builder::catalog_service::CancelMetadataJob {
         super::builder::catalog_service::CancelMetadataJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::catalog_service::ListLocations {
         super::builder::catalog_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetLocation {
-        super::builder::catalog_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::catalog_service::GetLocation {
+        super::builder::catalog_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -480,22 +373,14 @@ impl CatalogService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::catalog_service::SetIamPolicy {
         super::builder::catalog_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::catalog_service::GetIamPolicy {
         super::builder::catalog_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -505,55 +390,36 @@ impl CatalogService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::catalog_service::TestIamPermissions {
         super::builder::catalog_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::catalog_service::ListOperations {
         super::builder::catalog_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetOperation {
-        super::builder::catalog_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::catalog_service::GetOperation {
+        super::builder::catalog_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::catalog_service::DeleteOperation {
         super::builder::catalog_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::catalog_service::CancelOperation {
         super::builder::catalog_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -668,12 +534,8 @@ impl CmekService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_encryption_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::CreateEncryptionConfig {
+    pub fn create_encryption_config(&self) -> super::builder::cmek_service::CreateEncryptionConfig {
         super::builder::cmek_service::CreateEncryptionConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update an EncryptionConfig.
@@ -687,12 +549,8 @@ impl CmekService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_encryption_config(
-        &self,
-        encryption_config: impl Into<crate::model::EncryptionConfig>,
-    ) -> super::builder::cmek_service::UpdateEncryptionConfig {
+    pub fn update_encryption_config(&self) -> super::builder::cmek_service::UpdateEncryptionConfig {
         super::builder::cmek_service::UpdateEncryptionConfig::new(self.inner.clone())
-            .set_encryption_config(encryption_config.into())
     }
 
     /// Delete an EncryptionConfig.
@@ -706,46 +564,28 @@ impl CmekService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_encryption_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::DeleteEncryptionConfig {
+    pub fn delete_encryption_config(&self) -> super::builder::cmek_service::DeleteEncryptionConfig {
         super::builder::cmek_service::DeleteEncryptionConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List EncryptionConfigs.
-    pub fn list_encryption_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::ListEncryptionConfigs {
+    pub fn list_encryption_configs(&self) -> super::builder::cmek_service::ListEncryptionConfigs {
         super::builder::cmek_service::ListEncryptionConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get an EncryptionConfig.
-    pub fn get_encryption_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::GetEncryptionConfig {
+    pub fn get_encryption_config(&self) -> super::builder::cmek_service::GetEncryptionConfig {
         super::builder::cmek_service::GetEncryptionConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::ListLocations {
-        super::builder::cmek_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::cmek_service::ListLocations {
+        super::builder::cmek_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::GetLocation {
-        super::builder::cmek_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cmek_service::GetLocation {
+        super::builder::cmek_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -753,22 +593,14 @@ impl CmekService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cmek_service::SetIamPolicy {
         super::builder::cmek_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cmek_service::GetIamPolicy {
         super::builder::cmek_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -778,52 +610,36 @@ impl CmekService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::cmek_service::TestIamPermissions {
         super::builder::cmek_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::ListOperations {
-        super::builder::cmek_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::cmek_service::ListOperations {
+        super::builder::cmek_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::GetOperation {
-        super::builder::cmek_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cmek_service::GetOperation {
+        super::builder::cmek_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::DeleteOperation {
-        super::builder::cmek_service::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::cmek_service::DeleteOperation {
+        super::builder::cmek_service::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cmek_service::CancelOperation {
-        super::builder::cmek_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::cmek_service::CancelOperation {
+        super::builder::cmek_service::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -928,38 +744,23 @@ impl ContentService {
     }
 
     /// Create a content.
-    pub fn create_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::content_service::CreateContent {
+    pub fn create_content(&self) -> super::builder::content_service::CreateContent {
         super::builder::content_service::CreateContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a content. Only supports full resource update.
-    pub fn update_content(
-        &self,
-        content: impl Into<crate::model::Content>,
-    ) -> super::builder::content_service::UpdateContent {
+    pub fn update_content(&self) -> super::builder::content_service::UpdateContent {
         super::builder::content_service::UpdateContent::new(self.inner.clone())
-            .set_content(content.into())
     }
 
     /// Delete a content.
-    pub fn delete_content(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::DeleteContent {
+    pub fn delete_content(&self) -> super::builder::content_service::DeleteContent {
         super::builder::content_service::DeleteContent::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a content resource.
-    pub fn get_content(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::GetContent {
-        super::builder::content_service::GetContent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_content(&self) -> super::builder::content_service::GetContent {
+        super::builder::content_service::GetContent::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a contentitem resource. A `NOT_FOUND`
@@ -968,12 +769,8 @@ impl ContentService {
     ///
     /// Caller must have Google IAM `dataplex.content.getIamPolicy` permission
     /// on the resource.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::content_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::content_service::GetIamPolicy {
         super::builder::content_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on the specified contentitem resource.
@@ -981,12 +778,8 @@ impl ContentService {
     ///
     /// Caller must have Google IAM `dataplex.content.setIamPolicy` permission
     /// on the resource.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::content_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::content_service::SetIamPolicy {
         super::builder::content_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the caller's permissions on a resource.
@@ -999,81 +792,51 @@ impl ContentService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::content_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::content_service::TestIamPermissions {
         super::builder::content_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// List content.
-    pub fn list_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::content_service::ListContent {
+    pub fn list_content(&self) -> super::builder::content_service::ListContent {
         super::builder::content_service::ListContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::content_service::ListLocations {
         super::builder::content_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::GetLocation {
-        super::builder::content_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::content_service::GetLocation {
+        super::builder::content_service::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::content_service::ListOperations {
         super::builder::content_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::GetOperation {
-        super::builder::content_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::content_service::GetOperation {
+        super::builder::content_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::content_service::DeleteOperation {
         super::builder::content_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::content_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::content_service::CancelOperation {
         super::builder::content_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1195,10 +958,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn create_data_taxonomy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::CreateDataTaxonomy {
         super::builder::data_taxonomy_service::CreateDataTaxonomy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DataTaxonomy resource.
@@ -1215,10 +976,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn update_data_taxonomy(
         &self,
-        data_taxonomy: impl Into<crate::model::DataTaxonomy>,
     ) -> super::builder::data_taxonomy_service::UpdateDataTaxonomy {
         super::builder::data_taxonomy_service::UpdateDataTaxonomy::new(self.inner.clone())
-            .set_data_taxonomy(data_taxonomy.into())
     }
 
     /// Deletes a DataTaxonomy resource. All attributes within the DataTaxonomy
@@ -1236,30 +995,22 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn delete_data_taxonomy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::DeleteDataTaxonomy {
         super::builder::data_taxonomy_service::DeleteDataTaxonomy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataTaxonomy resources in a project and location.
     #[deprecated]
     pub fn list_data_taxonomies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::ListDataTaxonomies {
         super::builder::data_taxonomy_service::ListDataTaxonomies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a DataTaxonomy resource.
     #[deprecated]
-    pub fn get_data_taxonomy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::GetDataTaxonomy {
+    pub fn get_data_taxonomy(&self) -> super::builder::data_taxonomy_service::GetDataTaxonomy {
         super::builder::data_taxonomy_service::GetDataTaxonomy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a DataAttributeBinding resource.
@@ -1276,10 +1027,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn create_data_attribute_binding(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::CreateDataAttributeBinding {
         super::builder::data_taxonomy_service::CreateDataAttributeBinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DataAttributeBinding resource.
@@ -1296,10 +1045,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn update_data_attribute_binding(
         &self,
-        data_attribute_binding: impl Into<crate::model::DataAttributeBinding>,
     ) -> super::builder::data_taxonomy_service::UpdateDataAttributeBinding {
         super::builder::data_taxonomy_service::UpdateDataAttributeBinding::new(self.inner.clone())
-            .set_data_attribute_binding(data_attribute_binding.into())
     }
 
     /// Deletes a DataAttributeBinding resource. All attributes within the
@@ -1318,30 +1065,24 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn delete_data_attribute_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::DeleteDataAttributeBinding {
         super::builder::data_taxonomy_service::DeleteDataAttributeBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataAttributeBinding resources in a project and location.
     #[deprecated]
     pub fn list_data_attribute_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::ListDataAttributeBindings {
         super::builder::data_taxonomy_service::ListDataAttributeBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a DataAttributeBinding resource.
     #[deprecated]
     pub fn get_data_attribute_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::GetDataAttributeBinding {
         super::builder::data_taxonomy_service::GetDataAttributeBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a DataAttribute resource.
@@ -1358,10 +1099,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn create_data_attribute(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::CreateDataAttribute {
         super::builder::data_taxonomy_service::CreateDataAttribute::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DataAttribute resource.
@@ -1378,10 +1117,8 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn update_data_attribute(
         &self,
-        data_attribute: impl Into<crate::model::DataAttribute>,
     ) -> super::builder::data_taxonomy_service::UpdateDataAttribute {
         super::builder::data_taxonomy_service::UpdateDataAttribute::new(self.inner.clone())
-            .set_data_attribute(data_attribute.into())
     }
 
     /// Deletes a Data Attribute resource.
@@ -1398,48 +1135,32 @@ impl DataTaxonomyService {
     #[deprecated]
     pub fn delete_data_attribute(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::DeleteDataAttribute {
         super::builder::data_taxonomy_service::DeleteDataAttribute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Data Attribute resources in a DataTaxonomy.
     #[deprecated]
     pub fn list_data_attributes(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::ListDataAttributes {
         super::builder::data_taxonomy_service::ListDataAttributes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a Data Attribute resource.
     #[deprecated]
-    pub fn get_data_attribute(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::GetDataAttribute {
+    pub fn get_data_attribute(&self) -> super::builder::data_taxonomy_service::GetDataAttribute {
         super::builder::data_taxonomy_service::GetDataAttribute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::data_taxonomy_service::ListLocations {
         super::builder::data_taxonomy_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::data_taxonomy_service::GetLocation {
         super::builder::data_taxonomy_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1447,22 +1168,14 @@ impl DataTaxonomyService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::data_taxonomy_service::SetIamPolicy {
         super::builder::data_taxonomy_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::data_taxonomy_service::GetIamPolicy {
         super::builder::data_taxonomy_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1474,54 +1187,36 @@ impl DataTaxonomyService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::data_taxonomy_service::TestIamPermissions {
         super::builder::data_taxonomy_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::data_taxonomy_service::ListOperations {
         super::builder::data_taxonomy_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::data_taxonomy_service::GetOperation {
         super::builder::data_taxonomy_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::data_taxonomy_service::DeleteOperation {
         super::builder::data_taxonomy_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_taxonomy_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::data_taxonomy_service::CancelOperation {
         super::builder::data_taxonomy_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1640,12 +1335,8 @@ impl DataScanService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_data_scan(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::CreateDataScan {
+    pub fn create_data_scan(&self) -> super::builder::data_scan_service::CreateDataScan {
         super::builder::data_scan_service::CreateDataScan::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a DataScan resource.
@@ -1659,12 +1350,8 @@ impl DataScanService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_data_scan(
-        &self,
-        data_scan: impl Into<crate::model::DataScan>,
-    ) -> super::builder::data_scan_service::UpdateDataScan {
+    pub fn update_data_scan(&self) -> super::builder::data_scan_service::UpdateDataScan {
         super::builder::data_scan_service::UpdateDataScan::new(self.inner.clone())
-            .set_data_scan(data_scan.into())
     }
 
     /// Deletes a DataScan resource.
@@ -1678,57 +1365,33 @@ impl DataScanService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_data_scan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::DeleteDataScan {
+    pub fn delete_data_scan(&self) -> super::builder::data_scan_service::DeleteDataScan {
         super::builder::data_scan_service::DeleteDataScan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a DataScan resource.
-    pub fn get_data_scan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::GetDataScan {
+    pub fn get_data_scan(&self) -> super::builder::data_scan_service::GetDataScan {
         super::builder::data_scan_service::GetDataScan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataScans.
-    pub fn list_data_scans(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::ListDataScans {
+    pub fn list_data_scans(&self) -> super::builder::data_scan_service::ListDataScans {
         super::builder::data_scan_service::ListDataScans::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Runs an on-demand execution of a DataScan
-    pub fn run_data_scan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::RunDataScan {
+    pub fn run_data_scan(&self) -> super::builder::data_scan_service::RunDataScan {
         super::builder::data_scan_service::RunDataScan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a DataScanJob resource.
-    pub fn get_data_scan_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::GetDataScanJob {
+    pub fn get_data_scan_job(&self) -> super::builder::data_scan_service::GetDataScanJob {
         super::builder::data_scan_service::GetDataScanJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DataScanJobs under the given DataScan.
-    pub fn list_data_scan_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::ListDataScanJobs {
+    pub fn list_data_scan_jobs(&self) -> super::builder::data_scan_service::ListDataScanJobs {
         super::builder::data_scan_service::ListDataScanJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Generates recommended data quality rules based on the results of a data
@@ -1737,28 +1400,18 @@ impl DataScanService {
     /// Use the recommendations to build rules for a data quality scan.
     pub fn generate_data_quality_rules(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::data_scan_service::GenerateDataQualityRules {
         super::builder::data_scan_service::GenerateDataQualityRules::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::data_scan_service::ListLocations {
         super::builder::data_scan_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::data_scan_service::GetLocation {
         super::builder::data_scan_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1766,22 +1419,14 @@ impl DataScanService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::data_scan_service::SetIamPolicy {
         super::builder::data_scan_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::data_scan_service::GetIamPolicy {
         super::builder::data_scan_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1791,56 +1436,36 @@ impl DataScanService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::data_scan_service::TestIamPermissions {
         super::builder::data_scan_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::data_scan_service::ListOperations {
         super::builder::data_scan_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::data_scan_service::GetOperation {
         super::builder::data_scan_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::data_scan_service::DeleteOperation {
         super::builder::data_scan_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_scan_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::data_scan_service::CancelOperation {
         super::builder::data_scan_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1948,100 +1573,58 @@ impl MetadataService {
     }
 
     /// Create a metadata entity.
-    pub fn create_entity(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreateEntity {
+    pub fn create_entity(&self) -> super::builder::metadata_service::CreateEntity {
         super::builder::metadata_service::CreateEntity::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a metadata entity. Only supports full resource update.
-    pub fn update_entity(
-        &self,
-        entity: impl Into<crate::model::Entity>,
-    ) -> super::builder::metadata_service::UpdateEntity {
+    pub fn update_entity(&self) -> super::builder::metadata_service::UpdateEntity {
         super::builder::metadata_service::UpdateEntity::new(self.inner.clone())
-            .set_entity(entity.into())
     }
 
     /// Delete a metadata entity.
-    pub fn delete_entity(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteEntity {
+    pub fn delete_entity(&self) -> super::builder::metadata_service::DeleteEntity {
         super::builder::metadata_service::DeleteEntity::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a metadata entity.
-    pub fn get_entity(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetEntity {
-        super::builder::metadata_service::GetEntity::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entity(&self) -> super::builder::metadata_service::GetEntity {
+        super::builder::metadata_service::GetEntity::new(self.inner.clone())
     }
 
     /// List metadata entities in a zone.
-    pub fn list_entities(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListEntities {
+    pub fn list_entities(&self) -> super::builder::metadata_service::ListEntities {
         super::builder::metadata_service::ListEntities::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a metadata partition.
-    pub fn create_partition(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CreatePartition {
+    pub fn create_partition(&self) -> super::builder::metadata_service::CreatePartition {
         super::builder::metadata_service::CreatePartition::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete a metadata partition.
-    pub fn delete_partition(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeletePartition {
+    pub fn delete_partition(&self) -> super::builder::metadata_service::DeletePartition {
         super::builder::metadata_service::DeletePartition::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a metadata partition of an entity.
-    pub fn get_partition(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetPartition {
+    pub fn get_partition(&self) -> super::builder::metadata_service::GetPartition {
         super::builder::metadata_service::GetPartition::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List metadata partitions of an entity.
-    pub fn list_partitions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListPartitions {
+    pub fn list_partitions(&self) -> super::builder::metadata_service::ListPartitions {
         super::builder::metadata_service::ListPartitions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::metadata_service::ListLocations {
         super::builder::metadata_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetLocation {
-        super::builder::metadata_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::metadata_service::GetLocation {
+        super::builder::metadata_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -2049,22 +1632,14 @@ impl MetadataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::metadata_service::SetIamPolicy {
         super::builder::metadata_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::metadata_service::GetIamPolicy {
         super::builder::metadata_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2074,56 +1649,36 @@ impl MetadataService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::metadata_service::TestIamPermissions {
         super::builder::metadata_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::metadata_service::ListOperations {
         super::builder::metadata_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::metadata_service::GetOperation {
         super::builder::metadata_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::metadata_service::DeleteOperation {
         super::builder::metadata_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metadata_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::metadata_service::CancelOperation {
         super::builder::metadata_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2244,12 +1799,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_lake(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CreateLake {
+    pub fn create_lake(&self) -> super::builder::dataplex_service::CreateLake {
         super::builder::dataplex_service::CreateLake::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a lake resource.
@@ -2263,11 +1814,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_lake(
-        &self,
-        lake: impl Into<crate::model::Lake>,
-    ) -> super::builder::dataplex_service::UpdateLake {
-        super::builder::dataplex_service::UpdateLake::new(self.inner.clone()).set_lake(lake.into())
+    pub fn update_lake(&self) -> super::builder::dataplex_service::UpdateLake {
+        super::builder::dataplex_service::UpdateLake::new(self.inner.clone())
     }
 
     /// Deletes a lake resource. All zones within the lake must be deleted before
@@ -2282,37 +1830,23 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_lake(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteLake {
-        super::builder::dataplex_service::DeleteLake::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_lake(&self) -> super::builder::dataplex_service::DeleteLake {
+        super::builder::dataplex_service::DeleteLake::new(self.inner.clone())
     }
 
     /// Lists lake resources in a project and location.
-    pub fn list_lakes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListLakes {
+    pub fn list_lakes(&self) -> super::builder::dataplex_service::ListLakes {
         super::builder::dataplex_service::ListLakes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a lake resource.
-    pub fn get_lake(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetLake {
-        super::builder::dataplex_service::GetLake::new(self.inner.clone()).set_name(name.into())
+    pub fn get_lake(&self) -> super::builder::dataplex_service::GetLake {
+        super::builder::dataplex_service::GetLake::new(self.inner.clone())
     }
 
     /// Lists action resources in a lake.
-    pub fn list_lake_actions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListLakeActions {
+    pub fn list_lake_actions(&self) -> super::builder::dataplex_service::ListLakeActions {
         super::builder::dataplex_service::ListLakeActions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a zone resource within a lake.
@@ -2326,12 +1860,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_zone(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CreateZone {
+    pub fn create_zone(&self) -> super::builder::dataplex_service::CreateZone {
         super::builder::dataplex_service::CreateZone::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a zone resource.
@@ -2345,11 +1875,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_zone(
-        &self,
-        zone: impl Into<crate::model::Zone>,
-    ) -> super::builder::dataplex_service::UpdateZone {
-        super::builder::dataplex_service::UpdateZone::new(self.inner.clone()).set_zone(zone.into())
+    pub fn update_zone(&self) -> super::builder::dataplex_service::UpdateZone {
+        super::builder::dataplex_service::UpdateZone::new(self.inner.clone())
     }
 
     /// Deletes a zone resource. All assets within a zone must be deleted before
@@ -2364,37 +1891,23 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_zone(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteZone {
-        super::builder::dataplex_service::DeleteZone::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_zone(&self) -> super::builder::dataplex_service::DeleteZone {
+        super::builder::dataplex_service::DeleteZone::new(self.inner.clone())
     }
 
     /// Lists zone resources in a lake.
-    pub fn list_zones(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListZones {
+    pub fn list_zones(&self) -> super::builder::dataplex_service::ListZones {
         super::builder::dataplex_service::ListZones::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a zone resource.
-    pub fn get_zone(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetZone {
-        super::builder::dataplex_service::GetZone::new(self.inner.clone()).set_name(name.into())
+    pub fn get_zone(&self) -> super::builder::dataplex_service::GetZone {
+        super::builder::dataplex_service::GetZone::new(self.inner.clone())
     }
 
     /// Lists action resources in a zone.
-    pub fn list_zone_actions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListZoneActions {
+    pub fn list_zone_actions(&self) -> super::builder::dataplex_service::ListZoneActions {
         super::builder::dataplex_service::ListZoneActions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an asset resource.
@@ -2408,12 +1921,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_asset(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CreateAsset {
+    pub fn create_asset(&self) -> super::builder::dataplex_service::CreateAsset {
         super::builder::dataplex_service::CreateAsset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an asset resource.
@@ -2427,12 +1936,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_asset(
-        &self,
-        asset: impl Into<crate::model::Asset>,
-    ) -> super::builder::dataplex_service::UpdateAsset {
+    pub fn update_asset(&self) -> super::builder::dataplex_service::UpdateAsset {
         super::builder::dataplex_service::UpdateAsset::new(self.inner.clone())
-            .set_asset(asset.into())
     }
 
     /// Deletes an asset resource. The referenced storage resource is detached
@@ -2447,37 +1952,23 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteAsset {
-        super::builder::dataplex_service::DeleteAsset::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_asset(&self) -> super::builder::dataplex_service::DeleteAsset {
+        super::builder::dataplex_service::DeleteAsset::new(self.inner.clone())
     }
 
     /// Lists asset resources in a zone.
-    pub fn list_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListAssets {
+    pub fn list_assets(&self) -> super::builder::dataplex_service::ListAssets {
         super::builder::dataplex_service::ListAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves an asset resource.
-    pub fn get_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetAsset {
-        super::builder::dataplex_service::GetAsset::new(self.inner.clone()).set_name(name.into())
+    pub fn get_asset(&self) -> super::builder::dataplex_service::GetAsset {
+        super::builder::dataplex_service::GetAsset::new(self.inner.clone())
     }
 
     /// Lists action resources in an asset.
-    pub fn list_asset_actions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListAssetActions {
+    pub fn list_asset_actions(&self) -> super::builder::dataplex_service::ListAssetActions {
         super::builder::dataplex_service::ListAssetActions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a task resource within a lake.
@@ -2491,12 +1982,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_task(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CreateTask {
+    pub fn create_task(&self) -> super::builder::dataplex_service::CreateTask {
         super::builder::dataplex_service::CreateTask::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update the task resource.
@@ -2510,11 +1997,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_task(
-        &self,
-        task: impl Into<crate::model::Task>,
-    ) -> super::builder::dataplex_service::UpdateTask {
-        super::builder::dataplex_service::UpdateTask::new(self.inner.clone()).set_task(task.into())
+    pub fn update_task(&self) -> super::builder::dataplex_service::UpdateTask {
+        super::builder::dataplex_service::UpdateTask::new(self.inner.clone())
     }
 
     /// Delete the task resource.
@@ -2528,61 +2012,38 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteTask {
-        super::builder::dataplex_service::DeleteTask::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_task(&self) -> super::builder::dataplex_service::DeleteTask {
+        super::builder::dataplex_service::DeleteTask::new(self.inner.clone())
     }
 
     /// Lists tasks under the given lake.
-    pub fn list_tasks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListTasks {
+    pub fn list_tasks(&self) -> super::builder::dataplex_service::ListTasks {
         super::builder::dataplex_service::ListTasks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get task resource.
-    pub fn get_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetTask {
-        super::builder::dataplex_service::GetTask::new(self.inner.clone()).set_name(name.into())
+    pub fn get_task(&self) -> super::builder::dataplex_service::GetTask {
+        super::builder::dataplex_service::GetTask::new(self.inner.clone())
     }
 
     /// Lists Jobs under the given task.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListJobs {
+    pub fn list_jobs(&self) -> super::builder::dataplex_service::ListJobs {
         super::builder::dataplex_service::ListJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Run an on demand execution of a Task.
-    pub fn run_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::RunTask {
-        super::builder::dataplex_service::RunTask::new(self.inner.clone()).set_name(name.into())
+    pub fn run_task(&self) -> super::builder::dataplex_service::RunTask {
+        super::builder::dataplex_service::RunTask::new(self.inner.clone())
     }
 
     /// Get job resource.
-    pub fn get_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetJob {
-        super::builder::dataplex_service::GetJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job(&self) -> super::builder::dataplex_service::GetJob {
+        super::builder::dataplex_service::GetJob::new(self.inner.clone())
     }
 
     /// Cancel jobs running for the task resource.
-    pub fn cancel_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CancelJob {
-        super::builder::dataplex_service::CancelJob::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_job(&self) -> super::builder::dataplex_service::CancelJob {
+        super::builder::dataplex_service::CancelJob::new(self.inner.clone())
     }
 
     /// Create an environment resource.
@@ -2596,12 +2057,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_environment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CreateEnvironment {
+    pub fn create_environment(&self) -> super::builder::dataplex_service::CreateEnvironment {
         super::builder::dataplex_service::CreateEnvironment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update the environment resource.
@@ -2615,12 +2072,8 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_environment(
-        &self,
-        environment: impl Into<crate::model::Environment>,
-    ) -> super::builder::dataplex_service::UpdateEnvironment {
+    pub fn update_environment(&self) -> super::builder::dataplex_service::UpdateEnvironment {
         super::builder::dataplex_service::UpdateEnvironment::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Delete the environment resource. All the child resources must have been
@@ -2635,56 +2088,33 @@ impl DataplexService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteEnvironment {
+    pub fn delete_environment(&self) -> super::builder::dataplex_service::DeleteEnvironment {
         super::builder::dataplex_service::DeleteEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists environments under the given lake.
-    pub fn list_environments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListEnvironments {
+    pub fn list_environments(&self) -> super::builder::dataplex_service::ListEnvironments {
         super::builder::dataplex_service::ListEnvironments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get environment resource.
-    pub fn get_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetEnvironment {
+    pub fn get_environment(&self) -> super::builder::dataplex_service::GetEnvironment {
         super::builder::dataplex_service::GetEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists session resources in an environment.
-    pub fn list_sessions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListSessions {
+    pub fn list_sessions(&self) -> super::builder::dataplex_service::ListSessions {
         super::builder::dataplex_service::ListSessions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::dataplex_service::ListLocations {
         super::builder::dataplex_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetLocation {
-        super::builder::dataplex_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::dataplex_service::GetLocation {
+        super::builder::dataplex_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -2692,22 +2122,14 @@ impl DataplexService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::dataplex_service::SetIamPolicy {
         super::builder::dataplex_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::dataplex_service::GetIamPolicy {
         super::builder::dataplex_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2717,55 +2139,35 @@ impl DataplexService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::dataplex_service::TestIamPermissions {
         super::builder::dataplex_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::dataplex_service::ListOperations {
         super::builder::dataplex_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::dataplex_service::GetOperation {
         super::builder::dataplex_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::dataplex_service::DeleteOperation {
         super::builder::dataplex_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataplex_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::dataplex_service::CancelOperation {
         super::builder::dataplex_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/dataplex/v1/src/transport.rs
+++ b/src/generated/cloud/dataplex/v1/src/transport.rs
@@ -75,10 +75,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entry_type
+            let arg = &req
+                .entry_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entry_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entry_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -218,10 +223,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.aspect_type
+            let arg = &req
+                .aspect_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("aspect_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aspect_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -361,10 +371,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entry_group
+            let arg = &req
+                .entry_group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entry_group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -501,10 +516,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entry
+            let arg = &req
+                .entry
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entry.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1123,10 +1143,15 @@ impl super::stub::CmekService for CmekService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.encryption_config
+            let arg = &req
+                .encryption_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("encryption_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("encryption_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1554,10 +1579,15 @@ impl super::stub::ContentService for ContentService {
     ) -> Result<gax::response::Response<crate::model::Content>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.content
+            let arg = &req
+                .content
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("content"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("content.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1976,10 +2006,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_taxonomy
+            let arg = &req
+                .data_taxonomy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_taxonomy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_taxonomy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2119,10 +2154,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_attribute_binding
+            let arg = &req
+                .data_attribute_binding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_attribute_binding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_attribute_binding.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2262,10 +2302,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_attribute
+            let arg = &req
+                .data_attribute
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_attribute"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_attribute.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2695,10 +2740,15 @@ impl super::stub::DataScanService for DataScanService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_scan
+            let arg = &req
+                .data_scan
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_scan"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_scan.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3230,10 +3280,15 @@ impl super::stub::MetadataService for MetadataService {
     ) -> Result<gax::response::Response<crate::model::Entity>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.entity
+            let arg = &req
+                .entity
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entity"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3757,10 +3812,15 @@ impl super::stub::DataplexService for DataplexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.lake
+            let arg = &req
+                .lake
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("lake"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("lake.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3923,10 +3983,15 @@ impl super::stub::DataplexService for DataplexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.zone
+            let arg = &req
+                .zone
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("zone"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("zone.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4089,10 +4154,15 @@ impl super::stub::DataplexService for DataplexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.asset
+            let arg = &req
+                .asset
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("asset.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4255,10 +4325,15 @@ impl super::stub::DataplexService for DataplexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.task
+            let arg = &req
+                .task
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("task"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("task.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4502,10 +4577,15 @@ impl super::stub::DataplexService for DataplexService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.environment
+            let arg = &req
+                .environment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/dataplex/v1/src/transport.rs
+++ b/src/generated/cloud/dataplex/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entryTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entryTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,18 +74,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entry_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entry_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entry_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entry_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,9 +106,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -125,12 +133,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntryTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entryTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entryTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -151,9 +163,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/aspectTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/aspectTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,18 +217,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.aspect_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("aspect_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.aspect_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("aspect_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -229,9 +249,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -249,12 +276,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAspectTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/aspectTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/aspectTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +306,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AspectType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,12 +332,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entryGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entryGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,18 +360,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entry_group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entry_group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entry_group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,9 +392,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -373,12 +419,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntryGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entryGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entryGroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -399,9 +449,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntryGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -418,9 +475,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/entries", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -436,18 +500,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entry
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entry
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entry"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -474,9 +535,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -493,9 +561,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/entries", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -515,9 +590,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -543,12 +625,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:lookupEntry", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:lookupEntry", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -575,12 +661,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchEntries", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:searchEntries", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -602,12 +692,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/metadataJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/metadataJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,9 +720,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetadataJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -645,12 +746,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMetadataJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/metadataJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/metadataJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -671,9 +776,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -693,9 +805,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -715,9 +834,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -734,12 +860,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -754,12 +884,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -786,12 +920,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -806,9 +944,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -828,9 +973,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -847,9 +999,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -870,9 +1029,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -929,12 +1095,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/encryptionConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/encryptionConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -952,18 +1122,15 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.encryption_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("encryption_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.encryption_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("encryption_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -986,9 +1153,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1006,12 +1180,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEncryptionConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/encryptionConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/encryptionConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1032,9 +1210,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EncryptionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1051,9 +1236,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1073,9 +1265,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1092,12 +1291,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1112,12 +1315,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1144,12 +1351,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1164,9 +1375,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1186,9 +1404,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1205,9 +1430,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1228,9 +1460,16 @@ impl super::stub::CmekService for CmekService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1287,12 +1526,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Content>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/contentitems", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/contentitems", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1310,18 +1553,15 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Content>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.content
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("content"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.content
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("content"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1345,9 +1585,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1368,9 +1615,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Content>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1388,12 +1642,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1420,12 +1678,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1440,12 +1702,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1460,12 +1726,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/contentitems", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/contentitems", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1485,9 +1755,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1507,9 +1784,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1526,9 +1810,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1548,9 +1839,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1567,9 +1865,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1590,9 +1895,16 @@ impl super::stub::ContentService for ContentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1635,12 +1947,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataTaxonomies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataTaxonomies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1659,18 +1975,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_taxonomy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_taxonomy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_taxonomy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_taxonomy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1694,9 +2007,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1714,12 +2034,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataTaxonomiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataTaxonomies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataTaxonomies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1740,9 +2064,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataTaxonomy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1759,12 +2090,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataAttributeBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataAttributeBindings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1783,18 +2118,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_attribute_binding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_attribute_binding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_attribute_binding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_attribute_binding"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1818,9 +2150,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1838,12 +2177,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataAttributeBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataAttributeBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataAttributeBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1864,9 +2207,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAttributeBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1883,12 +2233,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attributes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attributes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1907,18 +2261,15 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_attribute
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_attribute"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_attribute
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_attribute"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1942,9 +2293,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1962,12 +2320,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataAttributesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/attributes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/attributes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1988,9 +2350,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataAttribute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2007,9 +2376,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2029,9 +2405,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2048,12 +2431,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2068,12 +2455,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2100,12 +2491,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2120,9 +2515,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2142,9 +2544,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2161,9 +2570,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2184,9 +2600,16 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2243,12 +2666,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataScans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataScans", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2267,18 +2694,15 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_scan
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_scan"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_scan
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_scan"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2302,9 +2726,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2322,9 +2753,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataScan>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2342,12 +2780,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataScansResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataScans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataScans", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2368,9 +2810,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RunDataScanResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2385,9 +2834,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataScanJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2405,9 +2861,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataScanJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2427,12 +2890,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateDataQualityRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateDataQualityRules", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateDataQualityRules", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2447,9 +2914,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2469,9 +2943,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2488,12 +2969,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2508,12 +2993,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2540,12 +3029,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2560,9 +3053,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2582,9 +3082,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2601,9 +3108,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2624,9 +3138,16 @@ impl super::stub::DataScanService for DataScanService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2683,12 +3204,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entity>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entities", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entities", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2704,18 +3229,15 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entity>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.entity
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entity"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.entity
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entity"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2731,9 +3253,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2755,9 +3284,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entity>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2775,9 +3311,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntitiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entities", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/entities", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2798,12 +3341,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Partition>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/partitions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/partitions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2821,9 +3368,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2845,9 +3399,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Partition>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2864,12 +3425,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPartitionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/partitions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/partitions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2889,9 +3454,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2911,9 +3483,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2930,12 +3509,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2950,12 +3533,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2982,12 +3569,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3002,9 +3593,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3024,9 +3622,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3043,9 +3648,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3066,9 +3678,16 @@ impl super::stub::MetadataService for MetadataService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3111,9 +3730,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/lakes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/lakes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3130,18 +3756,15 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.lake
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("lake"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.lake
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("lake"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3163,9 +3786,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3182,9 +3812,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLakesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/lakes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/lakes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3205,9 +3842,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Lake>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3224,9 +3868,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListActionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/actions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/actions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3245,9 +3896,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/zones", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/zones", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3264,18 +3922,15 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.zone
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("zone"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.zone
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("zone"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3297,9 +3952,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3316,9 +3978,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListZonesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/zones", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/zones", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3339,9 +4008,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Zone>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3358,9 +4034,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListActionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/actions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/actions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3379,9 +4062,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3398,18 +4088,15 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.asset
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.asset
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3431,9 +4118,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3450,9 +4144,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3473,9 +4174,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Asset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3492,9 +4200,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListActionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/actions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/actions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3513,9 +4228,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/tasks", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3532,18 +4254,15 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.task
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("task"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.task
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("task"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3565,9 +4284,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3584,9 +4310,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTasksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/tasks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3607,9 +4340,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Task>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3626,9 +4366,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3647,9 +4394,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RunTaskResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3664,9 +4418,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3683,9 +4444,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3705,12 +4473,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3729,18 +4501,15 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.environment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.environment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3764,9 +4533,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3783,12 +4559,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnvironmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3809,9 +4589,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3828,9 +4615,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/sessions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3850,9 +4644,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3872,9 +4673,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3891,12 +4699,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3911,12 +4723,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3943,12 +4759,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3963,9 +4783,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3985,9 +4812,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4004,9 +4838,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4027,9 +4868,16 @@ impl super::stub::DataplexService for DataplexService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/dataproc/v1/src/client.rs
+++ b/src/generated/cloud/dataproc/v1/src/client.rs
@@ -124,10 +124,8 @@ impl AutoscalingPolicyService {
     /// Creates new autoscaling policy.
     pub fn create_autoscaling_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::autoscaling_policy_service::CreateAutoscalingPolicy {
         super::builder::autoscaling_policy_service::CreateAutoscalingPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates (replaces) autoscaling policy.
@@ -136,38 +134,30 @@ impl AutoscalingPolicyService {
     /// replacements.
     pub fn update_autoscaling_policy(
         &self,
-        policy: impl Into<crate::model::AutoscalingPolicy>,
     ) -> super::builder::autoscaling_policy_service::UpdateAutoscalingPolicy {
         super::builder::autoscaling_policy_service::UpdateAutoscalingPolicy::new(self.inner.clone())
-            .set_policy(policy.into())
     }
 
     /// Retrieves autoscaling policy.
     pub fn get_autoscaling_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::autoscaling_policy_service::GetAutoscalingPolicy {
         super::builder::autoscaling_policy_service::GetAutoscalingPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists autoscaling policies in the project.
     pub fn list_autoscaling_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::autoscaling_policy_service::ListAutoscalingPolicies {
         super::builder::autoscaling_policy_service::ListAutoscalingPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an autoscaling policy. It is an error to delete an autoscaling
     /// policy that is in use by one or more clusters.
     pub fn delete_autoscaling_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::autoscaling_policy_service::DeleteAutoscalingPolicy {
         super::builder::autoscaling_policy_service::DeleteAutoscalingPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -175,22 +165,14 @@ impl AutoscalingPolicyService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::autoscaling_policy_service::SetIamPolicy {
         super::builder::autoscaling_policy_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::autoscaling_policy_service::GetIamPolicy {
         super::builder::autoscaling_policy_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -202,54 +184,36 @@ impl AutoscalingPolicyService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::autoscaling_policy_service::TestIamPermissions {
         super::builder::autoscaling_policy_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::autoscaling_policy_service::ListOperations {
         super::builder::autoscaling_policy_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::autoscaling_policy_service::GetOperation {
         super::builder::autoscaling_policy_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::autoscaling_policy_service::DeleteOperation {
         super::builder::autoscaling_policy_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autoscaling_policy_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::autoscaling_policy_service::CancelOperation {
         super::builder::autoscaling_policy_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -366,38 +330,24 @@ impl BatchController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_batch(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::CreateBatch {
+    pub fn create_batch(&self) -> super::builder::batch_controller::CreateBatch {
         super::builder::batch_controller::CreateBatch::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the batch workload resource representation.
-    pub fn get_batch(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::GetBatch {
-        super::builder::batch_controller::GetBatch::new(self.inner.clone()).set_name(name.into())
+    pub fn get_batch(&self) -> super::builder::batch_controller::GetBatch {
+        super::builder::batch_controller::GetBatch::new(self.inner.clone())
     }
 
     /// Lists batch workloads.
-    pub fn list_batches(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::ListBatches {
+    pub fn list_batches(&self) -> super::builder::batch_controller::ListBatches {
         super::builder::batch_controller::ListBatches::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the batch workload resource. If the batch is not in terminal state,
     /// the delete fails and the response returns `FAILED_PRECONDITION`.
-    pub fn delete_batch(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::DeleteBatch {
-        super::builder::batch_controller::DeleteBatch::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_batch(&self) -> super::builder::batch_controller::DeleteBatch {
+        super::builder::batch_controller::DeleteBatch::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -405,22 +355,14 @@ impl BatchController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::batch_controller::SetIamPolicy {
         super::builder::batch_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::batch_controller::GetIamPolicy {
         super::builder::batch_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -430,56 +372,36 @@ impl BatchController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::batch_controller::TestIamPermissions {
         super::builder::batch_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::batch_controller::ListOperations {
         super::builder::batch_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::GetOperation {
+    pub fn get_operation(&self) -> super::builder::batch_controller::GetOperation {
         super::builder::batch_controller::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::batch_controller::DeleteOperation {
         super::builder::batch_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::batch_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::batch_controller::CancelOperation {
         super::builder::batch_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -601,14 +523,8 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::cluster_controller::CreateCluster {
         super::builder::cluster_controller::CreateCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
     }
 
     /// Updates a cluster in a project. The returned
@@ -630,16 +546,8 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::cluster_controller::UpdateCluster {
         super::builder::cluster_controller::UpdateCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Stops a cluster in a project.
@@ -653,16 +561,8 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::StopCluster {
+    pub fn stop_cluster(&self) -> super::builder::cluster_controller::StopCluster {
         super::builder::cluster_controller::StopCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Starts a cluster in a project.
@@ -676,16 +576,8 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::StartCluster {
+    pub fn start_cluster(&self) -> super::builder::cluster_controller::StartCluster {
         super::builder::cluster_controller::StartCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Deletes a cluster in a project. The returned
@@ -703,40 +595,18 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::DeleteCluster {
+    pub fn delete_cluster(&self) -> super::builder::cluster_controller::DeleteCluster {
         super::builder::cluster_controller::DeleteCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Gets the resource representation for a cluster in a project.
-    pub fn get_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::GetCluster {
+    pub fn get_cluster(&self) -> super::builder::cluster_controller::GetCluster {
         super::builder::cluster_controller::GetCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Lists all regions/{region}/clusters in a project alphabetically.
-    pub fn list_clusters(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::cluster_controller::ListClusters {
         super::builder::cluster_controller::ListClusters::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
     }
 
     /// Gets cluster diagnostic information. The returned
@@ -759,16 +629,8 @@ impl ClusterController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn diagnose_cluster(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        cluster_name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::DiagnoseCluster {
+    pub fn diagnose_cluster(&self) -> super::builder::cluster_controller::DiagnoseCluster {
         super::builder::cluster_controller::DiagnoseCluster::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_cluster_name(cluster_name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -776,22 +638,14 @@ impl ClusterController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cluster_controller::SetIamPolicy {
         super::builder::cluster_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cluster_controller::GetIamPolicy {
         super::builder::cluster_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -801,56 +655,36 @@ impl ClusterController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::cluster_controller::TestIamPermissions {
         super::builder::cluster_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::cluster_controller::ListOperations {
         super::builder::cluster_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::GetOperation {
+    pub fn get_operation(&self) -> super::builder::cluster_controller::GetOperation {
         super::builder::cluster_controller::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::cluster_controller::DeleteOperation {
         super::builder::cluster_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::cluster_controller::CancelOperation {
         super::builder::cluster_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -955,14 +789,8 @@ impl JobController {
     }
 
     /// Submits a job to a cluster.
-    pub fn submit_job(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::SubmitJob {
+    pub fn submit_job(&self) -> super::builder::job_controller::SubmitJob {
         super::builder::job_controller::SubmitJob::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
     }
 
     /// Submits job to a cluster.
@@ -976,51 +804,23 @@ impl JobController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn submit_job_as_operation(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::SubmitJobAsOperation {
+    pub fn submit_job_as_operation(&self) -> super::builder::job_controller::SubmitJobAsOperation {
         super::builder::job_controller::SubmitJobAsOperation::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
     }
 
     /// Gets the resource representation for a job in a project.
-    pub fn get_job(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        job_id: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::GetJob {
+    pub fn get_job(&self) -> super::builder::job_controller::GetJob {
         super::builder::job_controller::GetJob::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_job_id(job_id.into())
     }
 
     /// Lists regions/{region}/jobs in a project.
-    pub fn list_jobs(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::ListJobs {
+    pub fn list_jobs(&self) -> super::builder::job_controller::ListJobs {
         super::builder::job_controller::ListJobs::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
     }
 
     /// Updates a job in a project.
-    pub fn update_job(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        job_id: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::UpdateJob {
+    pub fn update_job(&self) -> super::builder::job_controller::UpdateJob {
         super::builder::job_controller::UpdateJob::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_job_id(job_id.into())
     }
 
     /// Starts a job cancellation request. To access the job resource
@@ -1028,30 +828,14 @@ impl JobController {
     /// [regions/{region}/jobs.list](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/list)
     /// or
     /// [regions/{region}/jobs.get](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
-    pub fn cancel_job(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        job_id: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::CancelJob {
+    pub fn cancel_job(&self) -> super::builder::job_controller::CancelJob {
         super::builder::job_controller::CancelJob::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_job_id(job_id.into())
     }
 
     /// Deletes the job from the project. If the job is active, the delete fails,
     /// and the response returns `FAILED_PRECONDITION`.
-    pub fn delete_job(
-        &self,
-        project_id: impl Into<std::string::String>,
-        region: impl Into<std::string::String>,
-        job_id: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::DeleteJob {
+    pub fn delete_job(&self) -> super::builder::job_controller::DeleteJob {
         super::builder::job_controller::DeleteJob::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_region(region.into())
-            .set_job_id(job_id.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1059,22 +843,14 @@ impl JobController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::job_controller::SetIamPolicy {
         super::builder::job_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::job_controller::GetIamPolicy {
         super::builder::job_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1084,55 +860,36 @@ impl JobController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::job_controller::TestIamPermissions {
         super::builder::job_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::job_controller::ListOperations {
         super::builder::job_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::GetOperation {
-        super::builder::job_controller::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::job_controller::GetOperation {
+        super::builder::job_controller::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::job_controller::DeleteOperation {
         super::builder::job_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::job_controller::CancelOperation {
         super::builder::job_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1254,12 +1011,8 @@ impl NodeGroupController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_node_group(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::CreateNodeGroup {
+    pub fn create_node_group(&self) -> super::builder::node_group_controller::CreateNodeGroup {
         super::builder::node_group_controller::CreateNodeGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Resizes a node group in a cluster. The returned
@@ -1277,22 +1030,14 @@ impl NodeGroupController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn resize_node_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::ResizeNodeGroup {
+    pub fn resize_node_group(&self) -> super::builder::node_group_controller::ResizeNodeGroup {
         super::builder::node_group_controller::ResizeNodeGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the resource representation for a node group in a
     /// cluster.
-    pub fn get_node_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::GetNodeGroup {
+    pub fn get_node_group(&self) -> super::builder::node_group_controller::GetNodeGroup {
         super::builder::node_group_controller::GetNodeGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1300,22 +1045,14 @@ impl NodeGroupController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::node_group_controller::SetIamPolicy {
         super::builder::node_group_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::node_group_controller::GetIamPolicy {
         super::builder::node_group_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1327,54 +1064,36 @@ impl NodeGroupController {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::node_group_controller::TestIamPermissions {
         super::builder::node_group_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::node_group_controller::ListOperations {
         super::builder::node_group_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::GetOperation {
+    pub fn get_operation(&self) -> super::builder::node_group_controller::GetOperation {
         super::builder::node_group_controller::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::node_group_controller::DeleteOperation {
         super::builder::node_group_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::node_group_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::node_group_controller::CancelOperation {
         super::builder::node_group_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1483,46 +1202,36 @@ impl SessionTemplateController {
     /// Create a session template synchronously.
     pub fn create_session_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_template_controller::CreateSessionTemplate {
         super::builder::session_template_controller::CreateSessionTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the session template synchronously.
     pub fn update_session_template(
         &self,
-        session_template: impl Into<crate::model::SessionTemplate>,
     ) -> super::builder::session_template_controller::UpdateSessionTemplate {
         super::builder::session_template_controller::UpdateSessionTemplate::new(self.inner.clone())
-            .set_session_template(session_template.into())
     }
 
     /// Gets the resource representation for a session template.
     pub fn get_session_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_template_controller::GetSessionTemplate {
         super::builder::session_template_controller::GetSessionTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists session templates.
     pub fn list_session_templates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_template_controller::ListSessionTemplates {
         super::builder::session_template_controller::ListSessionTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a session template.
     pub fn delete_session_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_template_controller::DeleteSessionTemplate {
         super::builder::session_template_controller::DeleteSessionTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1530,22 +1239,14 @@ impl SessionTemplateController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::session_template_controller::SetIamPolicy {
         super::builder::session_template_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::session_template_controller::GetIamPolicy {
         super::builder::session_template_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1557,54 +1258,36 @@ impl SessionTemplateController {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::session_template_controller::TestIamPermissions {
         super::builder::session_template_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::session_template_controller::ListOperations {
         super::builder::session_template_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::GetOperation {
+    pub fn get_operation(&self) -> super::builder::session_template_controller::GetOperation {
         super::builder::session_template_controller::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::session_template_controller::DeleteOperation {
         super::builder::session_template_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_template_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::session_template_controller::CancelOperation {
         super::builder::session_template_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1721,30 +1404,18 @@ impl SessionController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_session(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::CreateSession {
+    pub fn create_session(&self) -> super::builder::session_controller::CreateSession {
         super::builder::session_controller::CreateSession::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the resource representation for an interactive session.
-    pub fn get_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::GetSession {
+    pub fn get_session(&self) -> super::builder::session_controller::GetSession {
         super::builder::session_controller::GetSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists interactive sessions.
-    pub fn list_sessions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::ListSessions {
+    pub fn list_sessions(&self) -> super::builder::session_controller::ListSessions {
         super::builder::session_controller::ListSessions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Terminates the interactive session.
@@ -1758,12 +1429,8 @@ impl SessionController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn terminate_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::TerminateSession {
+    pub fn terminate_session(&self) -> super::builder::session_controller::TerminateSession {
         super::builder::session_controller::TerminateSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the interactive session resource. If the session is not in terminal
@@ -1778,12 +1445,8 @@ impl SessionController {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::DeleteSession {
+    pub fn delete_session(&self) -> super::builder::session_controller::DeleteSession {
         super::builder::session_controller::DeleteSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1791,22 +1454,14 @@ impl SessionController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::session_controller::SetIamPolicy {
         super::builder::session_controller::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::session_controller::GetIamPolicy {
         super::builder::session_controller::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1816,56 +1471,36 @@ impl SessionController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::session_controller::TestIamPermissions {
         super::builder::session_controller::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::ListOperations {
+    pub fn list_operations(&self) -> super::builder::session_controller::ListOperations {
         super::builder::session_controller::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::GetOperation {
+    pub fn get_operation(&self) -> super::builder::session_controller::GetOperation {
         super::builder::session_controller::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::session_controller::DeleteOperation {
         super::builder::session_controller::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_controller::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::session_controller::CancelOperation {
         super::builder::session_controller::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1975,10 +1610,8 @@ impl WorkflowTemplateService {
     /// Creates new workflow template.
     pub fn create_workflow_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::CreateWorkflowTemplate {
         super::builder::workflow_template_service::CreateWorkflowTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the latest workflow template.
@@ -1987,10 +1620,8 @@ impl WorkflowTemplateService {
     /// version parameter.
     pub fn get_workflow_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::GetWorkflowTemplate {
         super::builder::workflow_template_service::GetWorkflowTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Instantiates a template and begins execution.
@@ -2029,12 +1660,10 @@ impl WorkflowTemplateService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn instantiate_workflow_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::InstantiateWorkflowTemplate {
         super::builder::workflow_template_service::InstantiateWorkflowTemplate::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Instantiates a template and begins execution.
@@ -2081,40 +1710,32 @@ impl WorkflowTemplateService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn instantiate_inline_workflow_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::InstantiateInlineWorkflowTemplate {
         super::builder::workflow_template_service::InstantiateInlineWorkflowTemplate::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates (replaces) workflow template. The updated template
     /// must contain version that matches the current server version.
     pub fn update_workflow_template(
         &self,
-        template: impl Into<crate::model::WorkflowTemplate>,
     ) -> super::builder::workflow_template_service::UpdateWorkflowTemplate {
         super::builder::workflow_template_service::UpdateWorkflowTemplate::new(self.inner.clone())
-            .set_template(template.into())
     }
 
     /// Lists workflows that match the specified filter in the request.
     pub fn list_workflow_templates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::ListWorkflowTemplates {
         super::builder::workflow_template_service::ListWorkflowTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a workflow template. It does not cancel in-progress workflows.
     pub fn delete_workflow_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::DeleteWorkflowTemplate {
         super::builder::workflow_template_service::DeleteWorkflowTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -2122,22 +1743,14 @@ impl WorkflowTemplateService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::workflow_template_service::SetIamPolicy {
         super::builder::workflow_template_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::workflow_template_service::GetIamPolicy {
         super::builder::workflow_template_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -2149,53 +1762,35 @@ impl WorkflowTemplateService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::workflow_template_service::TestIamPermissions {
         super::builder::workflow_template_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::workflow_template_service::ListOperations {
         super::builder::workflow_template_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::workflow_template_service::GetOperation {
         super::builder::workflow_template_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::workflow_template_service::DeleteOperation {
         super::builder::workflow_template_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflow_template_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::workflow_template_service::CancelOperation {
         super::builder::workflow_template_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutoscalingPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/autoscalingPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/autoscalingPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,18 +70,15 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutoscalingPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,9 +93,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutoscalingPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,12 +119,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutoscalingPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/autoscalingPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/autoscalingPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +147,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,12 +177,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,12 +201,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,12 +225,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -218,9 +249,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,9 +278,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,9 +304,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,9 +334,16 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +387,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/batches", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/batches", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +413,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Batch>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -366,9 +439,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBatchesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/batches", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/batches", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,9 +469,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,12 +499,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -432,12 +523,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -452,12 +547,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -472,9 +571,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -494,9 +600,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -513,9 +626,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -536,9 +656,16 @@ impl super::stub::BatchController for BatchController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,15 +723,26 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters",
-                    req.project_id, req.region
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,15 +764,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -668,15 +824,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}:stop",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}:stop",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -691,15 +865,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}:start",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}:start",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -714,15 +906,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,15 +951,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -766,15 +994,26 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters",
-                    req.project_id, req.region
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -794,15 +1033,33 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/clusters/{}:diagnose",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.cluster_name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("cluster_name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/clusters/{}:diagnose",
-                    req.project_id, req.region, req.cluster_name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -817,12 +1074,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -837,12 +1098,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -857,12 +1122,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -877,9 +1146,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -899,9 +1175,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -918,9 +1201,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -941,9 +1231,16 @@ impl super::stub::ClusterController for ClusterController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1001,15 +1298,26 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs:submit",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs:submit",
-                    req.project_id, req.region
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1024,15 +1332,26 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs:submitAsOperation",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs:submitAsOperation",
-                    req.project_id, req.region
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1047,15 +1366,33 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.job_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("job_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs/{}",
-                    req.project_id, req.region, req.job_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1072,15 +1409,26 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs",
-                    req.project_id, req.region
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1102,15 +1450,33 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.job_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("job_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs/{}",
-                    req.project_id, req.region, req.job_id
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1131,15 +1497,33 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs/{}:cancel",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.job_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("job_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs/{}:cancel",
-                    req.project_id, req.region, req.job_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1154,15 +1538,33 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/regions/{}/jobs/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.region;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("region"));
+                }
+                arg
+            },
+            {
+                let arg = &req.job_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("job_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/regions/{}/jobs/{}",
-                    req.project_id, req.region, req.job_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1183,12 +1585,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1203,12 +1609,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1223,12 +1633,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1243,9 +1657,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1265,9 +1686,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1284,9 +1712,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1307,9 +1742,16 @@ impl super::stub::JobController for JobController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1367,12 +1809,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/nodeGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/nodeGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1391,9 +1837,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resize", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resize", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1408,9 +1861,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NodeGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1427,12 +1887,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1447,12 +1911,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1467,12 +1935,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1487,9 +1959,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1509,9 +1988,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1528,9 +2014,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1551,9 +2044,16 @@ impl super::stub::NodeGroupController for NodeGroupController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1611,12 +2111,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sessionTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/sessionTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1633,18 +2137,15 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.session_template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("session_template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.session_template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("session_template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1661,9 +2162,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1680,12 +2188,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sessionTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/sessionTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1705,9 +2217,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1728,12 +2247,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1748,12 +2271,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1768,12 +2295,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1788,9 +2319,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1810,9 +2348,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1829,9 +2374,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1852,9 +2404,16 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1898,12 +2457,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/sessions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1922,9 +2485,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1941,9 +2511,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/sessions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1963,9 +2540,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:terminate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:terminate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1980,9 +2564,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2000,12 +2591,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2020,12 +2615,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2040,12 +2639,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2060,9 +2663,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2082,9 +2692,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2101,9 +2718,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2124,9 +2748,16 @@ impl super::stub::SessionController for SessionController {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2184,12 +2815,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkflowTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workflowTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workflowTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2206,9 +2841,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkflowTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2226,12 +2868,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:instantiate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:instantiate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2246,12 +2892,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workflowTemplates:instantiateInline", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workflowTemplates:instantiateInline", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2269,18 +2919,15 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkflowTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2297,12 +2944,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkflowTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workflowTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workflowTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2321,9 +2972,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2345,12 +3003,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2365,12 +3027,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2385,12 +3051,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2405,9 +3075,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2427,9 +3104,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2446,9 +3130,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2469,9 +3160,16 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -71,10 +71,15 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
     ) -> Result<gax::response::Response<crate::model::AutoscalingPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.policy
+            let arg = &req
+                .policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2138,10 +2143,15 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
     ) -> Result<gax::response::Response<crate::model::SessionTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.session_template
+            let arg = &req
+                .session_template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("session_template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session_template.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2920,10 +2930,15 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
     ) -> Result<gax::response::Response<crate::model::WorkflowTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.template
+            let arg = &req
+                .template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("template.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/datastream/v1/src/client.rs
+++ b/src/generated/cloud/datastream/v1/src/client.rs
@@ -120,21 +120,13 @@ impl Datastream {
 
     /// Use this method to list connection profiles created in a project and
     /// location.
-    pub fn list_connection_profiles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListConnectionProfiles {
+    pub fn list_connection_profiles(&self) -> super::builder::datastream::ListConnectionProfiles {
         super::builder::datastream::ListConnectionProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to get details about a connection profile.
-    pub fn get_connection_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetConnectionProfile {
+    pub fn get_connection_profile(&self) -> super::builder::datastream::GetConnectionProfile {
         super::builder::datastream::GetConnectionProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Use this method to create a connection profile in a project and location.
@@ -148,12 +140,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_connection_profile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::CreateConnectionProfile {
+    pub fn create_connection_profile(&self) -> super::builder::datastream::CreateConnectionProfile {
         super::builder::datastream::CreateConnectionProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to update the parameters of a connection profile.
@@ -167,12 +155,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_connection_profile(
-        &self,
-        connection_profile: impl Into<crate::model::ConnectionProfile>,
-    ) -> super::builder::datastream::UpdateConnectionProfile {
+    pub fn update_connection_profile(&self) -> super::builder::datastream::UpdateConnectionProfile {
         super::builder::datastream::UpdateConnectionProfile::new(self.inner.clone())
-            .set_connection_profile(connection_profile.into())
     }
 
     /// Use this method to delete a connection profile.
@@ -186,12 +170,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_connection_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::DeleteConnectionProfile {
+    pub fn delete_connection_profile(&self) -> super::builder::datastream::DeleteConnectionProfile {
         super::builder::datastream::DeleteConnectionProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Use this method to discover a connection profile.
@@ -200,26 +180,18 @@ impl Datastream {
     /// parent data object that's optionally supplied in the request.
     pub fn discover_connection_profile(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::datastream::DiscoverConnectionProfile {
         super::builder::datastream::DiscoverConnectionProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to list streams in a project and location.
-    pub fn list_streams(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListStreams {
-        super::builder::datastream::ListStreams::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_streams(&self) -> super::builder::datastream::ListStreams {
+        super::builder::datastream::ListStreams::new(self.inner.clone())
     }
 
     /// Use this method to get details about a stream.
-    pub fn get_stream(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetStream {
-        super::builder::datastream::GetStream::new(self.inner.clone()).set_name(name.into())
+    pub fn get_stream(&self) -> super::builder::datastream::GetStream {
+        super::builder::datastream::GetStream::new(self.inner.clone())
     }
 
     /// Use this method to create a stream.
@@ -233,11 +205,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_stream(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::CreateStream {
-        super::builder::datastream::CreateStream::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_stream(&self) -> super::builder::datastream::CreateStream {
+        super::builder::datastream::CreateStream::new(self.inner.clone())
     }
 
     /// Use this method to update the configuration of a stream.
@@ -251,11 +220,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_stream(
-        &self,
-        stream: impl Into<crate::model::Stream>,
-    ) -> super::builder::datastream::UpdateStream {
-        super::builder::datastream::UpdateStream::new(self.inner.clone()).set_stream(stream.into())
+    pub fn update_stream(&self) -> super::builder::datastream::UpdateStream {
+        super::builder::datastream::UpdateStream::new(self.inner.clone())
     }
 
     /// Use this method to delete a stream.
@@ -269,11 +235,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_stream(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::DeleteStream {
-        super::builder::datastream::DeleteStream::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_stream(&self) -> super::builder::datastream::DeleteStream {
+        super::builder::datastream::DeleteStream::new(self.inner.clone())
     }
 
     /// Use this method to start, resume or recover a stream with a non default CDC
@@ -288,64 +251,39 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_stream(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::RunStream {
-        super::builder::datastream::RunStream::new(self.inner.clone()).set_name(name.into())
+    pub fn run_stream(&self) -> super::builder::datastream::RunStream {
+        super::builder::datastream::RunStream::new(self.inner.clone())
     }
 
     /// Use this method to get details about a stream object.
-    pub fn get_stream_object(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetStreamObject {
-        super::builder::datastream::GetStreamObject::new(self.inner.clone()).set_name(name.into())
+    pub fn get_stream_object(&self) -> super::builder::datastream::GetStreamObject {
+        super::builder::datastream::GetStreamObject::new(self.inner.clone())
     }
 
     /// Use this method to look up a stream object by its source object identifier.
-    pub fn lookup_stream_object(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::LookupStreamObject {
+    pub fn lookup_stream_object(&self) -> super::builder::datastream::LookupStreamObject {
         super::builder::datastream::LookupStreamObject::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to list the objects of a specific stream.
-    pub fn list_stream_objects(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListStreamObjects {
+    pub fn list_stream_objects(&self) -> super::builder::datastream::ListStreamObjects {
         super::builder::datastream::ListStreamObjects::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to start a backfill job for the specified stream object.
-    pub fn start_backfill_job(
-        &self,
-        object: impl Into<std::string::String>,
-    ) -> super::builder::datastream::StartBackfillJob {
+    pub fn start_backfill_job(&self) -> super::builder::datastream::StartBackfillJob {
         super::builder::datastream::StartBackfillJob::new(self.inner.clone())
-            .set_object(object.into())
     }
 
     /// Use this method to stop a backfill job for the specified stream object.
-    pub fn stop_backfill_job(
-        &self,
-        object: impl Into<std::string::String>,
-    ) -> super::builder::datastream::StopBackfillJob {
+    pub fn stop_backfill_job(&self) -> super::builder::datastream::StopBackfillJob {
         super::builder::datastream::StopBackfillJob::new(self.inner.clone())
-            .set_object(object.into())
     }
 
     /// The FetchStaticIps API call exposes the static IP addresses used by
     /// Datastream.
-    pub fn fetch_static_ips(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::FetchStaticIps {
-        super::builder::datastream::FetchStaticIps::new(self.inner.clone()).set_name(name.into())
+    pub fn fetch_static_ips(&self) -> super::builder::datastream::FetchStaticIps {
+        super::builder::datastream::FetchStaticIps::new(self.inner.clone())
     }
 
     /// Use this method to create a private connectivity configuration.
@@ -359,31 +297,19 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_private_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::CreatePrivateConnection {
+    pub fn create_private_connection(&self) -> super::builder::datastream::CreatePrivateConnection {
         super::builder::datastream::CreatePrivateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to get details about a private connectivity configuration.
-    pub fn get_private_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetPrivateConnection {
+    pub fn get_private_connection(&self) -> super::builder::datastream::GetPrivateConnection {
         super::builder::datastream::GetPrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Use this method to list private connectivity configurations in a project
     /// and location.
-    pub fn list_private_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListPrivateConnections {
+    pub fn list_private_connections(&self) -> super::builder::datastream::ListPrivateConnections {
         super::builder::datastream::ListPrivateConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Use this method to delete a private connectivity configuration.
@@ -397,12 +323,8 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_private_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::DeletePrivateConnection {
+    pub fn delete_private_connection(&self) -> super::builder::datastream::DeletePrivateConnection {
         super::builder::datastream::DeletePrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Use this method to create a route for a private connectivity configuration
@@ -417,28 +339,19 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_route(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::CreateRoute {
-        super::builder::datastream::CreateRoute::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_route(&self) -> super::builder::datastream::CreateRoute {
+        super::builder::datastream::CreateRoute::new(self.inner.clone())
     }
 
     /// Use this method to get details about a route.
-    pub fn get_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetRoute {
-        super::builder::datastream::GetRoute::new(self.inner.clone()).set_name(name.into())
+    pub fn get_route(&self) -> super::builder::datastream::GetRoute {
+        super::builder::datastream::GetRoute::new(self.inner.clone())
     }
 
     /// Use this method to list routes created for a private connectivity
     /// configuration in a project and location.
-    pub fn list_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListRoutes {
-        super::builder::datastream::ListRoutes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_routes(&self) -> super::builder::datastream::ListRoutes {
+        super::builder::datastream::ListRoutes::new(self.inner.clone())
     }
 
     /// Use this method to delete a route.
@@ -452,66 +365,45 @@ impl Datastream {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::DeleteRoute {
-        super::builder::datastream::DeleteRoute::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_route(&self) -> super::builder::datastream::DeleteRoute {
+        super::builder::datastream::DeleteRoute::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListLocations {
-        super::builder::datastream::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::datastream::ListLocations {
+        super::builder::datastream::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetLocation {
-        super::builder::datastream::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::datastream::GetLocation {
+        super::builder::datastream::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::ListOperations {
-        super::builder::datastream::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::datastream::ListOperations {
+        super::builder::datastream::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::GetOperation {
-        super::builder::datastream::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::datastream::GetOperation {
+        super::builder::datastream::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::DeleteOperation {
-        super::builder::datastream::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::datastream::DeleteOperation {
+        super::builder::datastream::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastream::CancelOperation {
-        super::builder::datastream::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::datastream::CancelOperation {
+        super::builder::datastream::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectionProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectionProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectionProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connectionProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connectionProfiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -117,18 +132,15 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.connection_profile
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.connection_profile
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -154,9 +166,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +193,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoverConnectionProfileResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connectionProfiles:discover", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connectionProfiles:discover", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,9 +217,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListStreamsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/streams", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/streams", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -217,9 +247,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Stream>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,9 +273,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/streams", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/streams", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -257,18 +301,15 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.stream
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("stream"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.stream
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("stream"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,9 +333,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,9 +360,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +384,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamObject>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,12 +410,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamObject>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/objects:lookup", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/objects:lookup", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -368,9 +434,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListStreamObjectsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/objects", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/objects", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,12 +462,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StartBackfillJobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:startBackfillJob", {
+            let arg = &req.object;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("object"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:startBackfillJob", req.object),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,12 +486,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StopBackfillJobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stopBackfillJob", {
+            let arg = &req.object;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("object"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:stopBackfillJob", req.object),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,12 +510,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchStaticIpsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchStaticIps", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchStaticIps", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -453,12 +538,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -478,9 +567,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PrivateConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -497,12 +593,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPrivateConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -523,9 +623,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -544,9 +651,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/routes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/routes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,9 +677,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Route>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -582,9 +703,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/routes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/routes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -605,9 +733,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -625,9 +760,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -647,9 +789,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -666,9 +815,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -688,9 +844,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -707,9 +870,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -730,9 +900,16 @@ impl super::stub::Datastream for Datastream {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -133,10 +133,15 @@ impl super::stub::Datastream for Datastream {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.connection_profile
+            let arg = &req
+                .connection_profile
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("connection_profile"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection_profile.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -302,10 +307,15 @@ impl super::stub::Datastream for Datastream {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.stream
+            let arg = &req
+                .stream
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("stream"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("stream.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/deploy/v1/src/client.rs
+++ b/src/generated/cloud/deploy/v1/src/client.rs
@@ -120,21 +120,13 @@ impl CloudDeploy {
     }
 
     /// Lists DeliveryPipelines in a given project and location.
-    pub fn list_delivery_pipelines(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListDeliveryPipelines {
+    pub fn list_delivery_pipelines(&self) -> super::builder::cloud_deploy::ListDeliveryPipelines {
         super::builder::cloud_deploy::ListDeliveryPipelines::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single DeliveryPipeline.
-    pub fn get_delivery_pipeline(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetDeliveryPipeline {
+    pub fn get_delivery_pipeline(&self) -> super::builder::cloud_deploy::GetDeliveryPipeline {
         super::builder::cloud_deploy::GetDeliveryPipeline::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new DeliveryPipeline in a given project and location.
@@ -148,12 +140,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_delivery_pipeline(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateDeliveryPipeline {
+    pub fn create_delivery_pipeline(&self) -> super::builder::cloud_deploy::CreateDeliveryPipeline {
         super::builder::cloud_deploy::CreateDeliveryPipeline::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single DeliveryPipeline.
@@ -167,12 +155,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_delivery_pipeline(
-        &self,
-        delivery_pipeline: impl Into<crate::model::DeliveryPipeline>,
-    ) -> super::builder::cloud_deploy::UpdateDeliveryPipeline {
+    pub fn update_delivery_pipeline(&self) -> super::builder::cloud_deploy::UpdateDeliveryPipeline {
         super::builder::cloud_deploy::UpdateDeliveryPipeline::new(self.inner.clone())
-            .set_delivery_pipeline(delivery_pipeline.into())
     }
 
     /// Deletes a single DeliveryPipeline.
@@ -186,36 +170,23 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_delivery_pipeline(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::DeleteDeliveryPipeline {
+    pub fn delete_delivery_pipeline(&self) -> super::builder::cloud_deploy::DeleteDeliveryPipeline {
         super::builder::cloud_deploy::DeleteDeliveryPipeline::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Targets in a given project and location.
-    pub fn list_targets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListTargets {
-        super::builder::cloud_deploy::ListTargets::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_targets(&self) -> super::builder::cloud_deploy::ListTargets {
+        super::builder::cloud_deploy::ListTargets::new(self.inner.clone())
     }
 
     /// Creates a `Rollout` to roll back the specified target.
-    pub fn rollback_target(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::RollbackTarget {
-        super::builder::cloud_deploy::RollbackTarget::new(self.inner.clone()).set_name(name.into())
+    pub fn rollback_target(&self) -> super::builder::cloud_deploy::RollbackTarget {
+        super::builder::cloud_deploy::RollbackTarget::new(self.inner.clone())
     }
 
     /// Gets details of a single Target.
-    pub fn get_target(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetTarget {
-        super::builder::cloud_deploy::GetTarget::new(self.inner.clone()).set_name(name.into())
+    pub fn get_target(&self) -> super::builder::cloud_deploy::GetTarget {
+        super::builder::cloud_deploy::GetTarget::new(self.inner.clone())
     }
 
     /// Creates a new Target in a given project and location.
@@ -229,12 +200,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_target(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateTarget {
+    pub fn create_target(&self) -> super::builder::cloud_deploy::CreateTarget {
         super::builder::cloud_deploy::CreateTarget::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Target.
@@ -248,12 +215,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_target(
-        &self,
-        target: impl Into<crate::model::Target>,
-    ) -> super::builder::cloud_deploy::UpdateTarget {
+    pub fn update_target(&self) -> super::builder::cloud_deploy::UpdateTarget {
         super::builder::cloud_deploy::UpdateTarget::new(self.inner.clone())
-            .set_target(target.into())
     }
 
     /// Deletes a single Target.
@@ -267,29 +230,18 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_target(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::DeleteTarget {
-        super::builder::cloud_deploy::DeleteTarget::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_target(&self) -> super::builder::cloud_deploy::DeleteTarget {
+        super::builder::cloud_deploy::DeleteTarget::new(self.inner.clone())
     }
 
     /// Lists CustomTargetTypes in a given project and location.
-    pub fn list_custom_target_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListCustomTargetTypes {
+    pub fn list_custom_target_types(&self) -> super::builder::cloud_deploy::ListCustomTargetTypes {
         super::builder::cloud_deploy::ListCustomTargetTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CustomTargetType.
-    pub fn get_custom_target_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetCustomTargetType {
+    pub fn get_custom_target_type(&self) -> super::builder::cloud_deploy::GetCustomTargetType {
         super::builder::cloud_deploy::GetCustomTargetType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new CustomTargetType in a given project and location.
@@ -305,10 +257,8 @@ impl CloudDeploy {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_custom_target_type(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cloud_deploy::CreateCustomTargetType {
         super::builder::cloud_deploy::CreateCustomTargetType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a single CustomTargetType.
@@ -324,10 +274,8 @@ impl CloudDeploy {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_custom_target_type(
         &self,
-        custom_target_type: impl Into<crate::model::CustomTargetType>,
     ) -> super::builder::cloud_deploy::UpdateCustomTargetType {
         super::builder::cloud_deploy::UpdateCustomTargetType::new(self.inner.clone())
-            .set_custom_target_type(custom_target_type.into())
     }
 
     /// Deletes a single CustomTargetType.
@@ -343,27 +291,18 @@ impl CloudDeploy {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_custom_target_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_deploy::DeleteCustomTargetType {
         super::builder::cloud_deploy::DeleteCustomTargetType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Releases in a given project and location.
-    pub fn list_releases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListReleases {
+    pub fn list_releases(&self) -> super::builder::cloud_deploy::ListReleases {
         super::builder::cloud_deploy::ListReleases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Release.
-    pub fn get_release(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetRelease {
-        super::builder::cloud_deploy::GetRelease::new(self.inner.clone()).set_name(name.into())
+    pub fn get_release(&self) -> super::builder::cloud_deploy::GetRelease {
+        super::builder::cloud_deploy::GetRelease::new(self.inner.clone())
     }
 
     /// Creates a new Release in a given project and location.
@@ -377,20 +316,13 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_release(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateRelease {
+    pub fn create_release(&self) -> super::builder::cloud_deploy::CreateRelease {
         super::builder::cloud_deploy::CreateRelease::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Abandons a Release in the Delivery Pipeline.
-    pub fn abandon_release(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::AbandonRelease {
-        super::builder::cloud_deploy::AbandonRelease::new(self.inner.clone()).set_name(name.into())
+    pub fn abandon_release(&self) -> super::builder::cloud_deploy::AbandonRelease {
+        super::builder::cloud_deploy::AbandonRelease::new(self.inner.clone())
     }
 
     /// Creates a new DeployPolicy in a given project and location.
@@ -404,12 +336,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_deploy_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateDeployPolicy {
+    pub fn create_deploy_policy(&self) -> super::builder::cloud_deploy::CreateDeployPolicy {
         super::builder::cloud_deploy::CreateDeployPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single DeployPolicy.
@@ -423,12 +351,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_deploy_policy(
-        &self,
-        deploy_policy: impl Into<crate::model::DeployPolicy>,
-    ) -> super::builder::cloud_deploy::UpdateDeployPolicy {
+    pub fn update_deploy_policy(&self) -> super::builder::cloud_deploy::UpdateDeployPolicy {
         super::builder::cloud_deploy::UpdateDeployPolicy::new(self.inner.clone())
-            .set_deploy_policy(deploy_policy.into())
     }
 
     /// Deletes a single DeployPolicy.
@@ -442,70 +366,43 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_deploy_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::DeleteDeployPolicy {
+    pub fn delete_deploy_policy(&self) -> super::builder::cloud_deploy::DeleteDeployPolicy {
         super::builder::cloud_deploy::DeleteDeployPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DeployPolicies in a given project and location.
-    pub fn list_deploy_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListDeployPolicies {
+    pub fn list_deploy_policies(&self) -> super::builder::cloud_deploy::ListDeployPolicies {
         super::builder::cloud_deploy::ListDeployPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single DeployPolicy.
-    pub fn get_deploy_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetDeployPolicy {
-        super::builder::cloud_deploy::GetDeployPolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn get_deploy_policy(&self) -> super::builder::cloud_deploy::GetDeployPolicy {
+        super::builder::cloud_deploy::GetDeployPolicy::new(self.inner.clone())
     }
 
     /// Approves a Rollout.
-    pub fn approve_rollout(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ApproveRollout {
-        super::builder::cloud_deploy::ApproveRollout::new(self.inner.clone()).set_name(name.into())
+    pub fn approve_rollout(&self) -> super::builder::cloud_deploy::ApproveRollout {
+        super::builder::cloud_deploy::ApproveRollout::new(self.inner.clone())
     }
 
     /// Advances a Rollout in a given project and location.
-    pub fn advance_rollout(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::AdvanceRollout {
-        super::builder::cloud_deploy::AdvanceRollout::new(self.inner.clone()).set_name(name.into())
+    pub fn advance_rollout(&self) -> super::builder::cloud_deploy::AdvanceRollout {
+        super::builder::cloud_deploy::AdvanceRollout::new(self.inner.clone())
     }
 
     /// Cancels a Rollout in a given project and location.
-    pub fn cancel_rollout(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CancelRollout {
-        super::builder::cloud_deploy::CancelRollout::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_rollout(&self) -> super::builder::cloud_deploy::CancelRollout {
+        super::builder::cloud_deploy::CancelRollout::new(self.inner.clone())
     }
 
     /// Lists Rollouts in a given project and location.
-    pub fn list_rollouts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListRollouts {
+    pub fn list_rollouts(&self) -> super::builder::cloud_deploy::ListRollouts {
         super::builder::cloud_deploy::ListRollouts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Rollout.
-    pub fn get_rollout(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetRollout {
-        super::builder::cloud_deploy::GetRollout::new(self.inner.clone()).set_name(name.into())
+    pub fn get_rollout(&self) -> super::builder::cloud_deploy::GetRollout {
+        super::builder::cloud_deploy::GetRollout::new(self.inner.clone())
     }
 
     /// Creates a new Rollout in a given project and location.
@@ -519,60 +416,38 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_rollout(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateRollout {
+    pub fn create_rollout(&self) -> super::builder::cloud_deploy::CreateRollout {
         super::builder::cloud_deploy::CreateRollout::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Ignores the specified Job in a Rollout.
-    pub fn ignore_job(
-        &self,
-        rollout: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::IgnoreJob {
-        super::builder::cloud_deploy::IgnoreJob::new(self.inner.clone()).set_rollout(rollout.into())
+    pub fn ignore_job(&self) -> super::builder::cloud_deploy::IgnoreJob {
+        super::builder::cloud_deploy::IgnoreJob::new(self.inner.clone())
     }
 
     /// Retries the specified Job in a Rollout.
-    pub fn retry_job(
-        &self,
-        rollout: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::RetryJob {
-        super::builder::cloud_deploy::RetryJob::new(self.inner.clone()).set_rollout(rollout.into())
+    pub fn retry_job(&self) -> super::builder::cloud_deploy::RetryJob {
+        super::builder::cloud_deploy::RetryJob::new(self.inner.clone())
     }
 
     /// Lists JobRuns in a given project and location.
-    pub fn list_job_runs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListJobRuns {
-        super::builder::cloud_deploy::ListJobRuns::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_job_runs(&self) -> super::builder::cloud_deploy::ListJobRuns {
+        super::builder::cloud_deploy::ListJobRuns::new(self.inner.clone())
     }
 
     /// Gets details of a single JobRun.
-    pub fn get_job_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetJobRun {
-        super::builder::cloud_deploy::GetJobRun::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job_run(&self) -> super::builder::cloud_deploy::GetJobRun {
+        super::builder::cloud_deploy::GetJobRun::new(self.inner.clone())
     }
 
     /// Terminates a Job Run in a given project and location.
-    pub fn terminate_job_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::TerminateJobRun {
-        super::builder::cloud_deploy::TerminateJobRun::new(self.inner.clone()).set_name(name.into())
+    pub fn terminate_job_run(&self) -> super::builder::cloud_deploy::TerminateJobRun {
+        super::builder::cloud_deploy::TerminateJobRun::new(self.inner.clone())
     }
 
     /// Gets the configuration for a location.
-    pub fn get_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetConfig {
-        super::builder::cloud_deploy::GetConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_config(&self) -> super::builder::cloud_deploy::GetConfig {
+        super::builder::cloud_deploy::GetConfig::new(self.inner.clone())
     }
 
     /// Creates a new Automation in a given project and location.
@@ -586,12 +461,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_automation(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CreateAutomation {
+    pub fn create_automation(&self) -> super::builder::cloud_deploy::CreateAutomation {
         super::builder::cloud_deploy::CreateAutomation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Automation resource.
@@ -605,12 +476,8 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_automation(
-        &self,
-        automation: impl Into<crate::model::Automation>,
-    ) -> super::builder::cloud_deploy::UpdateAutomation {
+    pub fn update_automation(&self) -> super::builder::cloud_deploy::UpdateAutomation {
         super::builder::cloud_deploy::UpdateAutomation::new(self.inner.clone())
-            .set_automation(automation.into())
     }
 
     /// Deletes a single Automation resource.
@@ -624,75 +491,46 @@ impl CloudDeploy {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_automation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::DeleteAutomation {
+    pub fn delete_automation(&self) -> super::builder::cloud_deploy::DeleteAutomation {
         super::builder::cloud_deploy::DeleteAutomation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets details of a single Automation.
-    pub fn get_automation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetAutomation {
-        super::builder::cloud_deploy::GetAutomation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_automation(&self) -> super::builder::cloud_deploy::GetAutomation {
+        super::builder::cloud_deploy::GetAutomation::new(self.inner.clone())
     }
 
     /// Lists Automations in a given project and location.
-    pub fn list_automations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListAutomations {
+    pub fn list_automations(&self) -> super::builder::cloud_deploy::ListAutomations {
         super::builder::cloud_deploy::ListAutomations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single AutomationRun.
-    pub fn get_automation_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetAutomationRun {
+    pub fn get_automation_run(&self) -> super::builder::cloud_deploy::GetAutomationRun {
         super::builder::cloud_deploy::GetAutomationRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists AutomationRuns in a given project and location.
-    pub fn list_automation_runs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListAutomationRuns {
+    pub fn list_automation_runs(&self) -> super::builder::cloud_deploy::ListAutomationRuns {
         super::builder::cloud_deploy::ListAutomationRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Cancels an AutomationRun. The `state` of the `AutomationRun` after
     /// cancelling is `CANCELLED`. `CancelAutomationRun` can be called on
     /// AutomationRun in the state `IN_PROGRESS` and `PENDING`; AutomationRun
     /// in a different state returns an `FAILED_PRECONDITION` error.
-    pub fn cancel_automation_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CancelAutomationRun {
+    pub fn cancel_automation_run(&self) -> super::builder::cloud_deploy::CancelAutomationRun {
         super::builder::cloud_deploy::CancelAutomationRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListLocations {
-        super::builder::cloud_deploy::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::cloud_deploy::ListLocations {
+        super::builder::cloud_deploy::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetLocation {
-        super::builder::cloud_deploy::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cloud_deploy::GetLocation {
+        super::builder::cloud_deploy::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -700,22 +538,14 @@ impl CloudDeploy {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cloud_deploy::SetIamPolicy {
         super::builder::cloud_deploy::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cloud_deploy::GetIamPolicy {
         super::builder::cloud_deploy::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -725,51 +555,35 @@ impl CloudDeploy {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::cloud_deploy::TestIamPermissions {
         super::builder::cloud_deploy::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::ListOperations {
-        super::builder::cloud_deploy::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::cloud_deploy::ListOperations {
+        super::builder::cloud_deploy::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::GetOperation {
-        super::builder::cloud_deploy::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cloud_deploy::GetOperation {
+        super::builder::cloud_deploy::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::DeleteOperation {
-        super::builder::cloud_deploy::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::cloud_deploy::DeleteOperation {
+        super::builder::cloud_deploy::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_deploy::CancelOperation {
-        super::builder::cloud_deploy::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::cloud_deploy::CancelOperation {
+        super::builder::cloud_deploy::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeliveryPipelinesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deliveryPipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deliveryPipelines", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeliveryPipeline>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deliveryPipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deliveryPipelines", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.delivery_pipeline
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("delivery_pipeline"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.delivery_pipeline
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("delivery_pipeline"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -153,9 +165,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -177,9 +196,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTargetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/targets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/targets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,12 +226,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RollbackTargetResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rollbackTarget", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rollbackTarget", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -220,9 +250,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Target>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,9 +276,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/targets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/targets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,18 +303,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.target
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("target"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.target
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("target"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,9 +335,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -317,12 +365,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomTargetTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/customTargetTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/customTargetTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -343,9 +395,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomTargetType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -362,12 +421,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/customTargetTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/customTargetTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -387,18 +450,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.custom_target_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("custom_target_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.custom_target_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("custom_target_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -424,9 +484,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,9 +514,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReleasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/releases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/releases", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,9 +544,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Release>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,12 +570,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/releases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/releases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -520,9 +605,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AbandonReleaseResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:abandon", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:abandon", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -537,12 +629,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deployPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deployPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -562,18 +658,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.deploy_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deploy_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.deploy_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deploy_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -599,9 +692,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -622,12 +722,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeployPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -648,9 +752,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeployPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,9 +778,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ApproveRolloutResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:approve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -684,9 +802,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AdvanceRolloutResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:advance", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:advance", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,9 +826,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CancelRolloutResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -718,9 +850,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRolloutsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/rollouts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/rollouts", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,9 +880,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rollout>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -760,12 +906,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/rollouts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/rollouts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -792,12 +942,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IgnoreJobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:ignoreJob", {
+            let arg = &req.rollout;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rollout"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:ignoreJob", req.rollout),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -812,12 +966,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RetryJobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:retryJob", {
+            let arg = &req.rollout;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rollout"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:retryJob", req.rollout),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -832,9 +990,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobRuns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobRuns", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -855,9 +1020,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -874,9 +1046,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TerminateJobRunResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:terminate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:terminate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -891,9 +1070,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Config>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -910,12 +1096,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/automations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/automations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -935,18 +1125,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.automation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("automation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.automation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("automation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -972,9 +1159,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -995,9 +1189,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Automation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1014,12 +1215,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutomationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/automations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/automations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1040,9 +1245,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutomationRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1059,12 +1271,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutomationRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/automationRuns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/automationRuns", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1085,9 +1301,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CancelAutomationRunResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1102,9 +1325,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1124,9 +1354,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1143,12 +1380,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1163,12 +1404,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1195,12 +1440,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1215,9 +1464,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1237,9 +1493,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1256,9 +1519,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1279,9 +1549,16 @@ impl super::stub::CloudDeploy for CloudDeploy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.delivery_pipeline
+            let arg = &req
+                .delivery_pipeline
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("delivery_pipeline"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("delivery_pipeline.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -304,10 +309,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.target
+            let arg = &req
+                .target
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("target"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("target.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -451,10 +461,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.custom_target_type
+            let arg = &req
+                .custom_target_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("custom_target_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("custom_target_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -659,10 +674,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.deploy_policy
+            let arg = &req
+                .deploy_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deploy_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deploy_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1126,10 +1146,15 @@ impl super::stub::CloudDeploy for CloudDeploy {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.automation
+            let arg = &req
+                .automation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("automation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("automation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/developerconnect/v1/src/client.rs
+++ b/src/generated/cloud/developerconnect/v1/src/client.rs
@@ -121,21 +121,13 @@ impl DeveloperConnect {
     }
 
     /// Lists Connections in a given project and location.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::ListConnections {
+    pub fn list_connections(&self) -> super::builder::developer_connect::ListConnections {
         super::builder::developer_connect::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Connection.
-    pub fn get_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::GetConnection {
+    pub fn get_connection(&self) -> super::builder::developer_connect::GetConnection {
         super::builder::developer_connect::GetConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Connection in a given project and location.
@@ -149,12 +141,8 @@ impl DeveloperConnect {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::CreateConnection {
+    pub fn create_connection(&self) -> super::builder::developer_connect::CreateConnection {
         super::builder::developer_connect::CreateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Connection.
@@ -168,12 +156,8 @@ impl DeveloperConnect {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_connection(
-        &self,
-        connection: impl Into<crate::model::Connection>,
-    ) -> super::builder::developer_connect::UpdateConnection {
+    pub fn update_connection(&self) -> super::builder::developer_connect::UpdateConnection {
         super::builder::developer_connect::UpdateConnection::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// Deletes a single Connection.
@@ -187,12 +171,8 @@ impl DeveloperConnect {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::DeleteConnection {
+    pub fn delete_connection(&self) -> super::builder::developer_connect::DeleteConnection {
         super::builder::developer_connect::DeleteConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a GitRepositoryLink. Upon linking a Git Repository, Developer
@@ -212,10 +192,8 @@ impl DeveloperConnect {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_git_repository_link(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::CreateGitRepositoryLink {
         super::builder::developer_connect::CreateGitRepositoryLink::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single GitRepositoryLink.
@@ -231,56 +209,40 @@ impl DeveloperConnect {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_git_repository_link(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::DeleteGitRepositoryLink {
         super::builder::developer_connect::DeleteGitRepositoryLink::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists GitRepositoryLinks in a given project, location, and connection.
     pub fn list_git_repository_links(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::ListGitRepositoryLinks {
         super::builder::developer_connect::ListGitRepositoryLinks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single GitRepositoryLink.
     pub fn get_git_repository_link(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::GetGitRepositoryLink {
         super::builder::developer_connect::GetGitRepositoryLink::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fetches read/write token of a given gitRepositoryLink.
-    pub fn fetch_read_write_token(
-        &self,
-        git_repository_link: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::FetchReadWriteToken {
+    pub fn fetch_read_write_token(&self) -> super::builder::developer_connect::FetchReadWriteToken {
         super::builder::developer_connect::FetchReadWriteToken::new(self.inner.clone())
-            .set_git_repository_link(git_repository_link.into())
     }
 
     /// Fetches read token of a given gitRepositoryLink.
-    pub fn fetch_read_token(
-        &self,
-        git_repository_link: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::FetchReadToken {
+    pub fn fetch_read_token(&self) -> super::builder::developer_connect::FetchReadToken {
         super::builder::developer_connect::FetchReadToken::new(self.inner.clone())
-            .set_git_repository_link(git_repository_link.into())
     }
 
     /// FetchLinkableGitRepositories returns a list of git repositories from an SCM
     /// that are available to be added to a Connection.
     pub fn fetch_linkable_git_repositories(
         &self,
-        connection: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::FetchLinkableGitRepositories {
         super::builder::developer_connect::FetchLinkableGitRepositories::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// FetchGitHubInstallations returns the list of GitHub Installations that
@@ -289,80 +251,50 @@ impl DeveloperConnect {
     /// are returned. For GitHub Enterprise, all installations are returned.
     pub fn fetch_git_hub_installations(
         &self,
-        connection: impl Into<std::string::String>,
     ) -> super::builder::developer_connect::FetchGitHubInstallations {
         super::builder::developer_connect::FetchGitHubInstallations::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// Fetch the list of branches or tags for a given repository.
-    pub fn fetch_git_refs(
-        &self,
-        git_repository_link: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::FetchGitRefs {
+    pub fn fetch_git_refs(&self) -> super::builder::developer_connect::FetchGitRefs {
         super::builder::developer_connect::FetchGitRefs::new(self.inner.clone())
-            .set_git_repository_link(git_repository_link.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::ListLocations {
+    pub fn list_locations(&self) -> super::builder::developer_connect::ListLocations {
         super::builder::developer_connect::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::GetLocation {
+    pub fn get_location(&self) -> super::builder::developer_connect::GetLocation {
         super::builder::developer_connect::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::ListOperations {
+    pub fn list_operations(&self) -> super::builder::developer_connect::ListOperations {
         super::builder::developer_connect::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::GetOperation {
+    pub fn get_operation(&self) -> super::builder::developer_connect::GetOperation {
         super::builder::developer_connect::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::developer_connect::DeleteOperation {
         super::builder::developer_connect::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::developer_connect::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::developer_connect::CancelOperation {
         super::builder::developer_connect::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -153,9 +165,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,12 +194,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/gitRepositoryLinks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/gitRepositoryLinks", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,9 +223,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,12 +252,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGitRepositoryLinksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/gitRepositoryLinks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/gitRepositoryLinks", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -248,9 +282,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GitRepositoryLink>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -267,12 +308,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchReadWriteTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:fetchReadWriteToken", {
+            let arg = &req.git_repository_link;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("git_repository_link"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:fetchReadWriteToken", req.git_repository_link),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -287,12 +332,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchReadTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:fetchReadToken", {
+            let arg = &req.git_repository_link;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("git_repository_link"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:fetchReadToken", req.git_repository_link),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,12 +356,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchLinkableGitRepositoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchLinkableGitRepositories", {
+            let arg = &req.connection;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchLinkableGitRepositories", req.connection),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -331,12 +384,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchGitHubInstallationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchGitHubInstallations", {
+            let arg = &req.connection;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchGitHubInstallations", req.connection),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,12 +410,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchGitRefsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchGitRefs", {
+            let arg = &req.git_repository_link;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("git_repository_link"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchGitRefs", req.git_repository_link),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -378,9 +439,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -400,9 +468,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -419,9 +494,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -441,9 +523,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -460,9 +549,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -483,9 +579,16 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.connection
+            let arg = &req
+                .connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/dialogflow/cx/v3/src/client.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/client.rs
@@ -121,19 +121,13 @@ impl Agents {
     }
 
     /// Returns the list of all agents in the specified location.
-    pub fn list_agents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::ListAgents {
-        super::builder::agents::ListAgents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_agents(&self) -> super::builder::agents::ListAgents {
+        super::builder::agents::ListAgents::new(self.inner.clone())
     }
 
     /// Retrieves the specified agent.
-    pub fn get_agent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetAgent {
-        super::builder::agents::GetAgent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_agent(&self) -> super::builder::agents::GetAgent {
+        super::builder::agents::GetAgent::new(self.inner.clone())
     }
 
     /// Creates an agent in the specified location.
@@ -141,11 +135,8 @@ impl Agents {
     /// Note: You should always train flows prior to sending them queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn create_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::CreateAgent {
-        super::builder::agents::CreateAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_agent(&self) -> super::builder::agents::CreateAgent {
+        super::builder::agents::CreateAgent::new(self.inner.clone())
     }
 
     /// Updates the specified agent.
@@ -153,19 +144,13 @@ impl Agents {
     /// Note: You should always train flows prior to sending them queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn update_agent(
-        &self,
-        agent: impl Into<crate::model::Agent>,
-    ) -> super::builder::agents::UpdateAgent {
-        super::builder::agents::UpdateAgent::new(self.inner.clone()).set_agent(agent.into())
+    pub fn update_agent(&self) -> super::builder::agents::UpdateAgent {
+        super::builder::agents::UpdateAgent::new(self.inner.clone())
     }
 
     /// Deletes the specified agent.
-    pub fn delete_agent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::DeleteAgent {
-        super::builder::agents::DeleteAgent::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_agent(&self) -> super::builder::agents::DeleteAgent {
+        super::builder::agents::DeleteAgent::new(self.inner.clone())
     }
 
     /// Exports the specified agent to a binary file.
@@ -190,11 +175,8 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_agent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ExportAgent {
-        super::builder::agents::ExportAgent::new(self.inner.clone()).set_name(name.into())
+    pub fn export_agent(&self) -> super::builder::agents::ExportAgent {
+        super::builder::agents::ExportAgent::new(self.inner.clone())
     }
 
     /// Restores the specified agent from a binary file.
@@ -224,94 +206,62 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_agent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::RestoreAgent {
-        super::builder::agents::RestoreAgent::new(self.inner.clone()).set_name(name.into())
+    pub fn restore_agent(&self) -> super::builder::agents::RestoreAgent {
+        super::builder::agents::RestoreAgent::new(self.inner.clone())
     }
 
     /// Validates the specified agent and creates or updates validation results.
     /// The agent in draft version is validated. Please call this API after the
     /// training is completed to get the complete validation results.
-    pub fn validate_agent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ValidateAgent {
-        super::builder::agents::ValidateAgent::new(self.inner.clone()).set_name(name.into())
+    pub fn validate_agent(&self) -> super::builder::agents::ValidateAgent {
+        super::builder::agents::ValidateAgent::new(self.inner.clone())
     }
 
     /// Gets the latest agent validation result. Agent validation is performed
     /// when ValidateAgent is called.
-    pub fn get_agent_validation_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetAgentValidationResult {
+    pub fn get_agent_validation_result(&self) -> super::builder::agents::GetAgentValidationResult {
         super::builder::agents::GetAgentValidationResult::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the generative settings for the agent.
-    pub fn get_generative_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetGenerativeSettings {
-        super::builder::agents::GetGenerativeSettings::new(self.inner.clone()).set_name(name.into())
+    pub fn get_generative_settings(&self) -> super::builder::agents::GetGenerativeSettings {
+        super::builder::agents::GetGenerativeSettings::new(self.inner.clone())
     }
 
     /// Updates the generative settings for the agent.
-    pub fn update_generative_settings(
-        &self,
-        generative_settings: impl Into<crate::model::GenerativeSettings>,
-    ) -> super::builder::agents::UpdateGenerativeSettings {
+    pub fn update_generative_settings(&self) -> super::builder::agents::UpdateGenerativeSettings {
         super::builder::agents::UpdateGenerativeSettings::new(self.inner.clone())
-            .set_generative_settings(generative_settings.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ListLocations {
-        super::builder::agents::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::agents::ListLocations {
+        super::builder::agents::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetLocation {
-        super::builder::agents::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::agents::GetLocation {
+        super::builder::agents::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ListOperations {
-        super::builder::agents::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::agents::ListOperations {
+        super::builder::agents::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetOperation {
-        super::builder::agents::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::agents::GetOperation {
+        super::builder::agents::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::CancelOperation {
-        super::builder::agents::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::agents::CancelOperation {
+        super::builder::agents::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -418,66 +368,44 @@ impl Changelogs {
     }
 
     /// Returns the list of Changelogs.
-    pub fn list_changelogs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::ListChangelogs {
+    pub fn list_changelogs(&self) -> super::builder::changelogs::ListChangelogs {
         super::builder::changelogs::ListChangelogs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified Changelog.
-    pub fn get_changelog(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::GetChangelog {
-        super::builder::changelogs::GetChangelog::new(self.inner.clone()).set_name(name.into())
+    pub fn get_changelog(&self) -> super::builder::changelogs::GetChangelog {
+        super::builder::changelogs::GetChangelog::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::ListLocations {
-        super::builder::changelogs::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::changelogs::ListLocations {
+        super::builder::changelogs::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::GetLocation {
-        super::builder::changelogs::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::changelogs::GetLocation {
+        super::builder::changelogs::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::ListOperations {
-        super::builder::changelogs::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::changelogs::ListOperations {
+        super::builder::changelogs::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::GetOperation {
-        super::builder::changelogs::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::changelogs::GetOperation {
+        super::builder::changelogs::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::changelogs::CancelOperation {
-        super::builder::changelogs::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::changelogs::CancelOperation {
+        super::builder::changelogs::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -587,69 +515,47 @@ impl Deployments {
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
-    pub fn list_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::deployments::ListDeployments {
+    pub fn list_deployments(&self) -> super::builder::deployments::ListDeployments {
         super::builder::deployments::ListDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified
     /// [Deployment][google.cloud.dialogflow.cx.v3.Deployment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Deployment]: crate::model::Deployment
-    pub fn get_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::GetDeployment {
-        super::builder::deployments::GetDeployment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_deployment(&self) -> super::builder::deployments::GetDeployment {
+        super::builder::deployments::GetDeployment::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::ListLocations {
-        super::builder::deployments::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::deployments::ListLocations {
+        super::builder::deployments::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::GetLocation {
-        super::builder::deployments::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::deployments::GetLocation {
+        super::builder::deployments::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::ListOperations {
-        super::builder::deployments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::deployments::ListOperations {
+        super::builder::deployments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::GetOperation {
-        super::builder::deployments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::deployments::GetOperation {
+        super::builder::deployments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::deployments::CancelOperation {
-        super::builder::deployments::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::deployments::CancelOperation {
+        super::builder::deployments::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -756,11 +662,8 @@ impl EntityTypes {
     }
 
     /// Retrieves the specified entity type.
-    pub fn get_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetEntityType {
-        super::builder::entity_types::GetEntityType::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entity_type(&self) -> super::builder::entity_types::GetEntityType {
+        super::builder::entity_types::GetEntityType::new(self.inner.clone())
     }
 
     /// Creates an entity type in the specified agent.
@@ -768,12 +671,8 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn create_entity_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::CreateEntityType {
+    pub fn create_entity_type(&self) -> super::builder::entity_types::CreateEntityType {
         super::builder::entity_types::CreateEntityType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified entity type.
@@ -781,12 +680,8 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn update_entity_type(
-        &self,
-        entity_type: impl Into<crate::model::EntityType>,
-    ) -> super::builder::entity_types::UpdateEntityType {
+    pub fn update_entity_type(&self) -> super::builder::entity_types::UpdateEntityType {
         super::builder::entity_types::UpdateEntityType::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Deletes the specified entity type.
@@ -794,21 +689,13 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn delete_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::DeleteEntityType {
+    pub fn delete_entity_type(&self) -> super::builder::entity_types::DeleteEntityType {
         super::builder::entity_types::DeleteEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the list of all entity types in the specified agent.
-    pub fn list_entity_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListEntityTypes {
+    pub fn list_entity_types(&self) -> super::builder::entity_types::ListEntityTypes {
         super::builder::entity_types::ListEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Exports the selected entity types.
@@ -822,12 +709,8 @@ impl EntityTypes {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_entity_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ExportEntityTypes {
+    pub fn export_entity_types(&self) -> super::builder::entity_types::ExportEntityTypes {
         super::builder::entity_types::ExportEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports the specified entitytypes into the agent.
@@ -841,58 +724,39 @@ impl EntityTypes {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_entity_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ImportEntityTypes {
+    pub fn import_entity_types(&self) -> super::builder::entity_types::ImportEntityTypes {
         super::builder::entity_types::ImportEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListLocations {
-        super::builder::entity_types::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::entity_types::ListLocations {
+        super::builder::entity_types::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetLocation {
-        super::builder::entity_types::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::entity_types::GetLocation {
+        super::builder::entity_types::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListOperations {
-        super::builder::entity_types::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::entity_types::ListOperations {
+        super::builder::entity_types::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetOperation {
-        super::builder::entity_types::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::entity_types::GetOperation {
+        super::builder::entity_types::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::CancelOperation {
-        super::builder::entity_types::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::entity_types::CancelOperation {
+        super::builder::entity_types::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1003,23 +867,16 @@ impl Environments {
     /// [Agent][google.cloud.dialogflow.cx.v3.Agent].
     ///
     /// [google.cloud.dialogflow.cx.v3.Agent]: crate::model::Agent
-    pub fn list_environments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListEnvironments {
+    pub fn list_environments(&self) -> super::builder::environments::ListEnvironments {
         super::builder::environments::ListEnvironments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
-    pub fn get_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetEnvironment {
-        super::builder::environments::GetEnvironment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
+        super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
 
     /// Creates an [Environment][google.cloud.dialogflow.cx.v3.Environment] in the
@@ -1045,12 +902,8 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_environment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::CreateEnvironment {
+    pub fn create_environment(&self) -> super::builder::environments::CreateEnvironment {
         super::builder::environments::CreateEnvironment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified
@@ -1075,24 +928,16 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_environment(
-        &self,
-        environment: impl Into<crate::model::Environment>,
-    ) -> super::builder::environments::UpdateEnvironment {
+    pub fn update_environment(&self) -> super::builder::environments::UpdateEnvironment {
         super::builder::environments::UpdateEnvironment::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Deletes the specified
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
-    pub fn delete_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::DeleteEnvironment {
+    pub fn delete_environment(&self) -> super::builder::environments::DeleteEnvironment {
         super::builder::environments::DeleteEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Looks up the history of the specified
@@ -1101,10 +946,8 @@ impl Environments {
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
     pub fn lookup_environment_history(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::environments::LookupEnvironmentHistory {
         super::builder::environments::LookupEnvironmentHistory::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Kicks off a continuous test under the specified
@@ -1132,21 +975,15 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_continuous_test(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::RunContinuousTest {
+    pub fn run_continuous_test(&self) -> super::builder::environments::RunContinuousTest {
         super::builder::environments::RunContinuousTest::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Fetches a list of continuous test results for a given environment.
     pub fn list_continuous_test_results(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::environments::ListContinuousTestResults {
         super::builder::environments::ListContinuousTestResults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deploys a flow to the specified
@@ -1174,58 +1011,39 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn deploy_flow(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::DeployFlow {
+    pub fn deploy_flow(&self) -> super::builder::environments::DeployFlow {
         super::builder::environments::DeployFlow::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListLocations {
-        super::builder::environments::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::environments::ListLocations {
+        super::builder::environments::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetLocation {
-        super::builder::environments::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::environments::GetLocation {
+        super::builder::environments::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListOperations {
-        super::builder::environments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::environments::ListOperations {
+        super::builder::environments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetOperation {
-        super::builder::environments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::environments::GetOperation {
+        super::builder::environments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::CancelOperation {
-        super::builder::environments::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::environments::CancelOperation {
+        super::builder::environments::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1335,23 +1153,16 @@ impl Experiments {
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
-    pub fn list_experiments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::experiments::ListExperiments {
+    pub fn list_experiments(&self) -> super::builder::experiments::ListExperiments {
         super::builder::experiments::ListExperiments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn get_experiment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::GetExperiment {
-        super::builder::experiments::GetExperiment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_experiment(&self) -> super::builder::experiments::GetExperiment {
+        super::builder::experiments::GetExperiment::new(self.inner.clone())
     }
 
     /// Creates an [Experiment][google.cloud.dialogflow.cx.v3.Experiment] in the
@@ -1359,35 +1170,24 @@ impl Experiments {
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn create_experiment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::experiments::CreateExperiment {
+    pub fn create_experiment(&self) -> super::builder::experiments::CreateExperiment {
         super::builder::experiments::CreateExperiment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn update_experiment(
-        &self,
-        experiment: impl Into<crate::model::Experiment>,
-    ) -> super::builder::experiments::UpdateExperiment {
+    pub fn update_experiment(&self) -> super::builder::experiments::UpdateExperiment {
         super::builder::experiments::UpdateExperiment::new(self.inner.clone())
-            .set_experiment(experiment.into())
     }
 
     /// Deletes the specified
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn delete_experiment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::DeleteExperiment {
-        super::builder::experiments::DeleteExperiment::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_experiment(&self) -> super::builder::experiments::DeleteExperiment {
+        super::builder::experiments::DeleteExperiment::new(self.inner.clone())
     }
 
     /// Starts the specified
@@ -1395,68 +1195,47 @@ impl Experiments {
     /// changes the state of experiment from PENDING to RUNNING.
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn start_experiment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::StartExperiment {
-        super::builder::experiments::StartExperiment::new(self.inner.clone()).set_name(name.into())
+    pub fn start_experiment(&self) -> super::builder::experiments::StartExperiment {
+        super::builder::experiments::StartExperiment::new(self.inner.clone())
     }
 
     /// Stops the specified [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     /// This rpc only changes the state of experiment from RUNNING to DONE.
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
-    pub fn stop_experiment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::StopExperiment {
-        super::builder::experiments::StopExperiment::new(self.inner.clone()).set_name(name.into())
+    pub fn stop_experiment(&self) -> super::builder::experiments::StopExperiment {
+        super::builder::experiments::StopExperiment::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::ListLocations {
-        super::builder::experiments::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::experiments::ListLocations {
+        super::builder::experiments::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::GetLocation {
-        super::builder::experiments::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::experiments::GetLocation {
+        super::builder::experiments::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::ListOperations {
-        super::builder::experiments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::experiments::ListOperations {
+        super::builder::experiments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::GetOperation {
-        super::builder::experiments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::experiments::GetOperation {
+        super::builder::experiments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::experiments::CancelOperation {
-        super::builder::experiments::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::experiments::CancelOperation {
+        super::builder::experiments::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1565,32 +1344,23 @@ impl Flows {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn create_flow(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::flows::CreateFlow {
-        super::builder::flows::CreateFlow::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_flow(&self) -> super::builder::flows::CreateFlow {
+        super::builder::flows::CreateFlow::new(self.inner.clone())
     }
 
     /// Deletes a specified flow.
-    pub fn delete_flow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::DeleteFlow {
-        super::builder::flows::DeleteFlow::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_flow(&self) -> super::builder::flows::DeleteFlow {
+        super::builder::flows::DeleteFlow::new(self.inner.clone())
     }
 
     /// Returns the list of all flows in the specified agent.
-    pub fn list_flows(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::flows::ListFlows {
-        super::builder::flows::ListFlows::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_flows(&self) -> super::builder::flows::ListFlows {
+        super::builder::flows::ListFlows::new(self.inner.clone())
     }
 
     /// Retrieves the specified flow.
-    pub fn get_flow(&self, name: impl Into<std::string::String>) -> super::builder::flows::GetFlow {
-        super::builder::flows::GetFlow::new(self.inner.clone()).set_name(name.into())
+    pub fn get_flow(&self) -> super::builder::flows::GetFlow {
+        super::builder::flows::GetFlow::new(self.inner.clone())
     }
 
     /// Updates the specified flow.
@@ -1598,11 +1368,8 @@ impl Flows {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn update_flow(
-        &self,
-        flow: impl Into<crate::model::Flow>,
-    ) -> super::builder::flows::UpdateFlow {
-        super::builder::flows::UpdateFlow::new(self.inner.clone()).set_flow(flow.into())
+    pub fn update_flow(&self) -> super::builder::flows::UpdateFlow {
+        super::builder::flows::UpdateFlow::new(self.inner.clone())
     }
 
     /// Trains the specified flow. Note that only the flow in 'draft' environment
@@ -1630,31 +1397,21 @@ impl Flows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn train_flow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::TrainFlow {
-        super::builder::flows::TrainFlow::new(self.inner.clone()).set_name(name.into())
+    pub fn train_flow(&self) -> super::builder::flows::TrainFlow {
+        super::builder::flows::TrainFlow::new(self.inner.clone())
     }
 
     /// Validates the specified flow and creates or updates validation results.
     /// Please call this API after the training is completed to get the complete
     /// validation results.
-    pub fn validate_flow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::ValidateFlow {
-        super::builder::flows::ValidateFlow::new(self.inner.clone()).set_name(name.into())
+    pub fn validate_flow(&self) -> super::builder::flows::ValidateFlow {
+        super::builder::flows::ValidateFlow::new(self.inner.clone())
     }
 
     /// Gets the latest flow validation result. Flow validation is performed
     /// when ValidateFlow is called.
-    pub fn get_flow_validation_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::GetFlowValidationResult {
+    pub fn get_flow_validation_result(&self) -> super::builder::flows::GetFlowValidationResult {
         super::builder::flows::GetFlowValidationResult::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports the specified flow to the specified agent from a binary file.
@@ -1683,11 +1440,8 @@ impl Flows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_flow(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::flows::ImportFlow {
-        super::builder::flows::ImportFlow::new(self.inner.clone()).set_parent(parent.into())
+    pub fn import_flow(&self) -> super::builder::flows::ImportFlow {
+        super::builder::flows::ImportFlow::new(self.inner.clone())
     }
 
     /// Exports the specified flow to a binary file.
@@ -1715,57 +1469,39 @@ impl Flows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_flow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::ExportFlow {
-        super::builder::flows::ExportFlow::new(self.inner.clone()).set_name(name.into())
+    pub fn export_flow(&self) -> super::builder::flows::ExportFlow {
+        super::builder::flows::ExportFlow::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::ListLocations {
-        super::builder::flows::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::flows::ListLocations {
+        super::builder::flows::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::GetLocation {
-        super::builder::flows::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::flows::GetLocation {
+        super::builder::flows::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::ListOperations {
-        super::builder::flows::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::flows::ListOperations {
+        super::builder::flows::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::GetOperation {
-        super::builder::flows::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::flows::GetOperation {
+        super::builder::flows::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::flows::CancelOperation {
-        super::builder::flows::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::flows::CancelOperation {
+        super::builder::flows::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1872,92 +1608,59 @@ impl Generators {
     }
 
     /// Returns the list of all generators in the specified agent.
-    pub fn list_generators(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListGenerators {
+    pub fn list_generators(&self) -> super::builder::generators::ListGenerators {
         super::builder::generators::ListGenerators::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified generator.
-    pub fn get_generator(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetGenerator {
-        super::builder::generators::GetGenerator::new(self.inner.clone()).set_name(name.into())
+    pub fn get_generator(&self) -> super::builder::generators::GetGenerator {
+        super::builder::generators::GetGenerator::new(self.inner.clone())
     }
 
     /// Creates a generator in the specified agent.
-    pub fn create_generator(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::generators::CreateGenerator {
+    pub fn create_generator(&self) -> super::builder::generators::CreateGenerator {
         super::builder::generators::CreateGenerator::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update the specified generator.
-    pub fn update_generator(
-        &self,
-        generator: impl Into<crate::model::Generator>,
-    ) -> super::builder::generators::UpdateGenerator {
+    pub fn update_generator(&self) -> super::builder::generators::UpdateGenerator {
         super::builder::generators::UpdateGenerator::new(self.inner.clone())
-            .set_generator(generator.into())
     }
 
     /// Deletes the specified generators.
-    pub fn delete_generator(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::DeleteGenerator {
-        super::builder::generators::DeleteGenerator::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_generator(&self) -> super::builder::generators::DeleteGenerator {
+        super::builder::generators::DeleteGenerator::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListLocations {
-        super::builder::generators::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::generators::ListLocations {
+        super::builder::generators::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetLocation {
-        super::builder::generators::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::generators::GetLocation {
+        super::builder::generators::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListOperations {
-        super::builder::generators::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::generators::ListOperations {
+        super::builder::generators::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetOperation {
-        super::builder::generators::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::generators::GetOperation {
+        super::builder::generators::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::CancelOperation {
-        super::builder::generators::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::generators::CancelOperation {
+        super::builder::generators::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2064,19 +1767,13 @@ impl Intents {
     }
 
     /// Returns the list of all intents in the specified agent.
-    pub fn list_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListIntents {
-        super::builder::intents::ListIntents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_intents(&self) -> super::builder::intents::ListIntents {
+        super::builder::intents::ListIntents::new(self.inner.clone())
     }
 
     /// Retrieves the specified intent.
-    pub fn get_intent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetIntent {
-        super::builder::intents::GetIntent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_intent(&self) -> super::builder::intents::GetIntent {
+        super::builder::intents::GetIntent::new(self.inner.clone())
     }
 
     /// Creates an intent in the specified agent.
@@ -2084,11 +1781,8 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn create_intent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::CreateIntent {
-        super::builder::intents::CreateIntent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_intent(&self) -> super::builder::intents::CreateIntent {
+        super::builder::intents::CreateIntent::new(self.inner.clone())
     }
 
     /// Updates the specified intent.
@@ -2096,11 +1790,8 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn update_intent(
-        &self,
-        intent: impl Into<crate::model::Intent>,
-    ) -> super::builder::intents::UpdateIntent {
-        super::builder::intents::UpdateIntent::new(self.inner.clone()).set_intent(intent.into())
+    pub fn update_intent(&self) -> super::builder::intents::UpdateIntent {
+        super::builder::intents::UpdateIntent::new(self.inner.clone())
     }
 
     /// Deletes the specified intent.
@@ -2108,11 +1799,8 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn delete_intent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::DeleteIntent {
-        super::builder::intents::DeleteIntent::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_intent(&self) -> super::builder::intents::DeleteIntent {
+        super::builder::intents::DeleteIntent::new(self.inner.clone())
     }
 
     /// Imports the specified intents into the agent.
@@ -2138,11 +1826,8 @@ impl Intents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::ImportIntents {
-        super::builder::intents::ImportIntents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn import_intents(&self) -> super::builder::intents::ImportIntents {
+        super::builder::intents::ImportIntents::new(self.inner.clone())
     }
 
     /// Exports the selected intents.
@@ -2168,57 +1853,39 @@ impl Intents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::ExportIntents {
-        super::builder::intents::ExportIntents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn export_intents(&self) -> super::builder::intents::ExportIntents {
+        super::builder::intents::ExportIntents::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListLocations {
-        super::builder::intents::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::intents::ListLocations {
+        super::builder::intents::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetLocation {
-        super::builder::intents::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::intents::GetLocation {
+        super::builder::intents::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListOperations {
-        super::builder::intents::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::intents::ListOperations {
+        super::builder::intents::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetOperation {
-        super::builder::intents::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::intents::GetOperation {
+        super::builder::intents::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::CancelOperation {
-        super::builder::intents::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::intents::CancelOperation {
+        super::builder::intents::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2323,16 +1990,13 @@ impl Pages {
     }
 
     /// Returns the list of all pages in the specified flow.
-    pub fn list_pages(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::pages::ListPages {
-        super::builder::pages::ListPages::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_pages(&self) -> super::builder::pages::ListPages {
+        super::builder::pages::ListPages::new(self.inner.clone())
     }
 
     /// Retrieves the specified page.
-    pub fn get_page(&self, name: impl Into<std::string::String>) -> super::builder::pages::GetPage {
-        super::builder::pages::GetPage::new(self.inner.clone()).set_name(name.into())
+    pub fn get_page(&self) -> super::builder::pages::GetPage {
+        super::builder::pages::GetPage::new(self.inner.clone())
     }
 
     /// Creates a page in the specified flow.
@@ -2340,11 +2004,8 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn create_page(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::pages::CreatePage {
-        super::builder::pages::CreatePage::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_page(&self) -> super::builder::pages::CreatePage {
+        super::builder::pages::CreatePage::new(self.inner.clone())
     }
 
     /// Updates the specified page.
@@ -2352,11 +2013,8 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn update_page(
-        &self,
-        page: impl Into<crate::model::Page>,
-    ) -> super::builder::pages::UpdatePage {
-        super::builder::pages::UpdatePage::new(self.inner.clone()).set_page(page.into())
+    pub fn update_page(&self) -> super::builder::pages::UpdatePage {
+        super::builder::pages::UpdatePage::new(self.inner.clone())
     }
 
     /// Deletes the specified page.
@@ -2364,57 +2022,39 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
-    pub fn delete_page(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::DeletePage {
-        super::builder::pages::DeletePage::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_page(&self) -> super::builder::pages::DeletePage {
+        super::builder::pages::DeletePage::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::ListLocations {
-        super::builder::pages::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::pages::ListLocations {
+        super::builder::pages::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::GetLocation {
-        super::builder::pages::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::pages::GetLocation {
+        super::builder::pages::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::ListOperations {
-        super::builder::pages::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::pages::ListOperations {
+        super::builder::pages::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::GetOperation {
-        super::builder::pages::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::pages::GetOperation {
+        super::builder::pages::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::pages::CancelOperation {
-        super::builder::pages::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::pages::CancelOperation {
+        super::builder::pages::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2523,10 +2163,8 @@ impl SecuritySettingsService {
     /// Create security settings in the specified location.
     pub fn create_security_settings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_settings_service::CreateSecuritySettings {
         super::builder::security_settings_service::CreateSecuritySettings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified
@@ -2536,10 +2174,8 @@ impl SecuritySettingsService {
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
     pub fn get_security_settings(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_settings_service::GetSecuritySettings {
         super::builder::security_settings_service::GetSecuritySettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified
@@ -2548,19 +2184,15 @@ impl SecuritySettingsService {
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
     pub fn update_security_settings(
         &self,
-        security_settings: impl Into<crate::model::SecuritySettings>,
     ) -> super::builder::security_settings_service::UpdateSecuritySettings {
         super::builder::security_settings_service::UpdateSecuritySettings::new(self.inner.clone())
-            .set_security_settings(security_settings.into())
     }
 
     /// Returns the list of all security settings in the specified location.
     pub fn list_security_settings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_settings_service::ListSecuritySettings {
         super::builder::security_settings_service::ListSecuritySettings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified
@@ -2569,61 +2201,39 @@ impl SecuritySettingsService {
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
     pub fn delete_security_settings(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_settings_service::DeleteSecuritySettings {
         super::builder::security_settings_service::DeleteSecuritySettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_settings_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::security_settings_service::ListLocations {
         super::builder::security_settings_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_settings_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::security_settings_service::GetLocation {
         super::builder::security_settings_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_settings_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::security_settings_service::ListOperations {
         super::builder::security_settings_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_settings_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::security_settings_service::GetOperation {
         super::builder::security_settings_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_settings_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::security_settings_service::CancelOperation {
         super::builder::security_settings_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2740,20 +2350,14 @@ impl Sessions {
     /// Note: Always use agent versions for production traffic.
     /// See [Versions and
     /// environments](https://cloud.google.com/dialogflow/cx/docs/concept/version).
-    pub fn detect_intent(
-        &self,
-        session: impl Into<std::string::String>,
-    ) -> super::builder::sessions::DetectIntent {
-        super::builder::sessions::DetectIntent::new(self.inner.clone()).set_session(session.into())
+    pub fn detect_intent(&self) -> super::builder::sessions::DetectIntent {
+        super::builder::sessions::DetectIntent::new(self.inner.clone())
     }
 
     /// Returns preliminary intent match results, doesn't change the session
     /// status.
-    pub fn match_intent(
-        &self,
-        session: impl Into<std::string::String>,
-    ) -> super::builder::sessions::MatchIntent {
-        super::builder::sessions::MatchIntent::new(self.inner.clone()).set_session(session.into())
+    pub fn match_intent(&self) -> super::builder::sessions::MatchIntent {
+        super::builder::sessions::MatchIntent::new(self.inner.clone())
     }
 
     /// Fulfills a matched intent returned by
@@ -2766,68 +2370,45 @@ impl Sessions {
     ///
     /// [google.cloud.dialogflow.cx.v3.MatchIntentResponse]: crate::model::MatchIntentResponse
     /// [google.cloud.dialogflow.cx.v3.Sessions.MatchIntent]: crate::client::Sessions::match_intent
-    pub fn fulfill_intent(
-        &self,
-        match_intent_request: impl Into<crate::model::MatchIntentRequest>,
-    ) -> super::builder::sessions::FulfillIntent {
+    pub fn fulfill_intent(&self) -> super::builder::sessions::FulfillIntent {
         super::builder::sessions::FulfillIntent::new(self.inner.clone())
-            .set_match_intent_request(match_intent_request.into())
     }
 
     /// Updates the feedback received from the user for a single turn of the bot
     /// response.
-    pub fn submit_answer_feedback(
-        &self,
-        session: impl Into<std::string::String>,
-    ) -> super::builder::sessions::SubmitAnswerFeedback {
+    pub fn submit_answer_feedback(&self) -> super::builder::sessions::SubmitAnswerFeedback {
         super::builder::sessions::SubmitAnswerFeedback::new(self.inner.clone())
-            .set_session(session.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::ListLocations {
-        super::builder::sessions::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::sessions::ListLocations {
+        super::builder::sessions::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::GetLocation {
-        super::builder::sessions::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::sessions::GetLocation {
+        super::builder::sessions::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::ListOperations {
-        super::builder::sessions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::sessions::ListOperations {
+        super::builder::sessions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::GetOperation {
-        super::builder::sessions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::sessions::GetOperation {
+        super::builder::sessions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::CancelOperation {
-        super::builder::sessions::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::sessions::CancelOperation {
+        super::builder::sessions::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2939,97 +2520,67 @@ impl SessionEntityTypes {
     /// Returns the list of all session entity types in the specified session.
     pub fn list_session_entity_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::ListSessionEntityTypes {
         super::builder::session_entity_types::ListSessionEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified session entity type.
     pub fn get_session_entity_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::GetSessionEntityType {
         super::builder::session_entity_types::GetSessionEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a session entity type.
     pub fn create_session_entity_type(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::CreateSessionEntityType {
         super::builder::session_entity_types::CreateSessionEntityType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified session entity type.
     pub fn update_session_entity_type(
         &self,
-        session_entity_type: impl Into<crate::model::SessionEntityType>,
     ) -> super::builder::session_entity_types::UpdateSessionEntityType {
         super::builder::session_entity_types::UpdateSessionEntityType::new(self.inner.clone())
-            .set_session_entity_type(session_entity_type.into())
     }
 
     /// Deletes the specified session entity type.
     pub fn delete_session_entity_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::DeleteSessionEntityType {
         super::builder::session_entity_types::DeleteSessionEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::ListLocations {
+    pub fn list_locations(&self) -> super::builder::session_entity_types::ListLocations {
         super::builder::session_entity_types::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::GetLocation {
+    pub fn get_location(&self) -> super::builder::session_entity_types::GetLocation {
         super::builder::session_entity_types::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::ListOperations {
+    pub fn list_operations(&self) -> super::builder::session_entity_types::ListOperations {
         super::builder::session_entity_types::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::GetOperation {
+    pub fn get_operation(&self) -> super::builder::session_entity_types::GetOperation {
         super::builder::session_entity_types::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::session_entity_types::CancelOperation {
         super::builder::session_entity_types::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3138,46 +2689,28 @@ impl TestCases {
     }
 
     /// Fetches a list of test cases for a given agent.
-    pub fn list_test_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ListTestCases {
-        super::builder::test_cases::ListTestCases::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_test_cases(&self) -> super::builder::test_cases::ListTestCases {
+        super::builder::test_cases::ListTestCases::new(self.inner.clone())
     }
 
     /// Batch deletes test cases.
-    pub fn batch_delete_test_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::BatchDeleteTestCases {
+    pub fn batch_delete_test_cases(&self) -> super::builder::test_cases::BatchDeleteTestCases {
         super::builder::test_cases::BatchDeleteTestCases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a test case.
-    pub fn get_test_case(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::GetTestCase {
-        super::builder::test_cases::GetTestCase::new(self.inner.clone()).set_name(name.into())
+    pub fn get_test_case(&self) -> super::builder::test_cases::GetTestCase {
+        super::builder::test_cases::GetTestCase::new(self.inner.clone())
     }
 
     /// Creates a test case for the given agent.
-    pub fn create_test_case(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::CreateTestCase {
+    pub fn create_test_case(&self) -> super::builder::test_cases::CreateTestCase {
         super::builder::test_cases::CreateTestCase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified test case.
-    pub fn update_test_case(
-        &self,
-        test_case: impl Into<crate::model::TestCase>,
-    ) -> super::builder::test_cases::UpdateTestCase {
+    pub fn update_test_case(&self) -> super::builder::test_cases::UpdateTestCase {
         super::builder::test_cases::UpdateTestCase::new(self.inner.clone())
-            .set_test_case(test_case.into())
     }
 
     /// Kicks off a test case run.
@@ -3203,11 +2736,8 @@ impl TestCases {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_test_case(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::RunTestCase {
-        super::builder::test_cases::RunTestCase::new(self.inner.clone()).set_name(name.into())
+    pub fn run_test_case(&self) -> super::builder::test_cases::RunTestCase {
+        super::builder::test_cases::RunTestCase::new(self.inner.clone())
     }
 
     /// Kicks off a batch run of test cases.
@@ -3233,21 +2763,13 @@ impl TestCases {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_run_test_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::BatchRunTestCases {
+    pub fn batch_run_test_cases(&self) -> super::builder::test_cases::BatchRunTestCases {
         super::builder::test_cases::BatchRunTestCases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Calculates the test coverage for an agent.
-    pub fn calculate_coverage(
-        &self,
-        agent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::CalculateCoverage {
+    pub fn calculate_coverage(&self) -> super::builder::test_cases::CalculateCoverage {
         super::builder::test_cases::CalculateCoverage::new(self.inner.clone())
-            .set_agent(agent.into())
     }
 
     /// Imports the test cases from a Cloud Storage bucket or a local file. It
@@ -3275,12 +2797,8 @@ impl TestCases {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_test_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ImportTestCases {
+    pub fn import_test_cases(&self) -> super::builder::test_cases::ImportTestCases {
         super::builder::test_cases::ImportTestCases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Exports the test cases under the agent to a Cloud Storage bucket or a local
@@ -3307,76 +2825,50 @@ impl TestCases {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_test_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ExportTestCases {
+    pub fn export_test_cases(&self) -> super::builder::test_cases::ExportTestCases {
         super::builder::test_cases::ExportTestCases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Fetches the list of run results for the given test case. A maximum of 100
     /// results are kept for each test case.
-    pub fn list_test_case_results(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ListTestCaseResults {
+    pub fn list_test_case_results(&self) -> super::builder::test_cases::ListTestCaseResults {
         super::builder::test_cases::ListTestCaseResults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a test case result.
-    pub fn get_test_case_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::GetTestCaseResult {
-        super::builder::test_cases::GetTestCaseResult::new(self.inner.clone()).set_name(name.into())
+    pub fn get_test_case_result(&self) -> super::builder::test_cases::GetTestCaseResult {
+        super::builder::test_cases::GetTestCaseResult::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ListLocations {
-        super::builder::test_cases::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::test_cases::ListLocations {
+        super::builder::test_cases::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::GetLocation {
-        super::builder::test_cases::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::test_cases::GetLocation {
+        super::builder::test_cases::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::ListOperations {
-        super::builder::test_cases::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::test_cases::ListOperations {
+        super::builder::test_cases::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::GetOperation {
-        super::builder::test_cases::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::test_cases::GetOperation {
+        super::builder::test_cases::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::test_cases::CancelOperation {
-        super::builder::test_cases::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::test_cases::CancelOperation {
+        super::builder::test_cases::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3488,10 +2980,8 @@ impl TransitionRouteGroups {
     /// Returns the list of all transition route groups in the specified flow.
     pub fn list_transition_route_groups(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::transition_route_groups::ListTransitionRouteGroups {
         super::builder::transition_route_groups::ListTransitionRouteGroups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified
@@ -3500,10 +2990,8 @@ impl TransitionRouteGroups {
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
     pub fn get_transition_route_group(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::transition_route_groups::GetTransitionRouteGroup {
         super::builder::transition_route_groups::GetTransitionRouteGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an
@@ -3517,10 +3005,8 @@ impl TransitionRouteGroups {
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
     pub fn create_transition_route_group(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::transition_route_groups::CreateTransitionRouteGroup {
         super::builder::transition_route_groups::CreateTransitionRouteGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified
@@ -3533,10 +3019,8 @@ impl TransitionRouteGroups {
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
     pub fn update_transition_route_group(
         &self,
-        transition_route_group: impl Into<crate::model::TransitionRouteGroup>,
     ) -> super::builder::transition_route_groups::UpdateTransitionRouteGroup {
         super::builder::transition_route_groups::UpdateTransitionRouteGroup::new(self.inner.clone())
-            .set_transition_route_group(transition_route_group.into())
     }
 
     /// Deletes the specified
@@ -3549,61 +3033,39 @@ impl TransitionRouteGroups {
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
     pub fn delete_transition_route_group(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::transition_route_groups::DeleteTransitionRouteGroup {
         super::builder::transition_route_groups::DeleteTransitionRouteGroup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transition_route_groups::ListLocations {
+    pub fn list_locations(&self) -> super::builder::transition_route_groups::ListLocations {
         super::builder::transition_route_groups::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transition_route_groups::GetLocation {
+    pub fn get_location(&self) -> super::builder::transition_route_groups::GetLocation {
         super::builder::transition_route_groups::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transition_route_groups::ListOperations {
+    pub fn list_operations(&self) -> super::builder::transition_route_groups::ListOperations {
         super::builder::transition_route_groups::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transition_route_groups::GetOperation {
+    pub fn get_operation(&self) -> super::builder::transition_route_groups::GetOperation {
         super::builder::transition_route_groups::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transition_route_groups::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::transition_route_groups::CancelOperation {
         super::builder::transition_route_groups::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3713,21 +3175,15 @@ impl Versions {
     /// [Flow][google.cloud.dialogflow.cx.v3.Flow].
     ///
     /// [google.cloud.dialogflow.cx.v3.Flow]: crate::model::Flow
-    pub fn list_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListVersions {
-        super::builder::versions::ListVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_versions(&self) -> super::builder::versions::ListVersions {
+        super::builder::versions::ListVersions::new(self.inner.clone())
     }
 
     /// Retrieves the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
-    pub fn get_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetVersion {
-        super::builder::versions::GetVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_version(&self) -> super::builder::versions::GetVersion {
+        super::builder::versions::GetVersion::new(self.inner.clone())
     }
 
     /// Creates a [Version][google.cloud.dialogflow.cx.v3.Version] in the specified
@@ -3754,31 +3210,22 @@ impl Versions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::CreateVersion {
-        super::builder::versions::CreateVersion::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_version(&self) -> super::builder::versions::CreateVersion {
+        super::builder::versions::CreateVersion::new(self.inner.clone())
     }
 
     /// Updates the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
-    pub fn update_version(
-        &self,
-        version: impl Into<crate::model::Version>,
-    ) -> super::builder::versions::UpdateVersion {
-        super::builder::versions::UpdateVersion::new(self.inner.clone()).set_version(version.into())
+    pub fn update_version(&self) -> super::builder::versions::UpdateVersion {
+        super::builder::versions::UpdateVersion::new(self.inner.clone())
     }
 
     /// Deletes the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
-    pub fn delete_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::DeleteVersion {
-        super::builder::versions::DeleteVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_version(&self) -> super::builder::versions::DeleteVersion {
+        super::builder::versions::DeleteVersion::new(self.inner.clone())
     }
 
     /// Loads resources in the specified version to the draft flow.
@@ -3801,66 +3248,44 @@ impl Versions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn load_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::LoadVersion {
-        super::builder::versions::LoadVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn load_version(&self) -> super::builder::versions::LoadVersion {
+        super::builder::versions::LoadVersion::new(self.inner.clone())
     }
 
     /// Compares the specified base version with target version.
-    pub fn compare_versions(
-        &self,
-        base_version: impl Into<std::string::String>,
-    ) -> super::builder::versions::CompareVersions {
+    pub fn compare_versions(&self) -> super::builder::versions::CompareVersions {
         super::builder::versions::CompareVersions::new(self.inner.clone())
-            .set_base_version(base_version.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListLocations {
-        super::builder::versions::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::versions::ListLocations {
+        super::builder::versions::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetLocation {
-        super::builder::versions::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::versions::GetLocation {
+        super::builder::versions::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListOperations {
-        super::builder::versions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::versions::ListOperations {
+        super::builder::versions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetOperation {
-        super::builder::versions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::versions::GetOperation {
+        super::builder::versions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::CancelOperation {
-        super::builder::versions::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::versions::CancelOperation {
+        super::builder::versions::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3967,88 +3392,58 @@ impl Webhooks {
     }
 
     /// Returns the list of all webhooks in the specified agent.
-    pub fn list_webhooks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::ListWebhooks {
-        super::builder::webhooks::ListWebhooks::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_webhooks(&self) -> super::builder::webhooks::ListWebhooks {
+        super::builder::webhooks::ListWebhooks::new(self.inner.clone())
     }
 
     /// Retrieves the specified webhook.
-    pub fn get_webhook(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::GetWebhook {
-        super::builder::webhooks::GetWebhook::new(self.inner.clone()).set_name(name.into())
+    pub fn get_webhook(&self) -> super::builder::webhooks::GetWebhook {
+        super::builder::webhooks::GetWebhook::new(self.inner.clone())
     }
 
     /// Creates a webhook in the specified agent.
-    pub fn create_webhook(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::CreateWebhook {
-        super::builder::webhooks::CreateWebhook::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_webhook(&self) -> super::builder::webhooks::CreateWebhook {
+        super::builder::webhooks::CreateWebhook::new(self.inner.clone())
     }
 
     /// Updates the specified webhook.
-    pub fn update_webhook(
-        &self,
-        webhook: impl Into<crate::model::Webhook>,
-    ) -> super::builder::webhooks::UpdateWebhook {
-        super::builder::webhooks::UpdateWebhook::new(self.inner.clone()).set_webhook(webhook.into())
+    pub fn update_webhook(&self) -> super::builder::webhooks::UpdateWebhook {
+        super::builder::webhooks::UpdateWebhook::new(self.inner.clone())
     }
 
     /// Deletes the specified webhook.
-    pub fn delete_webhook(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::DeleteWebhook {
-        super::builder::webhooks::DeleteWebhook::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_webhook(&self) -> super::builder::webhooks::DeleteWebhook {
+        super::builder::webhooks::DeleteWebhook::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::ListLocations {
-        super::builder::webhooks::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::webhooks::ListLocations {
+        super::builder::webhooks::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::GetLocation {
-        super::builder::webhooks::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::webhooks::GetLocation {
+        super::builder::webhooks::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::ListOperations {
-        super::builder::webhooks::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::webhooks::ListOperations {
+        super::builder::webhooks::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::GetOperation {
-        super::builder::webhooks::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::webhooks::GetOperation {
+        super::builder::webhooks::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::webhooks::CancelOperation {
-        super::builder::webhooks::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::webhooks::CancelOperation {
+        super::builder::webhooks::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -125,10 +125,15 @@ impl super::stub::Agents for Agents {
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.agent
+            let arg = &req
+                .agent
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("agent.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -310,10 +315,15 @@ impl super::stub::Agents for Agents {
     ) -> Result<gax::response::Response<crate::model::GenerativeSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.generative_settings
+            let arg = &req
+                .generative_settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("generative_settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("generative_settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1007,10 +1017,15 @@ impl super::stub::EntityTypes for EntityTypes {
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.entity_type
+            let arg = &req
+                .entity_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1404,10 +1419,15 @@ impl super::stub::Environments for Environments {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.environment
+            let arg = &req
+                .environment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1826,10 +1846,15 @@ impl super::stub::Experiments for Experiments {
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.experiment
+            let arg = &req
+                .experiment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("experiment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("experiment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2208,10 +2233,15 @@ impl super::stub::Flows for Flows {
     ) -> Result<gax::response::Response<crate::model::Flow>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.flow
+            let arg = &req
+                .flow
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("flow"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("flow.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2621,10 +2651,15 @@ impl super::stub::Generators for Generators {
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.generator
+            let arg = &req
+                .generator
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("generator.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2929,10 +2964,15 @@ impl super::stub::Intents for Intents {
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.intent
+            let arg = &req
+                .intent
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("intent.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3293,10 +3333,15 @@ impl super::stub::Pages for Pages {
     ) -> Result<gax::response::Response<crate::model::Page>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.page
+            let arg = &req
+                .page
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("page"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("page.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3569,10 +3614,15 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
     ) -> Result<gax::response::Response<crate::model::SecuritySettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.security_settings
+            let arg = &req
+                .security_settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("security_settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("security_settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3869,10 +3919,17 @@ impl super::stub::Sessions for Sessions {
     ) -> Result<gax::response::Response<crate::model::FulfillIntentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}:fulfillIntent", {
-            &req.match_intent_request
+            let arg = &req
+                .match_intent_request
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("match_intent_request"))?
-                .session
+                .session;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "match_intent_request.session",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4159,10 +4216,15 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.session_entity_type
+            let arg = &req
+                .session_entity_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session_entity_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4493,10 +4555,15 @@ impl super::stub::TestCases for TestCases {
     ) -> Result<gax::response::Response<crate::model::TestCase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.test_case
+            let arg = &req
+                .test_case
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("test_case"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("test_case.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4962,10 +5029,15 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
     ) -> Result<gax::response::Response<crate::model::TransitionRouteGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.transition_route_group
+            let arg = &req
+                .transition_route_group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("transition_route_group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("transition_route_group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -5268,10 +5340,15 @@ impl super::stub::Versions for Versions {
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.version
+            let arg = &req
+                .version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -5634,10 +5711,15 @@ impl super::stub::Webhooks for Webhooks {
     ) -> Result<gax::response::Response<crate::model::Webhook>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.webhook
+            let arg = &req
+                .webhook
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("webhook"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("webhook.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAgentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/agents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/agents", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,9 +74,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +100,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/agents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/agents", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,18 +124,15 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.agent
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.agent
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +153,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +183,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +207,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:restore", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,9 +231,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AgentValidationResult>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:validate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:validate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -209,9 +255,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AgentValidationResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -229,9 +282,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerativeSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -249,18 +309,15 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerativeSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.generative_settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("generative_settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.generative_settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("generative_settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -283,9 +340,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -305,9 +369,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,9 +395,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -346,9 +424,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -365,9 +450,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -425,12 +517,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListChangelogsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/changelogs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/changelogs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -450,9 +546,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Changelog>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -469,9 +572,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -491,9 +601,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -510,9 +627,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,9 +656,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -551,9 +682,16 @@ impl super::stub::Changelogs for Changelogs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -597,12 +735,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -621,9 +763,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -640,9 +789,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -662,9 +818,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -681,9 +844,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -703,9 +873,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -722,9 +899,16 @@ impl super::stub::Deployments for Deployments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -768,9 +952,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -788,12 +979,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -811,18 +1006,15 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.entity_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.entity_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -846,9 +1038,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -870,12 +1069,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntityTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -895,12 +1098,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/entityTypes:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/entityTypes:export", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -915,12 +1122,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/entityTypes:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/entityTypes:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -935,9 +1146,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -957,9 +1175,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -976,9 +1201,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -998,9 +1230,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1017,9 +1256,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1077,12 +1323,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnvironmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1101,9 +1351,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1120,12 +1377,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1142,18 +1403,15 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.environment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.environment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1176,9 +1434,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1199,12 +1464,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LookupEnvironmentHistoryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}:lookupEnvironmentHistory", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}:lookupEnvironmentHistory", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1223,12 +1492,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:runContinuousTest", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:runContinuousTest", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1243,12 +1516,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListContinuousTestResultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/continuousTestResults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/continuousTestResults", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1267,12 +1544,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:deployFlow", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:deployFlow", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1287,9 +1568,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1309,9 +1597,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1328,9 +1623,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1350,9 +1652,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1369,9 +1678,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1429,12 +1745,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExperimentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/experiments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/experiments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1453,9 +1773,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1472,12 +1799,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/experiments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/experiments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1494,18 +1825,15 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.experiment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("experiment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.experiment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("experiment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1528,9 +1856,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1551,9 +1886,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1568,9 +1910,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Experiment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1585,9 +1934,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1607,9 +1963,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1626,9 +1989,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1648,9 +2018,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1667,9 +2044,16 @@ impl super::stub::Experiments for Experiments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1711,9 +2095,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Flow>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/flows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/flows", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1729,9 +2120,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1753,9 +2151,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFlowsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/flows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/flows", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1775,9 +2180,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Flow>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1795,18 +2207,15 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Flow>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.flow
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("flow"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.flow
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("flow"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1828,9 +2237,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:train", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:train", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1845,9 +2261,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FlowValidationResult>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:validate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:validate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1862,9 +2285,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FlowValidationResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1882,12 +2312,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/flows:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/flows:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1902,9 +2336,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1919,9 +2360,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1941,9 +2389,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1960,9 +2415,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1982,9 +2444,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2001,9 +2470,16 @@ impl super::stub::Flows for Flows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2061,12 +2537,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGeneratorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/generators", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/generators", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2086,9 +2566,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2106,12 +2593,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/generators", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/generators", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2129,18 +2620,15 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.generator
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.generator
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2164,9 +2652,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2188,9 +2683,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2210,9 +2712,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2229,9 +2738,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2251,9 +2767,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2270,9 +2793,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2316,9 +2846,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIntentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/intents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/intents", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2339,9 +2876,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2359,9 +2903,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/intents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/intents", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2377,18 +2928,15 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.intent
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.intent
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2410,9 +2958,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2433,12 +2988,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/intents:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/intents:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2453,12 +3012,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/intents:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/intents:export", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2473,9 +3036,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2495,9 +3065,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2514,9 +3091,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2536,9 +3120,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2555,9 +3146,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2613,9 +3211,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/pages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/pages", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2635,9 +3240,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Page>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2655,9 +3267,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Page>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/pages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/pages", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2673,18 +3292,15 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Page>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.page
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("page"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.page
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("page"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2706,9 +3322,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2730,9 +3353,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2752,9 +3382,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2771,9 +3408,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2793,9 +3437,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2812,9 +3463,16 @@ impl super::stub::Pages for Pages {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2858,12 +3516,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecuritySettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/securitySettings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/securitySettings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2880,9 +3542,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecuritySettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2899,18 +3568,15 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecuritySettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.security_settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("security_settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.security_settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("security_settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2933,12 +3599,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecuritySettingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/securitySettings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/securitySettings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2957,9 +3627,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2980,9 +3657,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3002,9 +3686,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3021,9 +3712,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3043,9 +3741,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3062,9 +3767,16 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3108,12 +3820,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DetectIntentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:detectIntent", {
+            let arg = &req.session;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:detectIntent", req.session),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3128,12 +3844,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MatchIntentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:matchIntent", {
+            let arg = &req.session;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:matchIntent", req.session),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3148,18 +3868,15 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FulfillIntentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:fulfillIntent", {
+            &req.match_intent_request
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("match_intent_request"))?
+                .session
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v3/{}:fulfillIntent",
-                    req.match_intent_request
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("match_intent_request"))?
-                        .session
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3174,12 +3891,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnswerFeedback>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:submitAnswerFeedback", {
+            let arg = &req.session;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:submitAnswerFeedback", req.session),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3194,9 +3915,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3216,9 +3944,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3235,9 +3970,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3257,9 +3999,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3276,9 +4025,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3322,12 +4078,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionEntityTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3346,9 +4106,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3365,12 +4132,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3387,18 +4158,15 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.session_entity_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.session_entity_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3421,9 +4189,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3444,9 +4219,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3466,9 +4248,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3485,9 +4274,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3507,9 +4303,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3526,9 +4329,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3572,12 +4382,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTestCasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/testCases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/testCases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3597,12 +4411,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/testCases:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/testCases:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3622,9 +4440,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestCase>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3641,12 +4466,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestCase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/testCases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/testCases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3663,18 +4492,15 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestCase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.test_case
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("test_case"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.test_case
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("test_case"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3697,9 +4523,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3714,12 +4547,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/testCases:batchRun", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/testCases:batchRun", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3734,12 +4571,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CalculateCoverageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/testCases:calculateCoverage", {
+            let arg = &req.agent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("agent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/testCases:calculateCoverage", req.agent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3757,12 +4598,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/testCases:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/testCases:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3777,12 +4622,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/testCases:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/testCases:export", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3797,9 +4646,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTestCaseResultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/results", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/results", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3819,9 +4675,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestCaseResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3838,9 +4701,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3860,9 +4730,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3879,9 +4756,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3901,9 +4785,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3920,9 +4811,16 @@ impl super::stub::TestCases for TestCases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3980,12 +4878,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTransitionRouteGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/transitionRouteGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/transitionRouteGroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4005,9 +4907,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransitionRouteGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4025,12 +4934,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransitionRouteGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/transitionRouteGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/transitionRouteGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4048,18 +4961,15 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransitionRouteGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.transition_route_group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("transition_route_group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.transition_route_group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("transition_route_group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4083,9 +4993,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4107,9 +5024,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4129,9 +5053,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4148,9 +5079,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4170,9 +5108,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4189,9 +5134,16 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4235,9 +5187,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4256,9 +5215,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4275,12 +5241,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/versions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4297,18 +5267,15 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4331,9 +5298,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4354,9 +5328,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:load", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:load", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4371,12 +5352,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompareVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:compareVersions", {
+            let arg = &req.base_version;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("base_version"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:compareVersions", req.base_version),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4391,9 +5376,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4413,9 +5405,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4432,9 +5431,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4454,9 +5460,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4473,9 +5486,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4533,9 +5553,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWebhooksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/webhooks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/webhooks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4554,9 +5581,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Webhook>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4573,12 +5607,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Webhook>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/webhooks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/webhooks", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4595,18 +5633,15 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Webhook>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.webhook
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("webhook"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.webhook
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("webhook"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4629,9 +5664,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4653,9 +5695,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4675,9 +5724,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4694,9 +5750,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4716,9 +5779,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4735,9 +5805,16 @@ impl super::stub::Webhooks for Webhooks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/dialogflow/v2/src/client.rs
+++ b/src/generated/cloud/dialogflow/v2/src/client.rs
@@ -121,11 +121,8 @@ impl Agents {
     }
 
     /// Retrieves the specified agent.
-    pub fn get_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetAgent {
-        super::builder::agents::GetAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn get_agent(&self) -> super::builder::agents::GetAgent {
+        super::builder::agents::GetAgent::new(self.inner.clone())
     }
 
     /// Creates/updates the specified agent.
@@ -133,19 +130,13 @@ impl Agents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn set_agent(
-        &self,
-        agent: impl Into<crate::model::Agent>,
-    ) -> super::builder::agents::SetAgent {
-        super::builder::agents::SetAgent::new(self.inner.clone()).set_agent(agent.into())
+    pub fn set_agent(&self) -> super::builder::agents::SetAgent {
+        super::builder::agents::SetAgent::new(self.inner.clone())
     }
 
     /// Deletes the specified agent.
-    pub fn delete_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::DeleteAgent {
-        super::builder::agents::DeleteAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn delete_agent(&self) -> super::builder::agents::DeleteAgent {
+        super::builder::agents::DeleteAgent::new(self.inner.clone())
     }
 
     /// Returns the list of agents.
@@ -155,11 +146,8 @@ impl Agents {
     /// access to. One can achieve that with a wildcard project collection id "-".
     /// Refer to [List
     /// Sub-Collections](https://cloud.google.com/apis/design/design_patterns#list_sub-collections).
-    pub fn search_agents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::SearchAgents {
-        super::builder::agents::SearchAgents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn search_agents(&self) -> super::builder::agents::SearchAgents {
+        super::builder::agents::SearchAgents::new(self.inner.clone())
     }
 
     /// Trains the specified agent.
@@ -186,11 +174,8 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn train_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::TrainAgent {
-        super::builder::agents::TrainAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn train_agent(&self) -> super::builder::agents::TrainAgent {
+        super::builder::agents::TrainAgent::new(self.inner.clone())
     }
 
     /// Exports the specified agent to a ZIP file.
@@ -215,11 +200,8 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::ExportAgent {
-        super::builder::agents::ExportAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn export_agent(&self) -> super::builder::agents::ExportAgent {
+        super::builder::agents::ExportAgent::new(self.inner.clone())
     }
 
     /// Imports the specified agent from a ZIP file.
@@ -262,11 +244,8 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::ImportAgent {
-        super::builder::agents::ImportAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn import_agent(&self) -> super::builder::agents::ImportAgent {
+        super::builder::agents::ImportAgent::new(self.inner.clone())
     }
 
     /// Restores the specified agent from a ZIP file.
@@ -306,67 +285,45 @@ impl Agents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_agent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::RestoreAgent {
-        super::builder::agents::RestoreAgent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn restore_agent(&self) -> super::builder::agents::RestoreAgent {
+        super::builder::agents::RestoreAgent::new(self.inner.clone())
     }
 
     /// Gets agent validation result. Agent validation is performed during
     /// training time and is updated automatically when training is completed.
-    pub fn get_validation_result(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetValidationResult {
+    pub fn get_validation_result(&self) -> super::builder::agents::GetValidationResult {
         super::builder::agents::GetValidationResult::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ListLocations {
-        super::builder::agents::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::agents::ListLocations {
+        super::builder::agents::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetLocation {
-        super::builder::agents::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::agents::GetLocation {
+        super::builder::agents::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::ListOperations {
-        super::builder::agents::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::agents::ListOperations {
+        super::builder::agents::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::GetOperation {
-        super::builder::agents::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::agents::GetOperation {
+        super::builder::agents::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::agents::CancelOperation {
-        super::builder::agents::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::agents::CancelOperation {
+        super::builder::agents::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -475,69 +432,44 @@ impl AnswerRecords {
 
     /// Returns the list of all answer records in the specified project in reverse
     /// chronological order.
-    pub fn list_answer_records(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::ListAnswerRecords {
+    pub fn list_answer_records(&self) -> super::builder::answer_records::ListAnswerRecords {
         super::builder::answer_records::ListAnswerRecords::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified answer record.
-    pub fn update_answer_record(
-        &self,
-        answer_record: impl Into<crate::model::AnswerRecord>,
-    ) -> super::builder::answer_records::UpdateAnswerRecord {
+    pub fn update_answer_record(&self) -> super::builder::answer_records::UpdateAnswerRecord {
         super::builder::answer_records::UpdateAnswerRecord::new(self.inner.clone())
-            .set_answer_record(answer_record.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::ListLocations {
-        super::builder::answer_records::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::answer_records::ListLocations {
+        super::builder::answer_records::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::GetLocation {
-        super::builder::answer_records::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::answer_records::GetLocation {
+        super::builder::answer_records::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::ListOperations {
+    pub fn list_operations(&self) -> super::builder::answer_records::ListOperations {
         super::builder::answer_records::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::GetOperation {
-        super::builder::answer_records::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::answer_records::GetOperation {
+        super::builder::answer_records::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::answer_records::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::answer_records::CancelOperation {
         super::builder::answer_records::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -644,100 +576,66 @@ impl Contexts {
     }
 
     /// Returns the list of all contexts in the specified session.
-    pub fn list_contexts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contexts::ListContexts {
-        super::builder::contexts::ListContexts::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_contexts(&self) -> super::builder::contexts::ListContexts {
+        super::builder::contexts::ListContexts::new(self.inner.clone())
     }
 
     /// Retrieves the specified context.
-    pub fn get_context(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::GetContext {
-        super::builder::contexts::GetContext::new(self.inner.clone()).set_name(name.into())
+    pub fn get_context(&self) -> super::builder::contexts::GetContext {
+        super::builder::contexts::GetContext::new(self.inner.clone())
     }
 
     /// Creates a context.
     ///
     /// If the specified context already exists, overrides the context.
-    pub fn create_context(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contexts::CreateContext {
-        super::builder::contexts::CreateContext::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_context(&self) -> super::builder::contexts::CreateContext {
+        super::builder::contexts::CreateContext::new(self.inner.clone())
     }
 
     /// Updates the specified context.
-    pub fn update_context(
-        &self,
-        context: impl Into<crate::model::Context>,
-    ) -> super::builder::contexts::UpdateContext {
-        super::builder::contexts::UpdateContext::new(self.inner.clone()).set_context(context.into())
+    pub fn update_context(&self) -> super::builder::contexts::UpdateContext {
+        super::builder::contexts::UpdateContext::new(self.inner.clone())
     }
 
     /// Deletes the specified context.
-    pub fn delete_context(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::DeleteContext {
-        super::builder::contexts::DeleteContext::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_context(&self) -> super::builder::contexts::DeleteContext {
+        super::builder::contexts::DeleteContext::new(self.inner.clone())
     }
 
     /// Deletes all active contexts in the specified session.
-    pub fn delete_all_contexts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::contexts::DeleteAllContexts {
+    pub fn delete_all_contexts(&self) -> super::builder::contexts::DeleteAllContexts {
         super::builder::contexts::DeleteAllContexts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::ListLocations {
-        super::builder::contexts::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::contexts::ListLocations {
+        super::builder::contexts::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::GetLocation {
-        super::builder::contexts::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::contexts::GetLocation {
+        super::builder::contexts::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::ListOperations {
-        super::builder::contexts::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::contexts::ListOperations {
+        super::builder::contexts::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::GetOperation {
-        super::builder::contexts::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::contexts::GetOperation {
+        super::builder::contexts::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::contexts::CancelOperation {
-        super::builder::contexts::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::contexts::CancelOperation {
+        super::builder::contexts::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -869,50 +767,32 @@ impl Conversations {
     /// [google.cloud.dialogflow.v2.Conversation.conversation_profile]: crate::model::Conversation::conversation_profile
     /// [google.cloud.dialogflow.v2.Intent]: crate::model::Intent
     /// [google.cloud.dialogflow.v2.Intent.live_agent_handoff]: crate::model::Intent::live_agent_handoff
-    pub fn create_conversation(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversations::CreateConversation {
+    pub fn create_conversation(&self) -> super::builder::conversations::CreateConversation {
         super::builder::conversations::CreateConversation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the list of all conversations in the specified project.
-    pub fn list_conversations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversations::ListConversations {
+    pub fn list_conversations(&self) -> super::builder::conversations::ListConversations {
         super::builder::conversations::ListConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specific conversation.
-    pub fn get_conversation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::GetConversation {
+    pub fn get_conversation(&self) -> super::builder::conversations::GetConversation {
         super::builder::conversations::GetConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Completes the specified conversation. Finished conversations are purged
     /// from the database after 30 days.
-    pub fn complete_conversation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::CompleteConversation {
+    pub fn complete_conversation(&self) -> super::builder::conversations::CompleteConversation {
         super::builder::conversations::CompleteConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Data ingestion API.
     /// Ingests context references for an existing conversation.
     pub fn ingest_context_references(
         &self,
-        conversation: impl Into<std::string::String>,
     ) -> super::builder::conversations::IngestContextReferences {
         super::builder::conversations::IngestContextReferences::new(self.inner.clone())
-            .set_conversation(conversation.into())
     }
 
     /// Lists messages that belong to a given conversation.
@@ -920,12 +800,8 @@ impl Conversations {
     /// updates without duplication, send request with filter
     /// `create_time_epoch_microseconds >
     /// [first item's create_time of previous request]` and empty page_token.
-    pub fn list_messages(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversations::ListMessages {
+    pub fn list_messages(&self) -> super::builder::conversations::ListMessages {
         super::builder::conversations::ListMessages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Suggests summary for a conversation based on specific historical messages.
@@ -933,99 +809,67 @@ impl Conversations {
     /// request.
     pub fn suggest_conversation_summary(
         &self,
-        conversation: impl Into<std::string::String>,
     ) -> super::builder::conversations::SuggestConversationSummary {
         super::builder::conversations::SuggestConversationSummary::new(self.inner.clone())
-            .set_conversation(conversation.into())
     }
 
     /// Generates and returns a summary for a conversation that does not have a
     /// resource created for it.
     pub fn generate_stateless_summary(
         &self,
-        stateless_conversation: impl Into<
-            crate::model::generate_stateless_summary_request::MinimalConversation,
-        >,
     ) -> super::builder::conversations::GenerateStatelessSummary {
         super::builder::conversations::GenerateStatelessSummary::new(self.inner.clone())
-            .set_stateless_conversation(stateless_conversation.into())
     }
 
     /// Generates and returns a suggestion for a conversation that does not have a
     /// resource created for it.
     pub fn generate_stateless_suggestion(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversations::GenerateStatelessSuggestion {
         super::builder::conversations::GenerateStatelessSuggestion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get answers for the given query based on knowledge documents.
-    pub fn search_knowledge(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversations::SearchKnowledge {
+    pub fn search_knowledge(&self) -> super::builder::conversations::SearchKnowledge {
         super::builder::conversations::SearchKnowledge::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Generates all the suggestions using generators configured in the
     /// conversation profile. A generator is used only if its trigger event is
     /// matched.
-    pub fn generate_suggestions(
-        &self,
-        conversation: impl Into<std::string::String>,
-    ) -> super::builder::conversations::GenerateSuggestions {
+    pub fn generate_suggestions(&self) -> super::builder::conversations::GenerateSuggestions {
         super::builder::conversations::GenerateSuggestions::new(self.inner.clone())
-            .set_conversation(conversation.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::ListLocations {
-        super::builder::conversations::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::conversations::ListLocations {
+        super::builder::conversations::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::GetLocation {
-        super::builder::conversations::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::conversations::GetLocation {
+        super::builder::conversations::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::ListOperations {
-        super::builder::conversations::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::conversations::ListOperations {
+        super::builder::conversations::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::GetOperation {
-        super::builder::conversations::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::conversations::GetOperation {
+        super::builder::conversations::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversations::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::conversations::CancelOperation {
         super::builder::conversations::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1159,29 +1003,23 @@ impl ConversationDatasets {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_conversation_dataset(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_datasets::CreateConversationDataset {
         super::builder::conversation_datasets::CreateConversationDataset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified conversation dataset.
     pub fn get_conversation_dataset(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_datasets::GetConversationDataset {
         super::builder::conversation_datasets::GetConversationDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the list of all conversation datasets in the specified
     /// project and location.
     pub fn list_conversation_datasets(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_datasets::ListConversationDatasets {
         super::builder::conversation_datasets::ListConversationDatasets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified conversation dataset.
@@ -1208,10 +1046,8 @@ impl ConversationDatasets {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_conversation_dataset(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_datasets::DeleteConversationDataset {
         super::builder::conversation_datasets::DeleteConversationDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Import data into the specified conversation dataset. Note that it
@@ -1241,61 +1077,39 @@ impl ConversationDatasets {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_conversation_data(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_datasets::ImportConversationData {
         super::builder::conversation_datasets::ImportConversationData::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_datasets::ListLocations {
+    pub fn list_locations(&self) -> super::builder::conversation_datasets::ListLocations {
         super::builder::conversation_datasets::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_datasets::GetLocation {
+    pub fn get_location(&self) -> super::builder::conversation_datasets::GetLocation {
         super::builder::conversation_datasets::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_datasets::ListOperations {
+    pub fn list_operations(&self) -> super::builder::conversation_datasets::ListOperations {
         super::builder::conversation_datasets::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_datasets::GetOperation {
+    pub fn get_operation(&self) -> super::builder::conversation_datasets::GetOperation {
         super::builder::conversation_datasets::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_datasets::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::conversation_datasets::CancelOperation {
         super::builder::conversation_datasets::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1426,28 +1240,22 @@ impl ConversationModels {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_conversation_model(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::CreateConversationModel {
         super::builder::conversation_models::CreateConversationModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets conversation model.
     pub fn get_conversation_model(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::GetConversationModel {
         super::builder::conversation_models::GetConversationModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists conversation models.
     pub fn list_conversation_models(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::ListConversationModels {
         super::builder::conversation_models::ListConversationModels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a model.
@@ -1474,10 +1282,8 @@ impl ConversationModels {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_conversation_model(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::DeleteConversationModel {
         super::builder::conversation_models::DeleteConversationModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deploys a model. If a model is already deployed, deploying it
@@ -1507,10 +1313,8 @@ impl ConversationModels {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn deploy_conversation_model(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::DeployConversationModel {
         super::builder::conversation_models::DeployConversationModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Undeploys a model. If the model is not deployed this method has no effect.
@@ -1541,30 +1345,24 @@ impl ConversationModels {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn undeploy_conversation_model(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::UndeployConversationModel {
         super::builder::conversation_models::UndeployConversationModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets an evaluation of conversation model.
     pub fn get_conversation_model_evaluation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::GetConversationModelEvaluation {
         super::builder::conversation_models::GetConversationModelEvaluation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists evaluations of a conversation model.
     pub fn list_conversation_model_evaluations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::ListConversationModelEvaluations {
         super::builder::conversation_models::ListConversationModelEvaluations::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Creates evaluation of a conversation model.
@@ -1580,63 +1378,41 @@ impl ConversationModels {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_conversation_model_evaluation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_models::CreateConversationModelEvaluation {
         super::builder::conversation_models::CreateConversationModelEvaluation::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_models::ListLocations {
+    pub fn list_locations(&self) -> super::builder::conversation_models::ListLocations {
         super::builder::conversation_models::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_models::GetLocation {
+    pub fn get_location(&self) -> super::builder::conversation_models::GetLocation {
         super::builder::conversation_models::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_models::ListOperations {
+    pub fn list_operations(&self) -> super::builder::conversation_models::ListOperations {
         super::builder::conversation_models::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_models::GetOperation {
+    pub fn get_operation(&self) -> super::builder::conversation_models::GetOperation {
         super::builder::conversation_models::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_models::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::conversation_models::CancelOperation {
         super::builder::conversation_models::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1748,19 +1524,15 @@ impl ConversationProfiles {
     /// Returns the list of all conversation profiles in the specified project.
     pub fn list_conversation_profiles(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::ListConversationProfiles {
         super::builder::conversation_profiles::ListConversationProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified conversation profile.
     pub fn get_conversation_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::GetConversationProfile {
         super::builder::conversation_profiles::GetConversationProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a conversation profile in the specified project.
@@ -1777,10 +1549,8 @@ impl ConversationProfiles {
     /// [google.cloud.dialogflow.v2.ConversationProfiles.GetConversationProfile]: crate::client::ConversationProfiles::get_conversation_profile
     pub fn create_conversation_profile(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::CreateConversationProfile {
         super::builder::conversation_profiles::CreateConversationProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified conversation profile.
@@ -1797,19 +1567,15 @@ impl ConversationProfiles {
     /// [google.cloud.dialogflow.v2.ConversationProfiles.GetConversationProfile]: crate::client::ConversationProfiles::get_conversation_profile
     pub fn update_conversation_profile(
         &self,
-        conversation_profile: impl Into<crate::model::ConversationProfile>,
     ) -> super::builder::conversation_profiles::UpdateConversationProfile {
         super::builder::conversation_profiles::UpdateConversationProfile::new(self.inner.clone())
-            .set_conversation_profile(conversation_profile.into())
     }
 
     /// Deletes the specified conversation profile.
     pub fn delete_conversation_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::DeleteConversationProfile {
         super::builder::conversation_profiles::DeleteConversationProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds or updates a suggestion feature in a conversation profile.
@@ -1845,10 +1611,8 @@ impl ConversationProfiles {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn set_suggestion_feature_config(
         &self,
-        conversation_profile: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::SetSuggestionFeatureConfig {
         super::builder::conversation_profiles::SetSuggestionFeatureConfig::new(self.inner.clone())
-            .set_conversation_profile(conversation_profile.into())
     }
 
     /// Clears a suggestion feature from a conversation profile for the given
@@ -1877,61 +1641,39 @@ impl ConversationProfiles {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn clear_suggestion_feature_config(
         &self,
-        conversation_profile: impl Into<std::string::String>,
     ) -> super::builder::conversation_profiles::ClearSuggestionFeatureConfig {
         super::builder::conversation_profiles::ClearSuggestionFeatureConfig::new(self.inner.clone())
-            .set_conversation_profile(conversation_profile.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_profiles::ListLocations {
+    pub fn list_locations(&self) -> super::builder::conversation_profiles::ListLocations {
         super::builder::conversation_profiles::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_profiles::GetLocation {
+    pub fn get_location(&self) -> super::builder::conversation_profiles::GetLocation {
         super::builder::conversation_profiles::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_profiles::ListOperations {
+    pub fn list_operations(&self) -> super::builder::conversation_profiles::ListOperations {
         super::builder::conversation_profiles::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_profiles::GetOperation {
+    pub fn get_operation(&self) -> super::builder::conversation_profiles::GetOperation {
         super::builder::conversation_profiles::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversation_profiles::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::conversation_profiles::CancelOperation {
         super::builder::conversation_profiles::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2039,19 +1781,13 @@ impl Documents {
     }
 
     /// Returns the list of all documents of the knowledge base.
-    pub fn list_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::documents::ListDocuments {
-        super::builder::documents::ListDocuments::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_documents(&self) -> super::builder::documents::ListDocuments {
+        super::builder::documents::ListDocuments::new(self.inner.clone())
     }
 
     /// Retrieves the specified document.
-    pub fn get_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::GetDocument {
-        super::builder::documents::GetDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn get_document(&self) -> super::builder::documents::GetDocument {
+        super::builder::documents::GetDocument::new(self.inner.clone())
     }
 
     /// Creates a new document.
@@ -2076,11 +1812,8 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_document(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::documents::CreateDocument {
-        super::builder::documents::CreateDocument::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_document(&self) -> super::builder::documents::CreateDocument {
+        super::builder::documents::CreateDocument::new(self.inner.clone())
     }
 
     /// Creates documents by importing data from external sources.
@@ -2108,12 +1841,8 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::documents::ImportDocuments {
+    pub fn import_documents(&self) -> super::builder::documents::ImportDocuments {
         super::builder::documents::ImportDocuments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified document.
@@ -2138,11 +1867,8 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::DeleteDocument {
-        super::builder::documents::DeleteDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_document(&self) -> super::builder::documents::DeleteDocument {
+        super::builder::documents::DeleteDocument::new(self.inner.clone())
     }
 
     /// Updates the specified document.
@@ -2167,12 +1893,8 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_document(
-        &self,
-        document: impl Into<crate::model::Document>,
-    ) -> super::builder::documents::UpdateDocument {
+    pub fn update_document(&self) -> super::builder::documents::UpdateDocument {
         super::builder::documents::UpdateDocument::new(self.inner.clone())
-            .set_document(document.into())
     }
 
     /// Reloads the specified document from its specified source, content_uri or
@@ -2203,11 +1925,8 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reload_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::ReloadDocument {
-        super::builder::documents::ReloadDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn reload_document(&self) -> super::builder::documents::ReloadDocument {
+        super::builder::documents::ReloadDocument::new(self.inner.clone())
     }
 
     /// Exports a smart messaging candidate document into the specified
@@ -2233,57 +1952,39 @@ impl Documents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::ExportDocument {
-        super::builder::documents::ExportDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn export_document(&self) -> super::builder::documents::ExportDocument {
+        super::builder::documents::ExportDocument::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::ListLocations {
-        super::builder::documents::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::documents::ListLocations {
+        super::builder::documents::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::GetLocation {
-        super::builder::documents::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::documents::GetLocation {
+        super::builder::documents::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::ListOperations {
-        super::builder::documents::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::documents::ListOperations {
+        super::builder::documents::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::GetOperation {
-        super::builder::documents::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::documents::GetOperation {
+        super::builder::documents::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::documents::CancelOperation {
-        super::builder::documents::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::documents::CancelOperation {
+        super::builder::documents::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2392,10 +2093,8 @@ impl EncryptionSpecService {
     /// Gets location-level encryption key specification.
     pub fn get_encryption_spec(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::encryption_spec_service::GetEncryptionSpec {
         super::builder::encryption_spec_service::GetEncryptionSpec::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Initializes a location-level encryption key specification.  An error will
@@ -2415,61 +2114,39 @@ impl EncryptionSpecService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn initialize_encryption_spec(
         &self,
-        encryption_spec: impl Into<crate::model::EncryptionSpec>,
     ) -> super::builder::encryption_spec_service::InitializeEncryptionSpec {
         super::builder::encryption_spec_service::InitializeEncryptionSpec::new(self.inner.clone())
-            .set_encryption_spec(encryption_spec.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::encryption_spec_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::encryption_spec_service::ListLocations {
         super::builder::encryption_spec_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::encryption_spec_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::encryption_spec_service::GetLocation {
         super::builder::encryption_spec_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::encryption_spec_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::encryption_spec_service::ListOperations {
         super::builder::encryption_spec_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::encryption_spec_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::encryption_spec_service::GetOperation {
         super::builder::encryption_spec_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::encryption_spec_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::encryption_spec_service::CancelOperation {
         super::builder::encryption_spec_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2576,20 +2253,13 @@ impl EntityTypes {
     }
 
     /// Returns the list of all entity types in the specified agent.
-    pub fn list_entity_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListEntityTypes {
+    pub fn list_entity_types(&self) -> super::builder::entity_types::ListEntityTypes {
         super::builder::entity_types::ListEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified entity type.
-    pub fn get_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetEntityType {
-        super::builder::entity_types::GetEntityType::new(self.inner.clone()).set_name(name.into())
+    pub fn get_entity_type(&self) -> super::builder::entity_types::GetEntityType {
+        super::builder::entity_types::GetEntityType::new(self.inner.clone())
     }
 
     /// Creates an entity type in the specified agent.
@@ -2597,12 +2267,8 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn create_entity_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::CreateEntityType {
+    pub fn create_entity_type(&self) -> super::builder::entity_types::CreateEntityType {
         super::builder::entity_types::CreateEntityType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified entity type.
@@ -2610,12 +2276,8 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn update_entity_type(
-        &self,
-        entity_type: impl Into<crate::model::EntityType>,
-    ) -> super::builder::entity_types::UpdateEntityType {
+    pub fn update_entity_type(&self) -> super::builder::entity_types::UpdateEntityType {
         super::builder::entity_types::UpdateEntityType::new(self.inner.clone())
-            .set_entity_type(entity_type.into())
     }
 
     /// Deletes the specified entity type.
@@ -2623,12 +2285,8 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn delete_entity_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::DeleteEntityType {
+    pub fn delete_entity_type(&self) -> super::builder::entity_types::DeleteEntityType {
         super::builder::entity_types::DeleteEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates/Creates multiple entity types in the specified agent.
@@ -2659,10 +2317,8 @@ impl EntityTypes {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_update_entity_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::entity_types::BatchUpdateEntityTypes {
         super::builder::entity_types::BatchUpdateEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes entity types in the specified agent.
@@ -2691,10 +2347,8 @@ impl EntityTypes {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_delete_entity_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::entity_types::BatchDeleteEntityTypes {
         super::builder::entity_types::BatchDeleteEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates multiple new entities in the specified entity type.
@@ -2721,12 +2375,8 @@ impl EntityTypes {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_create_entities(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::BatchCreateEntities {
+    pub fn batch_create_entities(&self) -> super::builder::entity_types::BatchCreateEntities {
         super::builder::entity_types::BatchCreateEntities::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates or creates multiple entities in the specified entity type. This
@@ -2755,12 +2405,8 @@ impl EntityTypes {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_update_entities(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::BatchUpdateEntities {
+    pub fn batch_update_entities(&self) -> super::builder::entity_types::BatchUpdateEntities {
         super::builder::entity_types::BatchUpdateEntities::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes entities in the specified entity type.
@@ -2787,58 +2433,39 @@ impl EntityTypes {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_delete_entities(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::BatchDeleteEntities {
+    pub fn batch_delete_entities(&self) -> super::builder::entity_types::BatchDeleteEntities {
         super::builder::entity_types::BatchDeleteEntities::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListLocations {
-        super::builder::entity_types::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::entity_types::ListLocations {
+        super::builder::entity_types::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetLocation {
-        super::builder::entity_types::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::entity_types::GetLocation {
+        super::builder::entity_types::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::ListOperations {
-        super::builder::entity_types::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::entity_types::ListOperations {
+        super::builder::entity_types::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::GetOperation {
-        super::builder::entity_types::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::entity_types::GetOperation {
+        super::builder::entity_types::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::entity_types::CancelOperation {
-        super::builder::entity_types::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::entity_types::CancelOperation {
+        super::builder::entity_types::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2945,29 +2572,18 @@ impl Environments {
     }
 
     /// Returns the list of all non-default environments of the specified agent.
-    pub fn list_environments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListEnvironments {
+    pub fn list_environments(&self) -> super::builder::environments::ListEnvironments {
         super::builder::environments::ListEnvironments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified agent environment.
-    pub fn get_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetEnvironment {
-        super::builder::environments::GetEnvironment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
+        super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
 
     /// Creates an agent environment.
-    pub fn create_environment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::CreateEnvironment {
+    pub fn create_environment(&self) -> super::builder::environments::CreateEnvironment {
         super::builder::environments::CreateEnvironment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified agent environment.
@@ -2982,76 +2598,49 @@ impl Environments {
     /// version in the default environment. WARNING: this will negate all recent
     /// changes to the draft agent and can't be undone. You may want to save the
     /// draft agent to a version before calling this method.
-    pub fn update_environment(
-        &self,
-        environment: impl Into<crate::model::Environment>,
-    ) -> super::builder::environments::UpdateEnvironment {
+    pub fn update_environment(&self) -> super::builder::environments::UpdateEnvironment {
         super::builder::environments::UpdateEnvironment::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Deletes the specified agent environment.
-    pub fn delete_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::DeleteEnvironment {
+    pub fn delete_environment(&self) -> super::builder::environments::DeleteEnvironment {
         super::builder::environments::DeleteEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the history of the specified environment.
-    pub fn get_environment_history(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetEnvironmentHistory {
+    pub fn get_environment_history(&self) -> super::builder::environments::GetEnvironmentHistory {
         super::builder::environments::GetEnvironmentHistory::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListLocations {
-        super::builder::environments::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::environments::ListLocations {
+        super::builder::environments::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetLocation {
-        super::builder::environments::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::environments::GetLocation {
+        super::builder::environments::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListOperations {
-        super::builder::environments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::environments::ListOperations {
+        super::builder::environments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetOperation {
-        super::builder::environments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::environments::GetOperation {
+        super::builder::environments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::CancelOperation {
-        super::builder::environments::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::environments::CancelOperation {
+        super::builder::environments::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3158,66 +2747,44 @@ impl Fulfillments {
     }
 
     /// Retrieves the fulfillment.
-    pub fn get_fulfillment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::GetFulfillment {
-        super::builder::fulfillments::GetFulfillment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_fulfillment(&self) -> super::builder::fulfillments::GetFulfillment {
+        super::builder::fulfillments::GetFulfillment::new(self.inner.clone())
     }
 
     /// Updates the fulfillment.
-    pub fn update_fulfillment(
-        &self,
-        fulfillment: impl Into<crate::model::Fulfillment>,
-    ) -> super::builder::fulfillments::UpdateFulfillment {
+    pub fn update_fulfillment(&self) -> super::builder::fulfillments::UpdateFulfillment {
         super::builder::fulfillments::UpdateFulfillment::new(self.inner.clone())
-            .set_fulfillment(fulfillment.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::ListLocations {
-        super::builder::fulfillments::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::fulfillments::ListLocations {
+        super::builder::fulfillments::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::GetLocation {
-        super::builder::fulfillments::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::fulfillments::GetLocation {
+        super::builder::fulfillments::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::ListOperations {
-        super::builder::fulfillments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::fulfillments::ListOperations {
+        super::builder::fulfillments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::GetOperation {
-        super::builder::fulfillments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::fulfillments::GetOperation {
+        super::builder::fulfillments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fulfillments::CancelOperation {
-        super::builder::fulfillments::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::fulfillments::CancelOperation {
+        super::builder::fulfillments::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3326,92 +2893,59 @@ impl Generators {
     }
 
     /// Creates a generator.
-    pub fn create_generator(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::generators::CreateGenerator {
+    pub fn create_generator(&self) -> super::builder::generators::CreateGenerator {
         super::builder::generators::CreateGenerator::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a generator.
-    pub fn get_generator(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetGenerator {
-        super::builder::generators::GetGenerator::new(self.inner.clone()).set_name(name.into())
+    pub fn get_generator(&self) -> super::builder::generators::GetGenerator {
+        super::builder::generators::GetGenerator::new(self.inner.clone())
     }
 
     /// Lists generators.
-    pub fn list_generators(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListGenerators {
+    pub fn list_generators(&self) -> super::builder::generators::ListGenerators {
         super::builder::generators::ListGenerators::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a generator.
-    pub fn delete_generator(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::DeleteGenerator {
-        super::builder::generators::DeleteGenerator::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_generator(&self) -> super::builder::generators::DeleteGenerator {
+        super::builder::generators::DeleteGenerator::new(self.inner.clone())
     }
 
     /// Updates a generator.
-    pub fn update_generator(
-        &self,
-        generator: impl Into<crate::model::Generator>,
-    ) -> super::builder::generators::UpdateGenerator {
+    pub fn update_generator(&self) -> super::builder::generators::UpdateGenerator {
         super::builder::generators::UpdateGenerator::new(self.inner.clone())
-            .set_generator(generator.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListLocations {
-        super::builder::generators::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::generators::ListLocations {
+        super::builder::generators::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetLocation {
-        super::builder::generators::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::generators::GetLocation {
+        super::builder::generators::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::ListOperations {
-        super::builder::generators::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::generators::ListOperations {
+        super::builder::generators::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::GetOperation {
-        super::builder::generators::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::generators::GetOperation {
+        super::builder::generators::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generators::CancelOperation {
-        super::builder::generators::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::generators::CancelOperation {
+        super::builder::generators::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3518,19 +3052,13 @@ impl Intents {
     }
 
     /// Returns the list of all intents in the specified agent.
-    pub fn list_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListIntents {
-        super::builder::intents::ListIntents::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_intents(&self) -> super::builder::intents::ListIntents {
+        super::builder::intents::ListIntents::new(self.inner.clone())
     }
 
     /// Retrieves the specified intent.
-    pub fn get_intent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetIntent {
-        super::builder::intents::GetIntent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_intent(&self) -> super::builder::intents::GetIntent {
+        super::builder::intents::GetIntent::new(self.inner.clone())
     }
 
     /// Creates an intent in the specified agent.
@@ -3538,11 +3066,8 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn create_intent(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::CreateIntent {
-        super::builder::intents::CreateIntent::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_intent(&self) -> super::builder::intents::CreateIntent {
+        super::builder::intents::CreateIntent::new(self.inner.clone())
     }
 
     /// Updates the specified intent.
@@ -3550,11 +3075,8 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn update_intent(
-        &self,
-        intent: impl Into<crate::model::Intent>,
-    ) -> super::builder::intents::UpdateIntent {
-        super::builder::intents::UpdateIntent::new(self.inner.clone()).set_intent(intent.into())
+    pub fn update_intent(&self) -> super::builder::intents::UpdateIntent {
+        super::builder::intents::UpdateIntent::new(self.inner.clone())
     }
 
     /// Deletes the specified intent and its direct or indirect followup intents.
@@ -3562,11 +3084,8 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
-    pub fn delete_intent(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::DeleteIntent {
-        super::builder::intents::DeleteIntent::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_intent(&self) -> super::builder::intents::DeleteIntent {
+        super::builder::intents::DeleteIntent::new(self.inner.clone())
     }
 
     /// Updates/Creates multiple intents in the specified agent.
@@ -3595,12 +3114,8 @@ impl Intents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_update_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::BatchUpdateIntents {
+    pub fn batch_update_intents(&self) -> super::builder::intents::BatchUpdateIntents {
         super::builder::intents::BatchUpdateIntents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes intents in the specified agent.
@@ -3627,58 +3142,39 @@ impl Intents {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_delete_intents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::intents::BatchDeleteIntents {
+    pub fn batch_delete_intents(&self) -> super::builder::intents::BatchDeleteIntents {
         super::builder::intents::BatchDeleteIntents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListLocations {
-        super::builder::intents::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::intents::ListLocations {
+        super::builder::intents::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetLocation {
-        super::builder::intents::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::intents::GetLocation {
+        super::builder::intents::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::ListOperations {
-        super::builder::intents::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::intents::ListOperations {
+        super::builder::intents::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::GetOperation {
-        super::builder::intents::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::intents::GetOperation {
+        super::builder::intents::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::intents::CancelOperation {
-        super::builder::intents::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::intents::CancelOperation {
+        super::builder::intents::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -3786,97 +3282,59 @@ impl KnowledgeBases {
     }
 
     /// Returns the list of all knowledge bases of the specified agent.
-    pub fn list_knowledge_bases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::ListKnowledgeBases {
+    pub fn list_knowledge_bases(&self) -> super::builder::knowledge_bases::ListKnowledgeBases {
         super::builder::knowledge_bases::ListKnowledgeBases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified knowledge base.
-    pub fn get_knowledge_base(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::GetKnowledgeBase {
+    pub fn get_knowledge_base(&self) -> super::builder::knowledge_bases::GetKnowledgeBase {
         super::builder::knowledge_bases::GetKnowledgeBase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a knowledge base.
-    pub fn create_knowledge_base(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::CreateKnowledgeBase {
+    pub fn create_knowledge_base(&self) -> super::builder::knowledge_bases::CreateKnowledgeBase {
         super::builder::knowledge_bases::CreateKnowledgeBase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified knowledge base.
-    pub fn delete_knowledge_base(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::DeleteKnowledgeBase {
+    pub fn delete_knowledge_base(&self) -> super::builder::knowledge_bases::DeleteKnowledgeBase {
         super::builder::knowledge_bases::DeleteKnowledgeBase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified knowledge base.
-    pub fn update_knowledge_base(
-        &self,
-        knowledge_base: impl Into<crate::model::KnowledgeBase>,
-    ) -> super::builder::knowledge_bases::UpdateKnowledgeBase {
+    pub fn update_knowledge_base(&self) -> super::builder::knowledge_bases::UpdateKnowledgeBase {
         super::builder::knowledge_bases::UpdateKnowledgeBase::new(self.inner.clone())
-            .set_knowledge_base(knowledge_base.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::ListLocations {
+    pub fn list_locations(&self) -> super::builder::knowledge_bases::ListLocations {
         super::builder::knowledge_bases::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::GetLocation {
-        super::builder::knowledge_bases::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::knowledge_bases::GetLocation {
+        super::builder::knowledge_bases::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::ListOperations {
+    pub fn list_operations(&self) -> super::builder::knowledge_bases::ListOperations {
         super::builder::knowledge_bases::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::GetOperation {
-        super::builder::knowledge_bases::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::knowledge_bases::GetOperation {
+        super::builder::knowledge_bases::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::knowledge_bases::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::knowledge_bases::CancelOperation {
         super::builder::knowledge_bases::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3983,38 +3441,23 @@ impl Participants {
     }
 
     /// Creates a new participant in a conversation.
-    pub fn create_participant(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::CreateParticipant {
+    pub fn create_participant(&self) -> super::builder::participants::CreateParticipant {
         super::builder::participants::CreateParticipant::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a conversation participant.
-    pub fn get_participant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::GetParticipant {
-        super::builder::participants::GetParticipant::new(self.inner.clone()).set_name(name.into())
+    pub fn get_participant(&self) -> super::builder::participants::GetParticipant {
+        super::builder::participants::GetParticipant::new(self.inner.clone())
     }
 
     /// Returns the list of all participants in the specified conversation.
-    pub fn list_participants(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::ListParticipants {
+    pub fn list_participants(&self) -> super::builder::participants::ListParticipants {
         super::builder::participants::ListParticipants::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified participant.
-    pub fn update_participant(
-        &self,
-        participant: impl Into<crate::model::Participant>,
-    ) -> super::builder::participants::UpdateParticipant {
+    pub fn update_participant(&self) -> super::builder::participants::UpdateParticipant {
         super::builder::participants::UpdateParticipant::new(self.inner.clone())
-            .set_participant(participant.into())
     }
 
     /// Adds a text (chat, for example), or audio (phone recording, for example)
@@ -4023,97 +3466,62 @@ impl Participants {
     /// Note: Always use agent versions for production traffic
     /// sent to virtual agents. See [Versions and
     /// environments](https://cloud.google.com/dialogflow/es/docs/agents-versions).
-    pub fn analyze_content(
-        &self,
-        participant: impl Into<std::string::String>,
-    ) -> super::builder::participants::AnalyzeContent {
+    pub fn analyze_content(&self) -> super::builder::participants::AnalyzeContent {
         super::builder::participants::AnalyzeContent::new(self.inner.clone())
-            .set_participant(participant.into())
     }
 
     /// Gets suggested articles for a participant based on specific historical
     /// messages.
-    pub fn suggest_articles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::SuggestArticles {
+    pub fn suggest_articles(&self) -> super::builder::participants::SuggestArticles {
         super::builder::participants::SuggestArticles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets suggested faq answers for a participant based on specific historical
     /// messages.
-    pub fn suggest_faq_answers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::SuggestFaqAnswers {
+    pub fn suggest_faq_answers(&self) -> super::builder::participants::SuggestFaqAnswers {
         super::builder::participants::SuggestFaqAnswers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets smart replies for a participant based on specific historical
     /// messages.
-    pub fn suggest_smart_replies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::SuggestSmartReplies {
+    pub fn suggest_smart_replies(&self) -> super::builder::participants::SuggestSmartReplies {
         super::builder::participants::SuggestSmartReplies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets knowledge assist suggestions based on historical messages.
-    pub fn suggest_knowledge_assist(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::participants::SuggestKnowledgeAssist {
+    pub fn suggest_knowledge_assist(&self) -> super::builder::participants::SuggestKnowledgeAssist {
         super::builder::participants::SuggestKnowledgeAssist::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::ListLocations {
-        super::builder::participants::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::participants::ListLocations {
+        super::builder::participants::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::GetLocation {
-        super::builder::participants::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::participants::GetLocation {
+        super::builder::participants::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::ListOperations {
-        super::builder::participants::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::participants::ListOperations {
+        super::builder::participants::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::GetOperation {
-        super::builder::participants::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::participants::GetOperation {
+        super::builder::participants::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::participants::CancelOperation {
-        super::builder::participants::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::participants::CancelOperation {
+        super::builder::participants::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -4237,57 +3645,39 @@ impl Sessions {
     /// environments](https://cloud.google.com/dialogflow/es/docs/agents-versions).
     ///
     /// [google.cloud.dialogflow.v2.Participants.AnalyzeContent]: crate::client::Participants::analyze_content
-    pub fn detect_intent(
-        &self,
-        session: impl Into<std::string::String>,
-    ) -> super::builder::sessions::DetectIntent {
-        super::builder::sessions::DetectIntent::new(self.inner.clone()).set_session(session.into())
+    pub fn detect_intent(&self) -> super::builder::sessions::DetectIntent {
+        super::builder::sessions::DetectIntent::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::ListLocations {
-        super::builder::sessions::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::sessions::ListLocations {
+        super::builder::sessions::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::GetLocation {
-        super::builder::sessions::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::sessions::GetLocation {
+        super::builder::sessions::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::ListOperations {
-        super::builder::sessions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::sessions::ListOperations {
+        super::builder::sessions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::GetOperation {
-        super::builder::sessions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::sessions::GetOperation {
+        super::builder::sessions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sessions::CancelOperation {
-        super::builder::sessions::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::sessions::CancelOperation {
+        super::builder::sessions::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -4403,10 +3793,8 @@ impl SessionEntityTypes {
     /// with Google Assistant integration.
     pub fn list_session_entity_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::ListSessionEntityTypes {
         super::builder::session_entity_types::ListSessionEntityTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified session entity type.
@@ -4416,10 +3804,8 @@ impl SessionEntityTypes {
     /// with Google Assistant integration.
     pub fn get_session_entity_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::GetSessionEntityType {
         super::builder::session_entity_types::GetSessionEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a session entity type.
@@ -4432,10 +3818,8 @@ impl SessionEntityTypes {
     /// with Google Assistant integration.
     pub fn create_session_entity_type(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::CreateSessionEntityType {
         super::builder::session_entity_types::CreateSessionEntityType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified session entity type.
@@ -4445,10 +3829,8 @@ impl SessionEntityTypes {
     /// with Google Assistant integration.
     pub fn update_session_entity_type(
         &self,
-        session_entity_type: impl Into<crate::model::SessionEntityType>,
     ) -> super::builder::session_entity_types::UpdateSessionEntityType {
         super::builder::session_entity_types::UpdateSessionEntityType::new(self.inner.clone())
-            .set_session_entity_type(session_entity_type.into())
     }
 
     /// Deletes the specified session entity type.
@@ -4458,61 +3840,39 @@ impl SessionEntityTypes {
     /// with Google Assistant integration.
     pub fn delete_session_entity_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::session_entity_types::DeleteSessionEntityType {
         super::builder::session_entity_types::DeleteSessionEntityType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::ListLocations {
+    pub fn list_locations(&self) -> super::builder::session_entity_types::ListLocations {
         super::builder::session_entity_types::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::GetLocation {
+    pub fn get_location(&self) -> super::builder::session_entity_types::GetLocation {
         super::builder::session_entity_types::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::ListOperations {
+    pub fn list_operations(&self) -> super::builder::session_entity_types::ListOperations {
         super::builder::session_entity_types::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::GetOperation {
+    pub fn get_operation(&self) -> super::builder::session_entity_types::GetOperation {
         super::builder::session_entity_types::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::session_entity_types::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::session_entity_types::CancelOperation {
         super::builder::session_entity_types::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -4619,29 +3979,20 @@ impl Versions {
     }
 
     /// Returns the list of all versions of the specified agent.
-    pub fn list_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListVersions {
-        super::builder::versions::ListVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_versions(&self) -> super::builder::versions::ListVersions {
+        super::builder::versions::ListVersions::new(self.inner.clone())
     }
 
     /// Retrieves the specified agent version.
-    pub fn get_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetVersion {
-        super::builder::versions::GetVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_version(&self) -> super::builder::versions::GetVersion {
+        super::builder::versions::GetVersion::new(self.inner.clone())
     }
 
     /// Creates an agent version.
     ///
     /// The new version points to the agent instance in the "default" environment.
-    pub fn create_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::versions::CreateVersion {
-        super::builder::versions::CreateVersion::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_version(&self) -> super::builder::versions::CreateVersion {
+        super::builder::versions::CreateVersion::new(self.inner.clone())
     }
 
     /// Updates the specified agent version.
@@ -4649,64 +4000,43 @@ impl Versions {
     /// Note that this method does not allow you to update the state of the agent
     /// the given version points to. It allows you to update only mutable
     /// properties of the version resource.
-    pub fn update_version(
-        &self,
-        version: impl Into<crate::model::Version>,
-    ) -> super::builder::versions::UpdateVersion {
-        super::builder::versions::UpdateVersion::new(self.inner.clone()).set_version(version.into())
+    pub fn update_version(&self) -> super::builder::versions::UpdateVersion {
+        super::builder::versions::UpdateVersion::new(self.inner.clone())
     }
 
     /// Delete the specified agent version.
-    pub fn delete_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::DeleteVersion {
-        super::builder::versions::DeleteVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_version(&self) -> super::builder::versions::DeleteVersion {
+        super::builder::versions::DeleteVersion::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListLocations {
-        super::builder::versions::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::versions::ListLocations {
+        super::builder::versions::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetLocation {
-        super::builder::versions::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::versions::GetLocation {
+        super::builder::versions::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::ListOperations {
-        super::builder::versions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::versions::ListOperations {
+        super::builder::versions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::GetOperation {
-        super::builder::versions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::versions::GetOperation {
+        super::builder::versions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::versions::CancelOperation {
-        super::builder::versions::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::versions::CancelOperation {
+        super::builder::versions::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -73,10 +73,15 @@ impl super::stub::Agents for Agents {
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}/agent", {
-            &req.agent
+            let arg = &req
+                .agent
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
-                .parent
+                .parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("agent.parent"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -489,10 +494,15 @@ impl super::stub::AnswerRecords for AnswerRecords {
     ) -> Result<gax::response::Response<crate::model::AnswerRecord>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.answer_record
+            let arg = &req
+                .answer_record
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("answer_record"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("answer_record.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -763,10 +773,15 @@ impl super::stub::Contexts for Contexts {
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.context
+            let arg = &req
+                .context
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("context"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("context.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1200,10 +1215,17 @@ impl super::stub::Conversations for Conversations {
     ) -> Result<gax::response::Response<crate::model::GenerateStatelessSummaryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}/suggestions:generateStatelessSummary", {
-            &req.stateless_conversation
+            let arg = &req
+                .stateless_conversation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("stateless_conversation"))?
-                .parent
+                .parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "stateless_conversation.parent",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2255,10 +2277,15 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
     ) -> Result<gax::response::Response<crate::model::ConversationProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.conversation_profile
+            let arg = &req
+                .conversation_profile
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("conversation_profile"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation_profile.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2672,10 +2699,15 @@ impl super::stub::Documents for Documents {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.document
+            let arg = &req
+                .document
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("document"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("document.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2954,10 +2986,15 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}:initialize", {
-            &req.encryption_spec
+            let arg = &req
+                .encryption_spec
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("encryption_spec.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3237,10 +3274,15 @@ impl super::stub::EntityTypes for EntityTypes {
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.entity_type
+            let arg = &req
+                .entity_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entity_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3677,10 +3719,15 @@ impl super::stub::Environments for Environments {
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.environment
+            let arg = &req
+                .environment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3959,10 +4006,15 @@ impl super::stub::Fulfillments for Fulfillments {
     ) -> Result<gax::response::Response<crate::model::Fulfillment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.fulfillment
+            let arg = &req
+                .fulfillment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("fulfillment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("fulfillment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4264,10 +4316,15 @@ impl super::stub::Generators for Generators {
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.generator
+            let arg = &req
+                .generator
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("generator.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4542,10 +4599,15 @@ impl super::stub::Intents for Intents {
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.intent
+            let arg = &req
+                .intent
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("intent.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -4940,10 +5002,15 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
     ) -> Result<gax::response::Response<crate::model::KnowledgeBase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.knowledge_base
+            let arg = &req
+                .knowledge_base
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("knowledge_base"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("knowledge_base.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -5214,10 +5281,15 @@ impl super::stub::Participants for Participants {
     ) -> Result<gax::response::Response<crate::model::Participant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.participant
+            let arg = &req
+                .participant
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("participant"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("participant.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -5795,10 +5867,15 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.session_entity_type
+            let arg = &req
+                .session_entity_type
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session_entity_type.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -6099,10 +6176,15 @@ impl super::stub::Versions for Versions {
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.version
+            let arg = &req
+                .version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/agent", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/agent", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,18 +72,15 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Agent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/agent", {
+            &req.agent
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
+                .parent
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}/agent",
-                    req.agent
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("agent"))?
-                        .parent
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -97,9 +101,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/agent", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}/agent", req.parent))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -120,12 +131,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchAgentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/agent:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/agent:search", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -144,12 +159,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/agent:train", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/agent:train", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -164,12 +183,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/agent:export", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/agent:export", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,12 +207,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/agent:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/agent:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,12 +231,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/agent:restore", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/agent:restore", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -224,12 +255,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ValidationResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/agent/validationResult", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/agent/validationResult", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,9 +282,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -269,9 +311,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,9 +337,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +366,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +392,16 @@ impl super::stub::Agents for Agents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,12 +459,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAnswerRecordsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/answerRecords", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/answerRecords", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -414,18 +488,15 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnswerRecord>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.answer_record
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("answer_record"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.answer_record
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("answer_record"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -448,9 +519,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,9 +548,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,9 +574,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -511,9 +603,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -530,9 +629,16 @@ impl super::stub::AnswerRecords for AnswerRecords {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -576,9 +682,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListContextsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/contexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/contexts", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -597,9 +710,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -616,12 +736,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/contexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/contexts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -638,18 +762,15 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Context>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.context
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("context"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.context
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("context"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -672,9 +793,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -695,12 +823,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/contexts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v2/{}/contexts", req.parent),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -721,9 +853,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -743,9 +882,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -762,9 +908,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -784,9 +937,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -803,9 +963,16 @@ impl super::stub::Contexts for Contexts {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -849,12 +1016,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -872,12 +1043,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -897,9 +1072,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -916,9 +1098,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:complete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:complete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -933,12 +1122,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IngestContextReferencesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:ingestContextReferences", {
+            let arg = &req.conversation;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:ingestContextReferences", req.conversation),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -953,9 +1146,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMessagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/messages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/messages", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -975,15 +1175,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SuggestConversationSummaryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:suggestConversationSummary", {
+            let arg = &req.conversation;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}/suggestions:suggestConversationSummary",
-                    req.conversation
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -998,18 +1199,15 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateStatelessSummaryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:generateStatelessSummary", {
+            &req.stateless_conversation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("stateless_conversation"))?
+                .parent
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}/suggestions:generateStatelessSummary",
-                    req.stateless_conversation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("stateless_conversation"))?
-                        .parent
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1024,12 +1222,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateStatelessSuggestionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/statelessSuggestion:generate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/statelessSuggestion:generate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1044,12 +1246,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchKnowledgeResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:searchKnowledge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:searchKnowledge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1064,12 +1270,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateSuggestionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:generate", {
+            let arg = &req.conversation;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:generate", req.conversation),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1084,9 +1294,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1106,9 +1323,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1125,9 +1349,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1147,9 +1378,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1166,9 +1404,16 @@ impl super::stub::Conversations for Conversations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1212,12 +1457,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/conversationDatasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/conversationDatasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1234,9 +1483,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationDataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1253,12 +1509,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationDatasetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/conversationDatasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/conversationDatasets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1277,9 +1537,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1296,12 +1563,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:importConversationData", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:importConversationData", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1316,9 +1587,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1338,9 +1616,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1357,9 +1642,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1379,9 +1671,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1398,9 +1697,16 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1458,12 +1764,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/conversationModels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/conversationModels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1480,9 +1790,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationModel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1499,12 +1816,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/conversationModels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/conversationModels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1523,9 +1844,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1542,9 +1870,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:deploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:deploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1559,9 +1894,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undeploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undeploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1576,9 +1918,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationModelEvaluation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1596,12 +1945,16 @@ impl super::stub::ConversationModels for ConversationModels {
     ) -> Result<gax::response::Response<crate::model::ListConversationModelEvaluationsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/evaluations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/evaluations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1620,12 +1973,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/evaluations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/evaluations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1640,9 +1997,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1662,9 +2026,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1681,9 +2052,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1703,9 +2081,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1722,9 +2107,16 @@ impl super::stub::ConversationModels for ConversationModels {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1782,12 +2174,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/conversationProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/conversationProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1806,9 +2202,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1825,12 +2228,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/conversationProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/conversationProfiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1847,18 +2254,15 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConversationProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.conversation_profile
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("conversation_profile"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.conversation_profile
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("conversation_profile"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1881,9 +2285,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1904,15 +2315,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setSuggestionFeatureConfig", {
+            let arg = &req.conversation_profile;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation_profile"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}:setSuggestionFeatureConfig",
-                    req.conversation_profile
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1927,15 +2339,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:clearSuggestionFeatureConfig", {
+            let arg = &req.conversation_profile;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation_profile"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}:clearSuggestionFeatureConfig",
-                    req.conversation_profile
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1950,9 +2363,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1972,9 +2392,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1991,9 +2418,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2013,9 +2447,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2032,9 +2473,16 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2092,12 +2540,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDocumentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/documents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/documents", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2117,9 +2569,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2136,12 +2595,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/documents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/documents", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2158,12 +2621,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/documents:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/documents:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2178,9 +2645,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2197,18 +2671,15 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.document
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("document"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.document
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("document"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2231,9 +2702,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:reload", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:reload", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2248,9 +2726,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2265,9 +2750,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2287,9 +2779,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2306,9 +2805,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2328,9 +2834,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2347,9 +2860,16 @@ impl super::stub::Documents for Documents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2407,9 +2927,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EncryptionSpec>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2426,18 +2953,15 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:initialize", {
+            &req.encryption_spec
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}:initialize",
-                    req.encryption_spec
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("encryption_spec"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2452,9 +2976,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2474,9 +3005,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2493,9 +3031,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2515,9 +3060,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2534,9 +3086,16 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2594,12 +3153,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntityTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2619,9 +3182,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2639,12 +3209,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2662,18 +3236,15 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.entity_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.entity_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entity_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2697,9 +3268,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2720,12 +3298,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entityTypes:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entityTypes:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2740,12 +3322,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entityTypes:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entityTypes:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2760,12 +3346,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entities:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entities:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2780,12 +3370,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entities:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entities:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2800,12 +3394,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entities:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entities:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2820,9 +3418,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2842,9 +3447,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2861,9 +3473,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2883,9 +3502,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2902,9 +3528,16 @@ impl super::stub::EntityTypes for EntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2962,12 +3595,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnvironmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2986,9 +3623,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3005,12 +3649,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3028,18 +3676,15 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.environment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.environment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("environment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3066,9 +3711,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3089,9 +3741,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnvironmentHistory>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/history", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/history", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3110,9 +3769,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3132,9 +3798,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3151,9 +3824,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3173,9 +3853,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3192,9 +3879,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3238,9 +3932,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Fulfillment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3257,18 +3958,15 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Fulfillment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.fulfillment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("fulfillment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.fulfillment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("fulfillment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3291,9 +3989,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3313,9 +4018,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3332,9 +4044,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3354,9 +4073,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3373,9 +4099,16 @@ impl super::stub::Fulfillments for Fulfillments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3419,12 +4152,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/generators", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/generators", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3442,9 +4179,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3461,12 +4205,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGeneratorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/generators", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/generators", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3485,9 +4233,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3508,18 +4263,15 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Generator>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.generator
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.generator
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("generator"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3542,9 +4294,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3564,9 +4323,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3583,9 +4349,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3605,9 +4378,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3624,9 +4404,16 @@ impl super::stub::Generators for Generators {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3670,9 +4457,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIntentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/intents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/intents", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3693,9 +4487,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3714,9 +4515,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/intents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/intents", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3733,18 +4541,15 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Intent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.intent
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.intent
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("intent"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3767,9 +4572,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3790,12 +4602,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/intents:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/intents:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3810,12 +4626,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/intents:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/intents:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3830,9 +4650,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3852,9 +4679,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3871,9 +4705,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3893,9 +4734,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3912,9 +4760,16 @@ impl super::stub::Intents for Intents {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3972,12 +4827,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKnowledgeBasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/knowledgeBases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/knowledgeBases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3997,9 +4856,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KnowledgeBase>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4016,12 +4882,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KnowledgeBase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/knowledgeBases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/knowledgeBases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4038,9 +4908,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4062,18 +4939,15 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KnowledgeBase>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.knowledge_base
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("knowledge_base"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.knowledge_base
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("knowledge_base"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4096,9 +4970,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4118,9 +4999,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4137,9 +5025,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4159,9 +5054,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4178,9 +5080,16 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4224,12 +5133,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Participant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/participants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/participants", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4246,9 +5159,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Participant>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4265,12 +5185,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListParticipantsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/participants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/participants", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4289,18 +5213,15 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Participant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.participant
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("participant"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.participant
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("participant"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4323,12 +5244,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:analyzeContent", {
+            let arg = &req.participant;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("participant"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:analyzeContent", req.participant),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4343,12 +5268,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SuggestArticlesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:suggestArticles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:suggestArticles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4363,12 +5292,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SuggestFaqAnswersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:suggestFaqAnswers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:suggestFaqAnswers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4383,12 +5316,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SuggestSmartRepliesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:suggestSmartReplies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:suggestSmartReplies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4403,12 +5340,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SuggestKnowledgeAssistResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/suggestions:suggestKnowledgeAssist", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/suggestions:suggestKnowledgeAssist", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4423,9 +5364,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4445,9 +5393,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4464,9 +5419,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4486,9 +5448,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4505,9 +5474,16 @@ impl super::stub::Participants for Participants {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4551,12 +5527,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DetectIntentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:detectIntent", {
+            let arg = &req.session;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:detectIntent", req.session),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4571,9 +5551,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4593,9 +5580,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4612,9 +5606,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4634,9 +5635,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4653,9 +5661,16 @@ impl super::stub::Sessions for Sessions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4699,12 +5714,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionEntityTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4723,9 +5742,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4742,12 +5768,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/entityTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/entityTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4764,18 +5794,15 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SessionEntityType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.session_entity_type
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.session_entity_type
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("session_entity_type"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4798,9 +5825,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4821,9 +5855,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4843,9 +5884,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4862,9 +5910,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4884,9 +5939,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4903,9 +5965,16 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4949,9 +6018,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4970,9 +6046,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -4989,12 +6072,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/versions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5011,18 +6098,15 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5045,9 +6129,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5068,9 +6159,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5090,9 +6188,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5109,9 +6214,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5131,9 +6243,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -5150,9 +6269,16 @@ impl super::stub::Versions for Versions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/discoveryengine/v1/src/client.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/client.rs
@@ -121,12 +121,8 @@ impl CompletionService {
     }
 
     /// Completes the specified user input with keyword suggestions.
-    pub fn complete_query(
-        &self,
-        data_store: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::CompleteQuery {
+    pub fn complete_query(&self) -> super::builder::completion_service::CompleteQuery {
         super::builder::completion_service::CompleteQuery::new(self.inner.clone())
-            .set_data_store(data_store.into())
     }
 
     /// Imports all
@@ -146,10 +142,8 @@ impl CompletionService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_suggestion_deny_list_entries(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::completion_service::ImportSuggestionDenyListEntries {
         super::builder::completion_service::ImportSuggestionDenyListEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Permanently deletes all
@@ -169,10 +163,8 @@ impl CompletionService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn purge_suggestion_deny_list_entries(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::completion_service::PurgeSuggestionDenyListEntries {
         super::builder::completion_service::PurgeSuggestionDenyListEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports
@@ -192,10 +184,8 @@ impl CompletionService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_completion_suggestions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::completion_service::ImportCompletionSuggestions {
         super::builder::completion_service::ImportCompletionSuggestions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Permanently deletes all
@@ -215,43 +205,29 @@ impl CompletionService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn purge_completion_suggestions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::completion_service::PurgeCompletionSuggestions {
         super::builder::completion_service::PurgeCompletionSuggestions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::completion_service::ListOperations {
         super::builder::completion_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::completion_service::GetOperation {
         super::builder::completion_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::completion_service::CancelOperation {
         super::builder::completion_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -366,12 +342,8 @@ impl ControlService {
     /// exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
-    pub fn create_control(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::control_service::CreateControl {
+    pub fn create_control(&self) -> super::builder::control_service::CreateControl {
         super::builder::control_service::CreateControl::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Control.
@@ -380,12 +352,8 @@ impl ControlService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
-    pub fn delete_control(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::DeleteControl {
+    pub fn delete_control(&self) -> super::builder::control_service::DeleteControl {
         super::builder::control_service::DeleteControl::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Control.
@@ -395,64 +363,42 @@ impl ControlService {
     /// update does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
-    pub fn update_control(
-        &self,
-        control: impl Into<crate::model::Control>,
-    ) -> super::builder::control_service::UpdateControl {
+    pub fn update_control(&self) -> super::builder::control_service::UpdateControl {
         super::builder::control_service::UpdateControl::new(self.inner.clone())
-            .set_control(control.into())
     }
 
     /// Gets a Control.
-    pub fn get_control(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::GetControl {
-        super::builder::control_service::GetControl::new(self.inner.clone()).set_name(name.into())
+    pub fn get_control(&self) -> super::builder::control_service::GetControl {
+        super::builder::control_service::GetControl::new(self.inner.clone())
     }
 
     /// Lists all Controls by their parent
     /// [DataStore][google.cloud.discoveryengine.v1.DataStore].
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-    pub fn list_controls(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::control_service::ListControls {
+    pub fn list_controls(&self) -> super::builder::control_service::ListControls {
         super::builder::control_service::ListControls::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::control_service::ListOperations {
         super::builder::control_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::GetOperation {
-        super::builder::control_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::control_service::GetOperation {
+        super::builder::control_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::control_service::CancelOperation {
         super::builder::control_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -561,10 +507,8 @@ impl ConversationalSearchService {
     /// Converses a conversation.
     pub fn converse_conversation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::ConverseConversation {
         super::builder::conversational_search_service::ConverseConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Conversation.
@@ -575,10 +519,8 @@ impl ConversationalSearchService {
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
     pub fn create_conversation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::CreateConversation {
         super::builder::conversational_search_service::CreateConversation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Conversation.
@@ -589,10 +531,8 @@ impl ConversationalSearchService {
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
     pub fn delete_conversation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::DeleteConversation {
         super::builder::conversational_search_service::DeleteConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Conversation.
@@ -605,19 +545,15 @@ impl ConversationalSearchService {
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
     pub fn update_conversation(
         &self,
-        conversation: impl Into<crate::model::Conversation>,
     ) -> super::builder::conversational_search_service::UpdateConversation {
         super::builder::conversational_search_service::UpdateConversation::new(self.inner.clone())
-            .set_conversation(conversation.into())
     }
 
     /// Gets a Conversation.
     pub fn get_conversation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::GetConversation {
         super::builder::conversational_search_service::GetConversation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all Conversations by their parent
@@ -626,28 +562,18 @@ impl ConversationalSearchService {
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
     pub fn list_conversations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::ListConversations {
         super::builder::conversational_search_service::ListConversations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Answer query method.
-    pub fn answer_query(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::AnswerQuery {
+    pub fn answer_query(&self) -> super::builder::conversational_search_service::AnswerQuery {
         super::builder::conversational_search_service::AnswerQuery::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Gets a Answer.
-    pub fn get_answer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::GetAnswer {
+    pub fn get_answer(&self) -> super::builder::conversational_search_service::GetAnswer {
         super::builder::conversational_search_service::GetAnswer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Session.
@@ -656,12 +582,8 @@ impl ConversationalSearchService {
     /// exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
-    pub fn create_session(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::CreateSession {
+    pub fn create_session(&self) -> super::builder::conversational_search_service::CreateSession {
         super::builder::conversational_search_service::CreateSession::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Session.
@@ -670,12 +592,8 @@ impl ConversationalSearchService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
-    pub fn delete_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::DeleteSession {
+    pub fn delete_session(&self) -> super::builder::conversational_search_service::DeleteSession {
         super::builder::conversational_search_service::DeleteSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Session.
@@ -685,55 +603,35 @@ impl ConversationalSearchService {
     /// update does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
-    pub fn update_session(
-        &self,
-        session: impl Into<crate::model::Session>,
-    ) -> super::builder::conversational_search_service::UpdateSession {
+    pub fn update_session(&self) -> super::builder::conversational_search_service::UpdateSession {
         super::builder::conversational_search_service::UpdateSession::new(self.inner.clone())
-            .set_session(session.into())
     }
 
     /// Gets a Session.
-    pub fn get_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::GetSession {
+    pub fn get_session(&self) -> super::builder::conversational_search_service::GetSession {
         super::builder::conversational_search_service::GetSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all Sessions by their parent
     /// [DataStore][google.cloud.discoveryengine.v1.DataStore].
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-    pub fn list_sessions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::ListSessions {
+    pub fn list_sessions(&self) -> super::builder::conversational_search_service::ListSessions {
         super::builder::conversational_search_service::ListSessions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::conversational_search_service::ListOperations {
         super::builder::conversational_search_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::conversational_search_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::conversational_search_service::GetOperation {
         super::builder::conversational_search_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -741,10 +639,8 @@ impl ConversationalSearchService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::conversational_search_service::CancelOperation {
         super::builder::conversational_search_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -874,35 +770,23 @@ impl DataStoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_data_store(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::CreateDataStore {
+    pub fn create_data_store(&self) -> super::builder::data_store_service::CreateDataStore {
         super::builder::data_store_service::CreateDataStore::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a [DataStore][google.cloud.discoveryengine.v1.DataStore].
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-    pub fn get_data_store(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::GetDataStore {
+    pub fn get_data_store(&self) -> super::builder::data_store_service::GetDataStore {
         super::builder::data_store_service::GetDataStore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all the [DataStore][google.cloud.discoveryengine.v1.DataStore]s
     /// associated with the project.
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-    pub fn list_data_stores(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::ListDataStores {
+    pub fn list_data_stores(&self) -> super::builder::data_store_service::ListDataStores {
         super::builder::data_store_service::ListDataStores::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a [DataStore][google.cloud.discoveryengine.v1.DataStore].
@@ -918,56 +802,36 @@ impl DataStoreService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_data_store(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::DeleteDataStore {
+    pub fn delete_data_store(&self) -> super::builder::data_store_service::DeleteDataStore {
         super::builder::data_store_service::DeleteDataStore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a [DataStore][google.cloud.discoveryengine.v1.DataStore]
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-    pub fn update_data_store(
-        &self,
-        data_store: impl Into<crate::model::DataStore>,
-    ) -> super::builder::data_store_service::UpdateDataStore {
+    pub fn update_data_store(&self) -> super::builder::data_store_service::UpdateDataStore {
         super::builder::data_store_service::UpdateDataStore::new(self.inner.clone())
-            .set_data_store(data_store.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::data_store_service::ListOperations {
         super::builder::data_store_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::data_store_service::GetOperation {
         super::builder::data_store_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::data_store_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::data_store_service::CancelOperation {
         super::builder::data_store_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1079,55 +943,36 @@ impl DocumentService {
     /// Gets a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    pub fn get_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_service::GetDocument {
-        super::builder::document_service::GetDocument::new(self.inner.clone()).set_name(name.into())
+    pub fn get_document(&self) -> super::builder::document_service::GetDocument {
+        super::builder::document_service::GetDocument::new(self.inner.clone())
     }
 
     /// Gets a list of [Document][google.cloud.discoveryengine.v1.Document]s.
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    pub fn list_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_service::ListDocuments {
+    pub fn list_documents(&self) -> super::builder::document_service::ListDocuments {
         super::builder::document_service::ListDocuments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    pub fn create_document(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_service::CreateDocument {
+    pub fn create_document(&self) -> super::builder::document_service::CreateDocument {
         super::builder::document_service::CreateDocument::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    pub fn update_document(
-        &self,
-        document: impl Into<crate::model::Document>,
-    ) -> super::builder::document_service::UpdateDocument {
+    pub fn update_document(&self) -> super::builder::document_service::UpdateDocument {
         super::builder::document_service::UpdateDocument::new(self.inner.clone())
-            .set_document(document.into())
     }
 
     /// Deletes a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    pub fn delete_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_service::DeleteDocument {
+    pub fn delete_document(&self) -> super::builder::document_service::DeleteDocument {
         super::builder::document_service::DeleteDocument::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Bulk import of multiple
@@ -1149,12 +994,8 @@ impl DocumentService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_service::ImportDocuments {
+    pub fn import_documents(&self) -> super::builder::document_service::ImportDocuments {
         super::builder::document_service::ImportDocuments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Permanently deletes all selected
@@ -1188,12 +1029,8 @@ impl DocumentService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_documents(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_service::PurgeDocuments {
+    pub fn purge_documents(&self) -> super::builder::document_service::PurgeDocuments {
         super::builder::document_service::PurgeDocuments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets index freshness metadata for
@@ -1203,43 +1040,29 @@ impl DocumentService {
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
     pub fn batch_get_documents_metadata(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::document_service::BatchGetDocumentsMetadata {
         super::builder::document_service::BatchGetDocumentsMetadata::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::document_service::ListOperations {
         super::builder::document_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::document_service::GetOperation {
         super::builder::document_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::document_service::CancelOperation {
         super::builder::document_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1359,12 +1182,8 @@ impl EngineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_engine(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::CreateEngine {
+    pub fn create_engine(&self) -> super::builder::engine_service::CreateEngine {
         super::builder::engine_service::CreateEngine::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a [Engine][google.cloud.discoveryengine.v1.Engine].
@@ -1380,76 +1199,51 @@ impl EngineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_engine(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::DeleteEngine {
-        super::builder::engine_service::DeleteEngine::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_engine(&self) -> super::builder::engine_service::DeleteEngine {
+        super::builder::engine_service::DeleteEngine::new(self.inner.clone())
     }
 
     /// Updates an [Engine][google.cloud.discoveryengine.v1.Engine]
     ///
     /// [google.cloud.discoveryengine.v1.Engine]: crate::model::Engine
-    pub fn update_engine(
-        &self,
-        engine: impl Into<crate::model::Engine>,
-    ) -> super::builder::engine_service::UpdateEngine {
+    pub fn update_engine(&self) -> super::builder::engine_service::UpdateEngine {
         super::builder::engine_service::UpdateEngine::new(self.inner.clone())
-            .set_engine(engine.into())
     }
 
     /// Gets a [Engine][google.cloud.discoveryengine.v1.Engine].
     ///
     /// [google.cloud.discoveryengine.v1.Engine]: crate::model::Engine
-    pub fn get_engine(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::GetEngine {
-        super::builder::engine_service::GetEngine::new(self.inner.clone()).set_name(name.into())
+    pub fn get_engine(&self) -> super::builder::engine_service::GetEngine {
+        super::builder::engine_service::GetEngine::new(self.inner.clone())
     }
 
     /// Lists all the [Engine][google.cloud.discoveryengine.v1.Engine]s associated
     /// with the project.
     ///
     /// [google.cloud.discoveryengine.v1.Engine]: crate::model::Engine
-    pub fn list_engines(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::ListEngines {
+    pub fn list_engines(&self) -> super::builder::engine_service::ListEngines {
         super::builder::engine_service::ListEngines::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::engine_service::ListOperations {
         super::builder::engine_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::GetOperation {
-        super::builder::engine_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::engine_service::GetOperation {
+        super::builder::engine_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::engine_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::engine_service::CancelOperation {
         super::builder::engine_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1558,54 +1352,36 @@ impl GroundedGenerationService {
     /// Generates grounded content.
     pub fn generate_grounded_content(
         &self,
-        location: impl Into<std::string::String>,
     ) -> super::builder::grounded_generation_service::GenerateGroundedContent {
         super::builder::grounded_generation_service::GenerateGroundedContent::new(
             self.inner.clone(),
         )
-        .set_location(location.into())
     }
 
     /// Performs a grounding check.
-    pub fn check_grounding(
-        &self,
-        grounding_config: impl Into<std::string::String>,
-    ) -> super::builder::grounded_generation_service::CheckGrounding {
+    pub fn check_grounding(&self) -> super::builder::grounded_generation_service::CheckGrounding {
         super::builder::grounded_generation_service::CheckGrounding::new(self.inner.clone())
-            .set_grounding_config(grounding_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grounded_generation_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::grounded_generation_service::ListOperations {
         super::builder::grounded_generation_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grounded_generation_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::grounded_generation_service::GetOperation {
         super::builder::grounded_generation_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grounded_generation_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::grounded_generation_service::CancelOperation {
         super::builder::grounded_generation_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1728,44 +1504,29 @@ impl ProjectService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn provision_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::project_service::ProvisionProject {
+    pub fn provision_project(&self) -> super::builder::project_service::ProvisionProject {
         super::builder::project_service::ProvisionProject::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::project_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::project_service::ListOperations {
         super::builder::project_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::project_service::GetOperation {
-        super::builder::project_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::project_service::GetOperation {
+        super::builder::project_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::project_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::project_service::CancelOperation {
         super::builder::project_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1870,42 +1631,29 @@ impl RankService {
     }
 
     /// Ranks a list of text records based on the given input query.
-    pub fn rank(
-        &self,
-        ranking_config: impl Into<std::string::String>,
-    ) -> super::builder::rank_service::Rank {
+    pub fn rank(&self) -> super::builder::rank_service::Rank {
         super::builder::rank_service::Rank::new(self.inner.clone())
-            .set_ranking_config(ranking_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rank_service::ListOperations {
-        super::builder::rank_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::rank_service::ListOperations {
+        super::builder::rank_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rank_service::GetOperation {
-        super::builder::rank_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::rank_service::GetOperation {
+        super::builder::rank_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rank_service::CancelOperation {
-        super::builder::rank_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::rank_service::CancelOperation {
+        super::builder::rank_service::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -2012,45 +1760,29 @@ impl RecommendationService {
     }
 
     /// Makes a recommendation, which requires a contextual user event.
-    pub fn recommend(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::recommendation_service::Recommend {
+    pub fn recommend(&self) -> super::builder::recommendation_service::Recommend {
         super::builder::recommendation_service::Recommend::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommendation_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::recommendation_service::ListOperations {
         super::builder::recommendation_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommendation_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::recommendation_service::GetOperation {
         super::builder::recommendation_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommendation_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::recommendation_service::CancelOperation {
         super::builder::recommendation_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2159,22 +1891,15 @@ impl SchemaService {
     /// Gets a [Schema][google.cloud.discoveryengine.v1.Schema].
     ///
     /// [google.cloud.discoveryengine.v1.Schema]: crate::model::Schema
-    pub fn get_schema(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::GetSchema {
-        super::builder::schema_service::GetSchema::new(self.inner.clone()).set_name(name.into())
+    pub fn get_schema(&self) -> super::builder::schema_service::GetSchema {
+        super::builder::schema_service::GetSchema::new(self.inner.clone())
     }
 
     /// Gets a list of [Schema][google.cloud.discoveryengine.v1.Schema]s.
     ///
     /// [google.cloud.discoveryengine.v1.Schema]: crate::model::Schema
-    pub fn list_schemas(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::ListSchemas {
+    pub fn list_schemas(&self) -> super::builder::schema_service::ListSchemas {
         super::builder::schema_service::ListSchemas::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a [Schema][google.cloud.discoveryengine.v1.Schema].
@@ -2190,12 +1915,8 @@ impl SchemaService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_schema(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::CreateSchema {
+    pub fn create_schema(&self) -> super::builder::schema_service::CreateSchema {
         super::builder::schema_service::CreateSchema::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a [Schema][google.cloud.discoveryengine.v1.Schema].
@@ -2211,12 +1932,8 @@ impl SchemaService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_schema(
-        &self,
-        schema: impl Into<crate::model::Schema>,
-    ) -> super::builder::schema_service::UpdateSchema {
+    pub fn update_schema(&self) -> super::builder::schema_service::UpdateSchema {
         super::builder::schema_service::UpdateSchema::new(self.inner.clone())
-            .set_schema(schema.into())
     }
 
     /// Deletes a [Schema][google.cloud.discoveryengine.v1.Schema].
@@ -2232,43 +1949,29 @@ impl SchemaService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_schema(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::DeleteSchema {
-        super::builder::schema_service::DeleteSchema::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_schema(&self) -> super::builder::schema_service::DeleteSchema {
+        super::builder::schema_service::DeleteSchema::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::schema_service::ListOperations {
         super::builder::schema_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::GetOperation {
-        super::builder::schema_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::schema_service::GetOperation {
+        super::builder::schema_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::schema_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::schema_service::CancelOperation {
         super::builder::schema_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2373,12 +2076,8 @@ impl SearchService {
     }
 
     /// Performs a search.
-    pub fn search(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::search_service::Search {
+    pub fn search(&self) -> super::builder::search_service::Search {
         super::builder::search_service::Search::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Performs a search. Similar to the
@@ -2396,44 +2095,29 @@ impl SearchService {
     /// instead with required OAuth and IAM checks to provide better data security.
     ///
     /// [google.cloud.discoveryengine.v1.SearchService.Search]: crate::client::SearchService::search
-    pub fn search_lite(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::search_service::SearchLite {
+    pub fn search_lite(&self) -> super::builder::search_service::SearchLite {
         super::builder::search_service::SearchLite::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::search_service::ListOperations {
         super::builder::search_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_service::GetOperation {
-        super::builder::search_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::search_service::GetOperation {
+        super::builder::search_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::search_service::CancelOperation {
         super::builder::search_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2550,54 +2234,34 @@ impl SearchTuningService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn train_custom_model(
-        &self,
-        data_store: impl Into<std::string::String>,
-    ) -> super::builder::search_tuning_service::TrainCustomModel {
+    pub fn train_custom_model(&self) -> super::builder::search_tuning_service::TrainCustomModel {
         super::builder::search_tuning_service::TrainCustomModel::new(self.inner.clone())
-            .set_data_store(data_store.into())
     }
 
     /// Gets a list of all the custom models.
-    pub fn list_custom_models(
-        &self,
-        data_store: impl Into<std::string::String>,
-    ) -> super::builder::search_tuning_service::ListCustomModels {
+    pub fn list_custom_models(&self) -> super::builder::search_tuning_service::ListCustomModels {
         super::builder::search_tuning_service::ListCustomModels::new(self.inner.clone())
-            .set_data_store(data_store.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_tuning_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::search_tuning_service::ListOperations {
         super::builder::search_tuning_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_tuning_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::search_tuning_service::GetOperation {
         super::builder::search_tuning_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_tuning_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::search_tuning_service::CancelOperation {
         super::builder::search_tuning_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2711,43 +2375,29 @@ impl ServingConfigService {
     /// Returns a NOT_FOUND error if the ServingConfig does not exist.
     pub fn update_serving_config(
         &self,
-        serving_config: impl Into<crate::model::ServingConfig>,
     ) -> super::builder::serving_config_service::UpdateServingConfig {
         super::builder::serving_config_service::UpdateServingConfig::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::serving_config_service::ListOperations {
         super::builder::serving_config_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::serving_config_service::GetOperation {
         super::builder::serving_config_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::serving_config_service::CancelOperation {
         super::builder::serving_config_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2859,10 +2509,8 @@ impl SiteSearchEngineService {
     /// [google.cloud.discoveryengine.v1.SiteSearchEngine]: crate::model::SiteSearchEngine
     pub fn get_site_search_engine(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::GetSiteSearchEngine {
         super::builder::site_search_engine_service::GetSiteSearchEngine::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
@@ -2880,10 +2528,8 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_target_site(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::CreateTargetSite {
         super::builder::site_search_engine_service::CreateTargetSite::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates [TargetSite][google.cloud.discoveryengine.v1.TargetSite] in a
@@ -2902,21 +2548,15 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_create_target_sites(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::BatchCreateTargetSites {
         super::builder::site_search_engine_service::BatchCreateTargetSites::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
     ///
     /// [google.cloud.discoveryengine.v1.TargetSite]: crate::model::TargetSite
-    pub fn get_target_site(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::GetTargetSite {
+    pub fn get_target_site(&self) -> super::builder::site_search_engine_service::GetTargetSite {
         super::builder::site_search_engine_service::GetTargetSite::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
@@ -2934,10 +2574,8 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_target_site(
         &self,
-        target_site: impl Into<crate::model::TargetSite>,
     ) -> super::builder::site_search_engine_service::UpdateTargetSite {
         super::builder::site_search_engine_service::UpdateTargetSite::new(self.inner.clone())
-            .set_target_site(target_site.into())
     }
 
     /// Deletes a [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
@@ -2955,21 +2593,15 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_target_site(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::DeleteTargetSite {
         super::builder::site_search_engine_service::DeleteTargetSite::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a list of [TargetSite][google.cloud.discoveryengine.v1.TargetSite]s.
     ///
     /// [google.cloud.discoveryengine.v1.TargetSite]: crate::model::TargetSite
-    pub fn list_target_sites(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::ListTargetSites {
+    pub fn list_target_sites(&self) -> super::builder::site_search_engine_service::ListTargetSites {
         super::builder::site_search_engine_service::ListTargetSites::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a [Sitemap][google.cloud.discoveryengine.v1.Sitemap].
@@ -2985,12 +2617,8 @@ impl SiteSearchEngineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_sitemap(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::CreateSitemap {
+    pub fn create_sitemap(&self) -> super::builder::site_search_engine_service::CreateSitemap {
         super::builder::site_search_engine_service::CreateSitemap::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a [Sitemap][google.cloud.discoveryengine.v1.Sitemap].
@@ -3006,12 +2634,8 @@ impl SiteSearchEngineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_sitemap(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::DeleteSitemap {
+    pub fn delete_sitemap(&self) -> super::builder::site_search_engine_service::DeleteSitemap {
         super::builder::site_search_engine_service::DeleteSitemap::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fetch [Sitemap][google.cloud.discoveryengine.v1.Sitemap]s in a
@@ -3019,12 +2643,8 @@ impl SiteSearchEngineService {
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
     /// [google.cloud.discoveryengine.v1.Sitemap]: crate::model::Sitemap
-    pub fn fetch_sitemaps(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::FetchSitemaps {
+    pub fn fetch_sitemaps(&self) -> super::builder::site_search_engine_service::FetchSitemaps {
         super::builder::site_search_engine_service::FetchSitemaps::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Upgrade from basic site search to advanced site search.
@@ -3040,12 +2660,10 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn enable_advanced_site_search(
         &self,
-        site_search_engine: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::EnableAdvancedSiteSearch {
         super::builder::site_search_engine_service::EnableAdvancedSiteSearch::new(
             self.inner.clone(),
         )
-        .set_site_search_engine(site_search_engine.into())
     }
 
     /// Downgrade from advanced site search to basic site search.
@@ -3061,12 +2679,10 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn disable_advanced_site_search(
         &self,
-        site_search_engine: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::DisableAdvancedSiteSearch {
         super::builder::site_search_engine_service::DisableAdvancedSiteSearch::new(
             self.inner.clone(),
         )
-        .set_site_search_engine(site_search_engine.into())
     }
 
     /// Request on-demand recrawl for a list of URIs.
@@ -3080,12 +2696,8 @@ impl SiteSearchEngineService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn recrawl_uris(
-        &self,
-        site_search_engine: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::RecrawlUris {
+    pub fn recrawl_uris(&self) -> super::builder::site_search_engine_service::RecrawlUris {
         super::builder::site_search_engine_service::RecrawlUris::new(self.inner.clone())
-            .set_site_search_engine(site_search_engine.into())
     }
 
     /// Verify target sites' ownership and validity.
@@ -3103,10 +2715,8 @@ impl SiteSearchEngineService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_verify_target_sites(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::BatchVerifyTargetSites {
         super::builder::site_search_engine_service::BatchVerifyTargetSites::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns list of target sites with its domain verification status.
@@ -3114,45 +2724,31 @@ impl SiteSearchEngineService {
     /// state at the moment.
     pub fn fetch_domain_verification_status(
         &self,
-        site_search_engine: impl Into<std::string::String>,
     ) -> super::builder::site_search_engine_service::FetchDomainVerificationStatus {
         super::builder::site_search_engine_service::FetchDomainVerificationStatus::new(
             self.inner.clone(),
         )
-        .set_site_search_engine(site_search_engine.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::site_search_engine_service::ListOperations {
         super::builder::site_search_engine_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::site_search_engine_service::GetOperation {
         super::builder::site_search_engine_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::site_search_engine_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::site_search_engine_service::CancelOperation {
         super::builder::site_search_engine_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -3259,12 +2855,8 @@ impl UserEventService {
     }
 
     /// Writes a single user event.
-    pub fn write_user_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::WriteUserEvent {
+    pub fn write_user_event(&self) -> super::builder::user_event_service::WriteUserEvent {
         super::builder::user_event_service::WriteUserEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Writes a single user event from the browser. This uses a GET request to
@@ -3272,12 +2864,8 @@ impl UserEventService {
     ///
     /// This method is used only by the Discovery Engine API JavaScript pixel and
     /// Google Tag Manager. Users should not call this method directly.
-    pub fn collect_user_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::CollectUserEvent {
+    pub fn collect_user_event(&self) -> super::builder::user_event_service::CollectUserEvent {
         super::builder::user_event_service::CollectUserEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes permanently all user events specified by the filter provided.
@@ -3294,12 +2882,8 @@ impl UserEventService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_user_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::PurgeUserEvents {
+    pub fn purge_user_events(&self) -> super::builder::user_event_service::PurgeUserEvents {
         super::builder::user_event_service::PurgeUserEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Bulk import of user events. Request processing might be
@@ -3319,44 +2903,28 @@ impl UserEventService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_user_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::ImportUserEvents {
+    pub fn import_user_events(&self) -> super::builder::user_event_service::ImportUserEvents {
         super::builder::user_event_service::ImportUserEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::user_event_service::ListOperations {
         super::builder::user_event_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::user_event_service::GetOperation {
         super::builder::user_event_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::user_event_service::CancelOperation {
         super::builder::user_event_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -351,10 +351,15 @@ impl super::stub::ControlService for ControlService {
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.control
+            let arg = &req
+                .control
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("control"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("control.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -624,10 +629,15 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.conversation
+            let arg = &req
+                .conversation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("conversation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -817,10 +827,15 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.session
+            let arg = &req
+                .session
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("session"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("session.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1126,10 +1141,15 @@ impl super::stub::DataStoreService for DataStoreService {
     ) -> Result<gax::response::Response<crate::model::DataStore>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.data_store
+            let arg = &req
+                .data_store
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("data_store"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_store.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1359,10 +1379,15 @@ impl super::stub::DocumentService for DocumentService {
     ) -> Result<gax::response::Response<crate::model::Document>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.document
+            let arg = &req
+                .document
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("document"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("document.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1677,10 +1702,15 @@ impl super::stub::EngineService for EngineService {
     ) -> Result<gax::response::Response<crate::model::Engine>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.engine
+            let arg = &req
+                .engine
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("engine"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("engine.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2523,10 +2553,15 @@ impl super::stub::SchemaService for SchemaService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.schema
+            let arg = &req
+                .schema
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("schema"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("schema.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3020,10 +3055,15 @@ impl super::stub::ServingConfigService for ServingConfigService {
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.serving_config
+            let arg = &req
+                .serving_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -3260,10 +3300,15 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.target_site
+            let arg = &req
+                .target_site
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("target_site"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("target_site.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompleteQueryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:completeQuery", {
+            let arg = &req.data_store;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_store"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:completeQuery", req.data_store),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,12 +76,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/suggestionDenyListEntries:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/suggestionDenyListEntries:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,12 +100,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/suggestionDenyListEntries:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/suggestionDenyListEntries:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,12 +124,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/completionSuggestions:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/completionSuggestions:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -132,12 +148,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/completionSuggestions:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/completionSuggestions:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,9 +172,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +201,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +227,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,12 +293,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/controls", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/controls", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +320,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,18 +350,15 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.control
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("control"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.control
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("control"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,9 +381,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -351,9 +407,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListControlsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/controls", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/controls", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -373,9 +436,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -395,9 +465,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -414,9 +491,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -459,9 +543,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConverseConversationResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:converse", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:converse", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,12 +567,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -498,9 +593,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -521,18 +623,15 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.conversation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.conversation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("conversation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -555,9 +654,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Conversation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -574,12 +680,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConversationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/conversations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/conversations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -600,12 +710,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnswerQueryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:answer", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:answer", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -620,9 +734,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Answer>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -639,12 +760,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/sessions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -661,9 +786,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -684,18 +816,15 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.session
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("session"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.session
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("session"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -718,9 +847,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -738,9 +874,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/sessions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -761,9 +904,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -783,9 +933,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -802,9 +959,16 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -847,12 +1011,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dataStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dataStores", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -876,9 +1044,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataStore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -895,12 +1070,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataStoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dataStores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dataStores", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -920,9 +1099,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -939,18 +1125,15 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataStore>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.data_store
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("data_store"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.data_store
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("data_store"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -973,9 +1156,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -995,9 +1185,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1014,9 +1211,16 @@ impl super::stub::DataStoreService for DataStoreService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1073,9 +1277,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1092,12 +1303,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDocumentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/documents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/documents", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1116,12 +1331,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/documents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/documents", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1139,18 +1358,15 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.document
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("document"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.document
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("document"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1174,9 +1390,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1197,12 +1420,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/documents:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/documents:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1217,12 +1444,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/documents:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/documents:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1237,12 +1468,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchGetDocumentsMetadataResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/batchGetDocumentsMetadata", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/batchGetDocumentsMetadata", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1269,9 +1504,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1291,9 +1533,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1310,9 +1559,16 @@ impl super::stub::DocumentService for DocumentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1369,9 +1625,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/engines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/engines", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1387,9 +1650,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1406,18 +1676,15 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Engine>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.engine
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("engine"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.engine
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("engine"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1438,9 +1705,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Engine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1457,9 +1731,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnginesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/engines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/engines", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1479,9 +1760,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1501,9 +1789,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1520,9 +1815,16 @@ impl super::stub::EngineService for EngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1579,12 +1881,16 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateGroundedContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateGroundedContent", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateGroundedContent", req.location),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1599,12 +1905,16 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckGroundingResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:check", {
+            let arg = &req.grounding_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("grounding_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:check", req.grounding_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1619,9 +1929,16 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1641,9 +1958,16 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1660,9 +1984,16 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1705,9 +2036,16 @@ impl super::stub::ProjectService for ProjectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:provision", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:provision", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1722,9 +2060,16 @@ impl super::stub::ProjectService for ProjectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1744,9 +2089,16 @@ impl super::stub::ProjectService for ProjectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1763,9 +2115,16 @@ impl super::stub::ProjectService for ProjectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1822,12 +2181,16 @@ impl super::stub::RankService for RankService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RankResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rank", {
+            let arg = &req.ranking_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("ranking_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rank", req.ranking_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1842,9 +2205,16 @@ impl super::stub::RankService for RankService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1864,9 +2234,16 @@ impl super::stub::RankService for RankService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1883,9 +2260,16 @@ impl super::stub::RankService for RankService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1928,12 +2312,16 @@ impl super::stub::RecommendationService for RecommendationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RecommendResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:recommend", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:recommend", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1948,9 +2336,16 @@ impl super::stub::RecommendationService for RecommendationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1970,9 +2365,16 @@ impl super::stub::RecommendationService for RecommendationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1989,9 +2391,16 @@ impl super::stub::RecommendationService for RecommendationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2034,9 +2443,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Schema>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2053,9 +2469,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSchemasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/schemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/schemas", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2074,9 +2497,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/schemas", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/schemas", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2092,18 +2522,15 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.schema
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("schema"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.schema
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("schema"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2119,9 +2546,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2138,9 +2572,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2160,9 +2601,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2179,9 +2627,16 @@ impl super::stub::SchemaService for SchemaService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2238,12 +2693,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:search", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:search", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2258,12 +2717,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:searchLite", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:searchLite", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2278,9 +2741,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2300,9 +2770,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2319,9 +2796,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2364,12 +2848,16 @@ impl super::stub::SearchTuningService for SearchTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:trainCustomModel", {
+            let arg = &req.data_store;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_store"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:trainCustomModel", req.data_store),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2384,12 +2872,16 @@ impl super::stub::SearchTuningService for SearchTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/customModels", {
+            let arg = &req.data_store;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("data_store"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/customModels", req.data_store),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2406,9 +2898,16 @@ impl super::stub::SearchTuningService for SearchTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2428,9 +2927,16 @@ impl super::stub::SearchTuningService for SearchTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2447,9 +2953,16 @@ impl super::stub::SearchTuningService for SearchTuningService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2506,18 +3019,15 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.serving_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.serving_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2540,9 +3050,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2562,9 +3079,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2581,9 +3105,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2626,9 +3157,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SiteSearchEngine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2645,12 +3183,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/targetSites", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/targetSites", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2667,12 +3209,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/targetSites:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/targetSites:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2687,9 +3233,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TargetSite>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2706,18 +3259,15 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.target_site
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("target_site"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.target_site
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("target_site"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2734,9 +3284,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2753,12 +3310,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTargetSitesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/targetSites", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/targetSites", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2777,12 +3338,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sitemaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/sitemaps", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2799,9 +3364,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2818,12 +3390,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchSitemapsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sitemaps:fetch", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/sitemaps:fetch", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2850,12 +3426,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enableAdvancedSiteSearch", {
+            let arg = &req.site_search_engine;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("site_search_engine"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:enableAdvancedSiteSearch", req.site_search_engine),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2870,12 +3450,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disableAdvancedSiteSearch", {
+            let arg = &req.site_search_engine;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("site_search_engine"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:disableAdvancedSiteSearch", req.site_search_engine),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2890,12 +3474,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:recrawlUris", {
+            let arg = &req.site_search_engine;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("site_search_engine"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:recrawlUris", req.site_search_engine),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2910,12 +3498,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchVerifyTargetSites", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchVerifyTargetSites", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2930,15 +3522,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchDomainVerificationStatusResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchDomainVerificationStatus", {
+            let arg = &req.site_search_engine;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("site_search_engine"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/{}:fetchDomainVerificationStatus",
-                    req.site_search_engine
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2957,9 +3550,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2979,9 +3579,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2998,9 +3605,16 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3057,12 +3671,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userEvents:write", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userEvents:write", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3080,12 +3698,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::HttpBody>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/userEvents:collect", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/userEvents:collect", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3111,12 +3733,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userEvents:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userEvents:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3131,12 +3757,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userEvents:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userEvents:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3151,9 +3781,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3173,9 +3810,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -3192,9 +3836,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/documentai/v1/src/client.rs
+++ b/src/generated/cloud/documentai/v1/src/client.rs
@@ -124,12 +124,8 @@ impl DocumentProcessorService {
     }
 
     /// Processes a single document.
-    pub fn process_document(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ProcessDocument {
+    pub fn process_document(&self) -> super::builder::document_processor_service::ProcessDocument {
         super::builder::document_processor_service::ProcessDocument::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// LRO endpoint to batch process many documents. The output is written
@@ -146,10 +142,8 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_process_documents(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::BatchProcessDocuments {
         super::builder::document_processor_service::BatchProcessDocuments::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fetches processor types. Note that we don't use
@@ -159,46 +153,32 @@ impl DocumentProcessorService {
     /// [google.cloud.documentai.v1.DocumentProcessorService.ListProcessorTypes]: crate::client::DocumentProcessorService::list_processor_types
     pub fn fetch_processor_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::FetchProcessorTypes {
         super::builder::document_processor_service::FetchProcessorTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the processor types that exist.
     pub fn list_processor_types(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::ListProcessorTypes {
         super::builder::document_processor_service::ListProcessorTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a processor type detail.
     pub fn get_processor_type(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::GetProcessorType {
         super::builder::document_processor_service::GetProcessorType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all processors which belong to this project.
-    pub fn list_processors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ListProcessors {
+    pub fn list_processors(&self) -> super::builder::document_processor_service::ListProcessors {
         super::builder::document_processor_service::ListProcessors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a processor detail.
-    pub fn get_processor(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::GetProcessor {
+    pub fn get_processor(&self) -> super::builder::document_processor_service::GetProcessor {
         super::builder::document_processor_service::GetProcessor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Trains a new processor version.
@@ -218,28 +198,22 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn train_processor_version(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::TrainProcessorVersion {
         super::builder::document_processor_service::TrainProcessorVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a processor version detail.
     pub fn get_processor_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::GetProcessorVersion {
         super::builder::document_processor_service::GetProcessorVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all versions of a processor.
     pub fn list_processor_versions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::ListProcessorVersions {
         super::builder::document_processor_service::ListProcessorVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the processor version, all artifacts under the processor version
@@ -256,10 +230,8 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_processor_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::DeleteProcessorVersion {
         super::builder::document_processor_service::DeleteProcessorVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deploys the processor version.
@@ -275,10 +247,8 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn deploy_processor_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::DeployProcessorVersion {
         super::builder::document_processor_service::DeployProcessorVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Undeploys the processor version.
@@ -294,12 +264,10 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn undeploy_processor_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::UndeployProcessorVersion {
         super::builder::document_processor_service::UndeployProcessorVersion::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a processor from the
@@ -311,12 +279,8 @@ impl DocumentProcessorService {
     /// bucket in your project.
     ///
     /// [google.cloud.documentai.v1.ProcessorType]: crate::model::ProcessorType
-    pub fn create_processor(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::CreateProcessor {
+    pub fn create_processor(&self) -> super::builder::document_processor_service::CreateProcessor {
         super::builder::document_processor_service::CreateProcessor::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the processor, unloads all deployed model artifacts if it was
@@ -331,12 +295,8 @@ impl DocumentProcessorService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_processor(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::DeleteProcessor {
+    pub fn delete_processor(&self) -> super::builder::document_processor_service::DeleteProcessor {
         super::builder::document_processor_service::DeleteProcessor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Enables a processor
@@ -350,12 +310,8 @@ impl DocumentProcessorService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn enable_processor(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::EnableProcessor {
+    pub fn enable_processor(&self) -> super::builder::document_processor_service::EnableProcessor {
         super::builder::document_processor_service::EnableProcessor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Disables a processor
@@ -371,10 +327,8 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn disable_processor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::DisableProcessor {
         super::builder::document_processor_service::DisableProcessor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Set the default (active) version of a
@@ -398,12 +352,10 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn set_default_processor_version(
         &self,
-        processor: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::SetDefaultProcessorVersion {
         super::builder::document_processor_service::SetDefaultProcessorVersion::new(
             self.inner.clone(),
         )
-        .set_processor(processor.into())
     }
 
     /// Send a document for Human Review. The input document should be processed by
@@ -418,12 +370,8 @@ impl DocumentProcessorService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn review_document(
-        &self,
-        human_review_config: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ReviewDocument {
+    pub fn review_document(&self) -> super::builder::document_processor_service::ReviewDocument {
         super::builder::document_processor_service::ReviewDocument::new(self.inner.clone())
-            .set_human_review_config(human_review_config.into())
     }
 
     /// Evaluates a ProcessorVersion against annotated documents, producing an
@@ -440,80 +388,50 @@ impl DocumentProcessorService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn evaluate_processor_version(
         &self,
-        processor_version: impl Into<std::string::String>,
     ) -> super::builder::document_processor_service::EvaluateProcessorVersion {
         super::builder::document_processor_service::EvaluateProcessorVersion::new(
             self.inner.clone(),
         )
-        .set_processor_version(processor_version.into())
     }
 
     /// Retrieves a specific evaluation.
-    pub fn get_evaluation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::GetEvaluation {
+    pub fn get_evaluation(&self) -> super::builder::document_processor_service::GetEvaluation {
         super::builder::document_processor_service::GetEvaluation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves a set of evaluations for a given processor version.
-    pub fn list_evaluations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ListEvaluations {
+    pub fn list_evaluations(&self) -> super::builder::document_processor_service::ListEvaluations {
         super::builder::document_processor_service::ListEvaluations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::document_processor_service::ListLocations {
         super::builder::document_processor_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::document_processor_service::GetLocation {
         super::builder::document_processor_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::document_processor_service::ListOperations {
         super::builder::document_processor_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::document_processor_service::GetOperation {
         super::builder::document_processor_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::document_processor_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::document_processor_service::CancelOperation {
         super::builder::document_processor_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProcessResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:process", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:process", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,12 +70,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchProcess", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchProcess", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -83,12 +94,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchProcessorTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchProcessorTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchProcessorTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,12 +120,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProcessorTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/processorTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/processorTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -129,9 +148,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProcessorType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,12 +174,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProcessorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/processors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/processors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -172,9 +202,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Processor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,12 +228,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/processorVersions:train", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/processorVersions:train", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,9 +252,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProcessorVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +278,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProcessorVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/processorVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/processorVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,9 +306,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,9 +332,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:deploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +356,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undeploy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undeploy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,12 +380,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Processor>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/processors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/processors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +406,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,9 +432,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -365,9 +456,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -382,12 +480,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setDefaultProcessorVersion", {
+            let arg = &req.processor;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("processor"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setDefaultProcessorVersion", req.processor),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,12 +504,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reviewDocument", {
+            let arg = &req.human_review_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("human_review_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:reviewDocument", req.human_review_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,12 +528,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:evaluateProcessorVersion", {
+            let arg = &req.processor_version;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("processor_version"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:evaluateProcessorVersion", req.processor_version),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -442,9 +552,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Evaluation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -461,12 +578,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEvaluationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/evaluations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/evaluations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,9 +606,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -507,9 +635,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -526,9 +661,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -548,9 +690,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -567,9 +716,16 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/domains/v1/src/client.rs
+++ b/src/generated/cloud/domains/v1/src/client.rs
@@ -123,22 +123,16 @@ impl Domains {
     /// Availability results from this method are approximate; call
     /// `RetrieveRegisterParameters` on a domain before registering to confirm
     /// availability.
-    pub fn search_domains(
-        &self,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::domains::SearchDomains {
+    pub fn search_domains(&self) -> super::builder::domains::SearchDomains {
         super::builder::domains::SearchDomains::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Gets parameters needed to register a new domain name, including price and
     /// up-to-date availability. Use the returned values to call `RegisterDomain`.
     pub fn retrieve_register_parameters(
         &self,
-        location: impl Into<std::string::String>,
     ) -> super::builder::domains::RetrieveRegisterParameters {
         super::builder::domains::RetrieveRegisterParameters::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Registers a new domain name and creates a corresponding `Registration`
@@ -164,11 +158,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn register_domain(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::domains::RegisterDomain {
-        super::builder::domains::RegisterDomain::new(self.inner.clone()).set_parent(parent.into())
+    pub fn register_domain(&self) -> super::builder::domains::RegisterDomain {
+        super::builder::domains::RegisterDomain::new(self.inner.clone())
     }
 
     /// Gets parameters needed to transfer a domain name from another registrar to
@@ -178,10 +169,8 @@ impl Domains {
     /// Use the returned values to call `TransferDomain`.
     pub fn retrieve_transfer_parameters(
         &self,
-        location: impl Into<std::string::String>,
     ) -> super::builder::domains::RetrieveTransferParameters {
         super::builder::domains::RetrieveTransferParameters::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Transfers a domain name from another registrar to Cloud Domains.  For
@@ -214,28 +203,18 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn transfer_domain(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::domains::TransferDomain {
-        super::builder::domains::TransferDomain::new(self.inner.clone()).set_parent(parent.into())
+    pub fn transfer_domain(&self) -> super::builder::domains::TransferDomain {
+        super::builder::domains::TransferDomain::new(self.inner.clone())
     }
 
     /// Lists the `Registration` resources in a project.
-    pub fn list_registrations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::domains::ListRegistrations {
+    pub fn list_registrations(&self) -> super::builder::domains::ListRegistrations {
         super::builder::domains::ListRegistrations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a `Registration` resource.
-    pub fn get_registration(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domains::GetRegistration {
-        super::builder::domains::GetRegistration::new(self.inner.clone()).set_name(name.into())
+    pub fn get_registration(&self) -> super::builder::domains::GetRegistration {
+        super::builder::domains::GetRegistration::new(self.inner.clone())
     }
 
     /// Updates select fields of a `Registration` resource, notably `labels`. To
@@ -254,12 +233,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_registration(
-        &self,
-        registration: impl Into<crate::model::Registration>,
-    ) -> super::builder::domains::UpdateRegistration {
+    pub fn update_registration(&self) -> super::builder::domains::UpdateRegistration {
         super::builder::domains::UpdateRegistration::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Updates a `Registration`'s management settings.
@@ -275,10 +250,8 @@ impl Domains {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn configure_management_settings(
         &self,
-        registration: impl Into<std::string::String>,
     ) -> super::builder::domains::ConfigureManagementSettings {
         super::builder::domains::ConfigureManagementSettings::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Updates a `Registration`'s DNS settings.
@@ -292,12 +265,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn configure_dns_settings(
-        &self,
-        registration: impl Into<std::string::String>,
-    ) -> super::builder::domains::ConfigureDnsSettings {
+    pub fn configure_dns_settings(&self) -> super::builder::domains::ConfigureDnsSettings {
         super::builder::domains::ConfigureDnsSettings::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Updates a `Registration`'s contact settings. Some changes require
@@ -312,12 +281,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn configure_contact_settings(
-        &self,
-        registration: impl Into<std::string::String>,
-    ) -> super::builder::domains::ConfigureContactSettings {
+    pub fn configure_contact_settings(&self) -> super::builder::domains::ConfigureContactSettings {
         super::builder::domains::ConfigureContactSettings::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Exports a `Registration` resource, such that it is no longer managed by
@@ -339,11 +304,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_registration(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domains::ExportRegistration {
-        super::builder::domains::ExportRegistration::new(self.inner.clone()).set_name(name.into())
+    pub fn export_registration(&self) -> super::builder::domains::ExportRegistration {
+        super::builder::domains::ExportRegistration::new(self.inner.clone())
     }
 
     /// Deletes a `Registration` resource.
@@ -375,11 +337,8 @@ impl Domains {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_registration(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domains::DeleteRegistration {
-        super::builder::domains::DeleteRegistration::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_registration(&self) -> super::builder::domains::DeleteRegistration {
+        super::builder::domains::DeleteRegistration::new(self.inner.clone())
     }
 
     /// Gets the authorization code of the `Registration` for the purpose of
@@ -389,41 +348,29 @@ impl Domains {
     /// domain registration.
     pub fn retrieve_authorization_code(
         &self,
-        registration: impl Into<std::string::String>,
     ) -> super::builder::domains::RetrieveAuthorizationCode {
         super::builder::domains::RetrieveAuthorizationCode::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Resets the authorization code of the `Registration` to a new random string.
     ///
     /// You can call this method only after 60 days have elapsed since the initial
     /// domain registration.
-    pub fn reset_authorization_code(
-        &self,
-        registration: impl Into<std::string::String>,
-    ) -> super::builder::domains::ResetAuthorizationCode {
+    pub fn reset_authorization_code(&self) -> super::builder::domains::ResetAuthorizationCode {
         super::builder::domains::ResetAuthorizationCode::new(self.inner.clone())
-            .set_registration(registration.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domains::ListOperations {
-        super::builder::domains::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::domains::ListOperations {
+        super::builder::domains::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::domains::GetOperation {
-        super::builder::domains::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::domains::GetOperation {
+        super::builder::domains::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -231,10 +231,15 @@ impl super::stub::Domains for Domains {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.registration
+            let arg = &req
+                .registration
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("registration"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchDomainsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/registrations:searchDomains", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/registrations:searchDomains", req.location),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,15 +73,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RetrieveRegisterParametersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/registrations:retrieveRegisterParameters", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/{}/registrations:retrieveRegisterParameters",
-                    req.location
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,12 +100,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/registrations:register", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/registrations:register", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,15 +124,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RetrieveTransferParametersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/registrations:retrieveTransferParameters", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/{}/registrations:retrieveTransferParameters",
-                    req.location
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -141,12 +151,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/registrations:transfer", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/registrations:transfer", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,12 +175,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRegistrationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/registrations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/registrations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -186,9 +204,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Registration>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -205,18 +230,15 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.registration
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("registration"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.registration
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("registration"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,12 +261,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:configureManagementSettings", {
+            let arg = &req.registration;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:configureManagementSettings", req.registration),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,12 +285,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:configureDnsSettings", {
+            let arg = &req.registration;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:configureDnsSettings", req.registration),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -279,12 +309,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:configureContactSettings", {
+            let arg = &req.registration;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:configureContactSettings", req.registration),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -299,9 +333,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +357,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,12 +383,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizationCode>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:retrieveAuthorizationCode", {
+            let arg = &req.registration;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:retrieveAuthorizationCode", req.registration),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,12 +409,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizationCode>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetAuthorizationCode", {
+            let arg = &req.registration;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("registration"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetAuthorizationCode", req.registration),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +433,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -399,9 +462,16 @@ impl super::stub::Domains for Domains {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/edgecontainer/v1/src/client.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/client.rs
@@ -120,20 +120,13 @@ impl EdgeContainer {
     }
 
     /// Lists Clusters in a given project and location.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::edge_container::ListClusters {
         super::builder::edge_container::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Cluster.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetCluster {
-        super::builder::edge_container::GetCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn get_cluster(&self) -> super::builder::edge_container::GetCluster {
+        super::builder::edge_container::GetCluster::new(self.inner.clone())
     }
 
     /// Creates a new Cluster in a given project and location.
@@ -147,12 +140,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::edge_container::CreateCluster {
         super::builder::edge_container::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Cluster.
@@ -166,12 +155,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        cluster: impl Into<crate::model::Cluster>,
-    ) -> super::builder::edge_container::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::edge_container::UpdateCluster {
         super::builder::edge_container::UpdateCluster::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Upgrades a single cluster.
@@ -185,12 +170,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn upgrade_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::UpgradeCluster {
+    pub fn upgrade_cluster(&self) -> super::builder::edge_container::UpgradeCluster {
         super::builder::edge_container::UpgradeCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a single Cluster.
@@ -204,46 +185,30 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::DeleteCluster {
-        super::builder::edge_container::DeleteCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_cluster(&self) -> super::builder::edge_container::DeleteCluster {
+        super::builder::edge_container::DeleteCluster::new(self.inner.clone())
     }
 
     /// Generates an access token for a Cluster.
-    pub fn generate_access_token(
-        &self,
-        cluster: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GenerateAccessToken {
+    pub fn generate_access_token(&self) -> super::builder::edge_container::GenerateAccessToken {
         super::builder::edge_container::GenerateAccessToken::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Generates an offline credential for a Cluster.
     pub fn generate_offline_credential(
         &self,
-        cluster: impl Into<std::string::String>,
     ) -> super::builder::edge_container::GenerateOfflineCredential {
         super::builder::edge_container::GenerateOfflineCredential::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Lists NodePools in a given project and location.
-    pub fn list_node_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListNodePools {
+    pub fn list_node_pools(&self) -> super::builder::edge_container::ListNodePools {
         super::builder::edge_container::ListNodePools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single NodePool.
-    pub fn get_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetNodePool {
-        super::builder::edge_container::GetNodePool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_node_pool(&self) -> super::builder::edge_container::GetNodePool {
+        super::builder::edge_container::GetNodePool::new(self.inner.clone())
     }
 
     /// Creates a new NodePool in a given project and location.
@@ -257,12 +222,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_node_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::CreateNodePool {
+    pub fn create_node_pool(&self) -> super::builder::edge_container::CreateNodePool {
         super::builder::edge_container::CreateNodePool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single NodePool.
@@ -276,12 +237,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_node_pool(
-        &self,
-        node_pool: impl Into<crate::model::NodePool>,
-    ) -> super::builder::edge_container::UpdateNodePool {
+    pub fn update_node_pool(&self) -> super::builder::edge_container::UpdateNodePool {
         super::builder::edge_container::UpdateNodePool::new(self.inner.clone())
-            .set_node_pool(node_pool.into())
     }
 
     /// Deletes a single NodePool.
@@ -295,47 +252,28 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::DeleteNodePool {
+    pub fn delete_node_pool(&self) -> super::builder::edge_container::DeleteNodePool {
         super::builder::edge_container::DeleteNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Machines in a given project and location.
-    pub fn list_machines(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListMachines {
+    pub fn list_machines(&self) -> super::builder::edge_container::ListMachines {
         super::builder::edge_container::ListMachines::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Machine.
-    pub fn get_machine(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetMachine {
-        super::builder::edge_container::GetMachine::new(self.inner.clone()).set_name(name.into())
+    pub fn get_machine(&self) -> super::builder::edge_container::GetMachine {
+        super::builder::edge_container::GetMachine::new(self.inner.clone())
     }
 
     /// Lists VPN connections in a given project and location.
-    pub fn list_vpn_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListVpnConnections {
+    pub fn list_vpn_connections(&self) -> super::builder::edge_container::ListVpnConnections {
         super::builder::edge_container::ListVpnConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single VPN connection.
-    pub fn get_vpn_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetVpnConnection {
+    pub fn get_vpn_connection(&self) -> super::builder::edge_container::GetVpnConnection {
         super::builder::edge_container::GetVpnConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new VPN connection in a given project and location.
@@ -349,12 +287,8 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_vpn_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::CreateVpnConnection {
+    pub fn create_vpn_connection(&self) -> super::builder::edge_container::CreateVpnConnection {
         super::builder::edge_container::CreateVpnConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single VPN connection.
@@ -368,79 +302,50 @@ impl EdgeContainer {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_vpn_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::DeleteVpnConnection {
+    pub fn delete_vpn_connection(&self) -> super::builder::edge_container::DeleteVpnConnection {
         super::builder::edge_container::DeleteVpnConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the server config.
-    pub fn get_server_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetServerConfig {
+    pub fn get_server_config(&self) -> super::builder::edge_container::GetServerConfig {
         super::builder::edge_container::GetServerConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListLocations {
-        super::builder::edge_container::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::edge_container::ListLocations {
+        super::builder::edge_container::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetLocation {
-        super::builder::edge_container::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::edge_container::GetLocation {
+        super::builder::edge_container::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::ListOperations {
+    pub fn list_operations(&self) -> super::builder::edge_container::ListOperations {
         super::builder::edge_container::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::GetOperation {
-        super::builder::edge_container::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::edge_container::GetOperation {
+        super::builder::edge_container::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::edge_container::DeleteOperation {
         super::builder::edge_container::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_container::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::edge_container::CancelOperation {
         super::builder::edge_container::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::EdgeContainer for EdgeContainer {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cluster
+            let arg = &req
+                .cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -350,10 +355,15 @@ impl super::stub::EdgeContainer for EdgeContainer {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.node_pool
+            let arg = &req
+                .node_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("node_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("node_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +102,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,18 +130,15 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -147,9 +162,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:upgrade", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -164,9 +186,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,12 +213,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAccessTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateAccessToken", {
+            let arg = &req.cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateAccessToken", req.cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,12 +239,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateOfflineCredentialResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateOfflineCredential", {
+            let arg = &req.cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateOfflineCredential", req.cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -228,12 +265,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNodePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/nodePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,9 +295,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NodePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,12 +321,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/nodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/nodePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,18 +349,15 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.node_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("node_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.node_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("node_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,9 +381,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,9 +408,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMachinesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/machines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/machines", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -375,9 +438,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Machine>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -394,12 +464,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVpnConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vpnConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vpnConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -420,9 +494,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VpnConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -439,12 +520,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/vpnConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/vpnConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,9 +548,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -483,12 +575,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServerConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serverConfig", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serverConfig", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -505,9 +601,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -527,9 +630,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,9 +656,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -568,9 +685,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -587,9 +711,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -610,9 +741,16 @@ impl super::stub::EdgeContainer for EdgeContainer {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/edgenetwork/v1/src/client.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/client.rs
@@ -122,56 +122,37 @@ impl EdgeNetwork {
     }
 
     /// InitializeZone will initialize resources for a zone in a project.
-    pub fn initialize_zone(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::InitializeZone {
-        super::builder::edge_network::InitializeZone::new(self.inner.clone()).set_name(name.into())
+    pub fn initialize_zone(&self) -> super::builder::edge_network::InitializeZone {
+        super::builder::edge_network::InitializeZone::new(self.inner.clone())
     }
 
     /// Deprecated: not implemented.
     /// Lists Zones in a given project and location.
     #[deprecated]
-    pub fn list_zones(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListZones {
-        super::builder::edge_network::ListZones::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_zones(&self) -> super::builder::edge_network::ListZones {
+        super::builder::edge_network::ListZones::new(self.inner.clone())
     }
 
     /// Deprecated: not implemented.
     /// Gets details of a single Zone.
     #[deprecated]
-    pub fn get_zone(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetZone {
-        super::builder::edge_network::GetZone::new(self.inner.clone()).set_name(name.into())
+    pub fn get_zone(&self) -> super::builder::edge_network::GetZone {
+        super::builder::edge_network::GetZone::new(self.inner.clone())
     }
 
     /// Lists Networks in a given project and location.
-    pub fn list_networks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListNetworks {
+    pub fn list_networks(&self) -> super::builder::edge_network::ListNetworks {
         super::builder::edge_network::ListNetworks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Network.
-    pub fn get_network(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetNetwork {
-        super::builder::edge_network::GetNetwork::new(self.inner.clone()).set_name(name.into())
+    pub fn get_network(&self) -> super::builder::edge_network::GetNetwork {
+        super::builder::edge_network::GetNetwork::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single network resource.
-    pub fn diagnose_network(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DiagnoseNetwork {
-        super::builder::edge_network::DiagnoseNetwork::new(self.inner.clone()).set_name(name.into())
+    pub fn diagnose_network(&self) -> super::builder::edge_network::DiagnoseNetwork {
+        super::builder::edge_network::DiagnoseNetwork::new(self.inner.clone())
     }
 
     /// Creates a new Network in a given project and location.
@@ -185,12 +166,8 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_network(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::CreateNetwork {
+    pub fn create_network(&self) -> super::builder::edge_network::CreateNetwork {
         super::builder::edge_network::CreateNetwork::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Network.
@@ -204,27 +181,18 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_network(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DeleteNetwork {
-        super::builder::edge_network::DeleteNetwork::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_network(&self) -> super::builder::edge_network::DeleteNetwork {
+        super::builder::edge_network::DeleteNetwork::new(self.inner.clone())
     }
 
     /// Lists Subnets in a given project and location.
-    pub fn list_subnets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListSubnets {
-        super::builder::edge_network::ListSubnets::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_subnets(&self) -> super::builder::edge_network::ListSubnets {
+        super::builder::edge_network::ListSubnets::new(self.inner.clone())
     }
 
     /// Gets details of a single Subnet.
-    pub fn get_subnet(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetSubnet {
-        super::builder::edge_network::GetSubnet::new(self.inner.clone()).set_name(name.into())
+    pub fn get_subnet(&self) -> super::builder::edge_network::GetSubnet {
+        super::builder::edge_network::GetSubnet::new(self.inner.clone())
     }
 
     /// Creates a new Subnet in a given project and location.
@@ -238,12 +206,8 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_subnet(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::CreateSubnet {
+    pub fn create_subnet(&self) -> super::builder::edge_network::CreateSubnet {
         super::builder::edge_network::CreateSubnet::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Subnet.
@@ -257,12 +221,8 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_subnet(
-        &self,
-        subnet: impl Into<crate::model::Subnet>,
-    ) -> super::builder::edge_network::UpdateSubnet {
+    pub fn update_subnet(&self) -> super::builder::edge_network::UpdateSubnet {
         super::builder::edge_network::UpdateSubnet::new(self.inner.clone())
-            .set_subnet(subnet.into())
     }
 
     /// Deletes a single Subnet.
@@ -276,55 +236,37 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_subnet(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DeleteSubnet {
-        super::builder::edge_network::DeleteSubnet::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_subnet(&self) -> super::builder::edge_network::DeleteSubnet {
+        super::builder::edge_network::DeleteSubnet::new(self.inner.clone())
     }
 
     /// Lists Interconnects in a given project and location.
-    pub fn list_interconnects(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListInterconnects {
+    pub fn list_interconnects(&self) -> super::builder::edge_network::ListInterconnects {
         super::builder::edge_network::ListInterconnects::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Interconnect.
-    pub fn get_interconnect(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetInterconnect {
-        super::builder::edge_network::GetInterconnect::new(self.inner.clone()).set_name(name.into())
+    pub fn get_interconnect(&self) -> super::builder::edge_network::GetInterconnect {
+        super::builder::edge_network::GetInterconnect::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single interconnect resource.
-    pub fn diagnose_interconnect(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DiagnoseInterconnect {
+    pub fn diagnose_interconnect(&self) -> super::builder::edge_network::DiagnoseInterconnect {
         super::builder::edge_network::DiagnoseInterconnect::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists InterconnectAttachments in a given project and location.
     pub fn list_interconnect_attachments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::edge_network::ListInterconnectAttachments {
         super::builder::edge_network::ListInterconnectAttachments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single InterconnectAttachment.
     pub fn get_interconnect_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::edge_network::GetInterconnectAttachment {
         super::builder::edge_network::GetInterconnectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new InterconnectAttachment in a given project and location.
@@ -340,10 +282,8 @@ impl EdgeNetwork {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_interconnect_attachment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::edge_network::CreateInterconnectAttachment {
         super::builder::edge_network::CreateInterconnectAttachment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single InterconnectAttachment.
@@ -359,34 +299,23 @@ impl EdgeNetwork {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_interconnect_attachment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::edge_network::DeleteInterconnectAttachment {
         super::builder::edge_network::DeleteInterconnectAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Routers in a given project and location.
-    pub fn list_routers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListRouters {
-        super::builder::edge_network::ListRouters::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_routers(&self) -> super::builder::edge_network::ListRouters {
+        super::builder::edge_network::ListRouters::new(self.inner.clone())
     }
 
     /// Gets details of a single Router.
-    pub fn get_router(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetRouter {
-        super::builder::edge_network::GetRouter::new(self.inner.clone()).set_name(name.into())
+    pub fn get_router(&self) -> super::builder::edge_network::GetRouter {
+        super::builder::edge_network::GetRouter::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single router resource.
-    pub fn diagnose_router(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DiagnoseRouter {
-        super::builder::edge_network::DiagnoseRouter::new(self.inner.clone()).set_name(name.into())
+    pub fn diagnose_router(&self) -> super::builder::edge_network::DiagnoseRouter {
+        super::builder::edge_network::DiagnoseRouter::new(self.inner.clone())
     }
 
     /// Creates a new Router in a given project and location.
@@ -400,12 +329,8 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_router(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::CreateRouter {
+    pub fn create_router(&self) -> super::builder::edge_network::CreateRouter {
         super::builder::edge_network::CreateRouter::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Router.
@@ -419,12 +344,8 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_router(
-        &self,
-        router: impl Into<crate::model::Router>,
-    ) -> super::builder::edge_network::UpdateRouter {
+    pub fn update_router(&self) -> super::builder::edge_network::UpdateRouter {
         super::builder::edge_network::UpdateRouter::new(self.inner.clone())
-            .set_router(router.into())
     }
 
     /// Deletes a single Router.
@@ -438,66 +359,45 @@ impl EdgeNetwork {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_router(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DeleteRouter {
-        super::builder::edge_network::DeleteRouter::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_router(&self) -> super::builder::edge_network::DeleteRouter {
+        super::builder::edge_network::DeleteRouter::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListLocations {
-        super::builder::edge_network::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::edge_network::ListLocations {
+        super::builder::edge_network::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetLocation {
-        super::builder::edge_network::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::edge_network::GetLocation {
+        super::builder::edge_network::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::ListOperations {
-        super::builder::edge_network::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::edge_network::ListOperations {
+        super::builder::edge_network::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::GetOperation {
-        super::builder::edge_network::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::edge_network::GetOperation {
+        super::builder::edge_network::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::DeleteOperation {
-        super::builder::edge_network::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::edge_network::DeleteOperation {
+        super::builder::edge_network::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::edge_network::CancelOperation {
-        super::builder::edge_network::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::edge_network::CancelOperation {
+        super::builder::edge_network::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -346,10 +346,15 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.subnet
+            let arg = &req
+                .subnet
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("subnet.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -705,10 +710,15 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.router
+            let arg = &req
+                .router
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("router"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("router.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InitializeZoneResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:initialize", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:initialize", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListZonesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/zones", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/zones", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,9 +100,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Zone>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -108,9 +126,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNetworksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/networks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/networks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -131,9 +156,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Network>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +182,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiagnoseNetworkResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:diagnose", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +208,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/networks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/networks", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +236,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,9 +263,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSubnetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/subnets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/subnets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,9 +293,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Subnet>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,9 +319,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/subnets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/subnets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,18 +345,15 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.subnet
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.subnet
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,9 +375,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -327,12 +402,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInterconnectsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/interconnects", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/interconnects", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,9 +432,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Interconnect>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -372,9 +458,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiagnoseInterconnectResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:diagnose", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -391,12 +484,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInterconnectAttachmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/interconnectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/interconnectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -417,9 +514,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InterconnectAttachment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -436,12 +540,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/interconnectAttachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/interconnectAttachments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -461,9 +569,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -481,9 +596,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoutersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/routers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/routers", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,9 +626,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Router>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -523,9 +652,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiagnoseRouterResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:diagnose", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:diagnose", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -542,9 +678,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/routers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/routers", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -561,18 +704,15 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.router
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("router"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.router
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("router"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -594,9 +734,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -614,9 +761,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -636,9 +790,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -655,9 +816,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -677,9 +845,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -696,9 +871,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -719,9 +901,16 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/essentialcontacts/v1/src/client.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/client.rs
@@ -121,69 +121,41 @@ impl EssentialContactsService {
     }
 
     /// Adds a new contact for a resource.
-    pub fn create_contact(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::CreateContact {
+    pub fn create_contact(&self) -> super::builder::essential_contacts_service::CreateContact {
         super::builder::essential_contacts_service::CreateContact::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a contact.
     /// Note: A contact's email address cannot be changed.
-    pub fn update_contact(
-        &self,
-        contact: impl Into<crate::model::Contact>,
-    ) -> super::builder::essential_contacts_service::UpdateContact {
+    pub fn update_contact(&self) -> super::builder::essential_contacts_service::UpdateContact {
         super::builder::essential_contacts_service::UpdateContact::new(self.inner.clone())
-            .set_contact(contact.into())
     }
 
     /// Lists the contacts that have been set on a resource.
-    pub fn list_contacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::ListContacts {
+    pub fn list_contacts(&self) -> super::builder::essential_contacts_service::ListContacts {
         super::builder::essential_contacts_service::ListContacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a single contact.
-    pub fn get_contact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::GetContact {
+    pub fn get_contact(&self) -> super::builder::essential_contacts_service::GetContact {
         super::builder::essential_contacts_service::GetContact::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a contact.
-    pub fn delete_contact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::DeleteContact {
+    pub fn delete_contact(&self) -> super::builder::essential_contacts_service::DeleteContact {
         super::builder::essential_contacts_service::DeleteContact::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all contacts for the resource that are subscribed to the
     /// specified notification categories, including contacts inherited from
     /// any parent resources.
-    pub fn compute_contacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::ComputeContacts {
+    pub fn compute_contacts(&self) -> super::builder::essential_contacts_service::ComputeContacts {
         super::builder::essential_contacts_service::ComputeContacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Allows a contact admin to send a test message to contact to verify that it
     /// has been configured correctly.
-    pub fn send_test_message(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::essential_contacts_service::SendTestMessage {
+    pub fn send_test_message(&self) -> super::builder::essential_contacts_service::SendTestMessage {
         super::builder::essential_contacts_service::SendTestMessage::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -73,10 +73,15 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
     ) -> Result<gax::response::Response<crate::model::Contact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.contact
+            let arg = &req
+                .contact
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("contact"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("contact.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Contact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/contacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/contacts", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,18 +72,15 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Contact>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.contact
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("contact"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.contact
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("contact"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -102,9 +103,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListContactsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/contacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/contacts", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,9 +131,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Contact>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -142,9 +157,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,12 +187,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ComputeContactsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/contacts:compute", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/contacts:compute", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -195,12 +221,16 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/contacts:sendTestMessage", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/contacts:sendTestMessage", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/eventarc/v1/src/client.rs
+++ b/src/generated/cloud/eventarc/v1/src/client.rs
@@ -120,19 +120,13 @@ impl Eventarc {
     }
 
     /// Get a single trigger.
-    pub fn get_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetTrigger {
-        super::builder::eventarc::GetTrigger::new(self.inner.clone()).set_name(name.into())
+    pub fn get_trigger(&self) -> super::builder::eventarc::GetTrigger {
+        super::builder::eventarc::GetTrigger::new(self.inner.clone())
     }
 
     /// List triggers.
-    pub fn list_triggers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListTriggers {
-        super::builder::eventarc::ListTriggers::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_triggers(&self) -> super::builder::eventarc::ListTriggers {
+        super::builder::eventarc::ListTriggers::new(self.inner.clone())
     }
 
     /// Create a new trigger in a particular project and location.
@@ -146,11 +140,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_trigger(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateTrigger {
-        super::builder::eventarc::CreateTrigger::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_trigger(&self) -> super::builder::eventarc::CreateTrigger {
+        super::builder::eventarc::CreateTrigger::new(self.inner.clone())
     }
 
     /// Update a single trigger.
@@ -164,11 +155,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_trigger(
-        &self,
-        trigger: impl Into<crate::model::Trigger>,
-    ) -> super::builder::eventarc::UpdateTrigger {
-        super::builder::eventarc::UpdateTrigger::new(self.inner.clone()).set_trigger(trigger.into())
+    pub fn update_trigger(&self) -> super::builder::eventarc::UpdateTrigger {
+        super::builder::eventarc::UpdateTrigger::new(self.inner.clone())
     }
 
     /// Delete a single trigger.
@@ -182,27 +170,18 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteTrigger {
-        super::builder::eventarc::DeleteTrigger::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_trigger(&self) -> super::builder::eventarc::DeleteTrigger {
+        super::builder::eventarc::DeleteTrigger::new(self.inner.clone())
     }
 
     /// Get a single Channel.
-    pub fn get_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetChannel {
-        super::builder::eventarc::GetChannel::new(self.inner.clone()).set_name(name.into())
+    pub fn get_channel(&self) -> super::builder::eventarc::GetChannel {
+        super::builder::eventarc::GetChannel::new(self.inner.clone())
     }
 
     /// List channels.
-    pub fn list_channels(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListChannels {
-        super::builder::eventarc::ListChannels::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_channels(&self) -> super::builder::eventarc::ListChannels {
+        super::builder::eventarc::ListChannels::new(self.inner.clone())
     }
 
     /// Create a new channel in a particular project and location.
@@ -216,11 +195,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_channel(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateChannel {
-        super::builder::eventarc::CreateChannel::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_channel(&self) -> super::builder::eventarc::CreateChannel {
+        super::builder::eventarc::CreateChannel::new(self.inner.clone())
     }
 
     /// Update a single channel.
@@ -234,11 +210,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_channel(
-        &self,
-        channel: impl Into<crate::model::Channel>,
-    ) -> super::builder::eventarc::UpdateChannel {
-        super::builder::eventarc::UpdateChannel::new(self.inner.clone()).set_channel(channel.into())
+    pub fn update_channel(&self) -> super::builder::eventarc::UpdateChannel {
+        super::builder::eventarc::UpdateChannel::new(self.inner.clone())
     }
 
     /// Delete a single channel.
@@ -252,45 +225,28 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteChannel {
-        super::builder::eventarc::DeleteChannel::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_channel(&self) -> super::builder::eventarc::DeleteChannel {
+        super::builder::eventarc::DeleteChannel::new(self.inner.clone())
     }
 
     /// Get a single Provider.
-    pub fn get_provider(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetProvider {
-        super::builder::eventarc::GetProvider::new(self.inner.clone()).set_name(name.into())
+    pub fn get_provider(&self) -> super::builder::eventarc::GetProvider {
+        super::builder::eventarc::GetProvider::new(self.inner.clone())
     }
 
     /// List providers.
-    pub fn list_providers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListProviders {
-        super::builder::eventarc::ListProviders::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_providers(&self) -> super::builder::eventarc::ListProviders {
+        super::builder::eventarc::ListProviders::new(self.inner.clone())
     }
 
     /// Get a single ChannelConnection.
-    pub fn get_channel_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetChannelConnection {
+    pub fn get_channel_connection(&self) -> super::builder::eventarc::GetChannelConnection {
         super::builder::eventarc::GetChannelConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List channel connections.
-    pub fn list_channel_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListChannelConnections {
+    pub fn list_channel_connections(&self) -> super::builder::eventarc::ListChannelConnections {
         super::builder::eventarc::ListChannelConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new ChannelConnection in a particular project and location.
@@ -304,12 +260,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_channel_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateChannelConnection {
+    pub fn create_channel_connection(&self) -> super::builder::eventarc::CreateChannelConnection {
         super::builder::eventarc::CreateChannelConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete a single ChannelConnection.
@@ -323,56 +275,37 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_channel_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteChannelConnection {
+    pub fn delete_channel_connection(&self) -> super::builder::eventarc::DeleteChannelConnection {
         super::builder::eventarc::DeleteChannelConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a GoogleChannelConfig
-    pub fn get_google_channel_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetGoogleChannelConfig {
+    pub fn get_google_channel_config(&self) -> super::builder::eventarc::GetGoogleChannelConfig {
         super::builder::eventarc::GetGoogleChannelConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a single GoogleChannelConfig
     pub fn update_google_channel_config(
         &self,
-        google_channel_config: impl Into<crate::model::GoogleChannelConfig>,
     ) -> super::builder::eventarc::UpdateGoogleChannelConfig {
         super::builder::eventarc::UpdateGoogleChannelConfig::new(self.inner.clone())
-            .set_google_channel_config(google_channel_config.into())
     }
 
     /// Get a single MessageBus.
-    pub fn get_message_bus(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetMessageBus {
-        super::builder::eventarc::GetMessageBus::new(self.inner.clone()).set_name(name.into())
+    pub fn get_message_bus(&self) -> super::builder::eventarc::GetMessageBus {
+        super::builder::eventarc::GetMessageBus::new(self.inner.clone())
     }
 
     /// List message buses.
-    pub fn list_message_buses(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListMessageBuses {
+    pub fn list_message_buses(&self) -> super::builder::eventarc::ListMessageBuses {
         super::builder::eventarc::ListMessageBuses::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List message bus enrollments.
     pub fn list_message_bus_enrollments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::eventarc::ListMessageBusEnrollments {
         super::builder::eventarc::ListMessageBusEnrollments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new MessageBus in a particular project and location.
@@ -386,12 +319,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_message_bus(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateMessageBus {
+    pub fn create_message_bus(&self) -> super::builder::eventarc::CreateMessageBus {
         super::builder::eventarc::CreateMessageBus::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a single message bus.
@@ -405,12 +334,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_message_bus(
-        &self,
-        message_bus: impl Into<crate::model::MessageBus>,
-    ) -> super::builder::eventarc::UpdateMessageBus {
+    pub fn update_message_bus(&self) -> super::builder::eventarc::UpdateMessageBus {
         super::builder::eventarc::UpdateMessageBus::new(self.inner.clone())
-            .set_message_bus(message_bus.into())
     }
 
     /// Delete a single message bus.
@@ -424,27 +349,18 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_message_bus(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteMessageBus {
-        super::builder::eventarc::DeleteMessageBus::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_message_bus(&self) -> super::builder::eventarc::DeleteMessageBus {
+        super::builder::eventarc::DeleteMessageBus::new(self.inner.clone())
     }
 
     /// Get a single Enrollment.
-    pub fn get_enrollment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetEnrollment {
-        super::builder::eventarc::GetEnrollment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_enrollment(&self) -> super::builder::eventarc::GetEnrollment {
+        super::builder::eventarc::GetEnrollment::new(self.inner.clone())
     }
 
     /// List Enrollments.
-    pub fn list_enrollments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListEnrollments {
-        super::builder::eventarc::ListEnrollments::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_enrollments(&self) -> super::builder::eventarc::ListEnrollments {
+        super::builder::eventarc::ListEnrollments::new(self.inner.clone())
     }
 
     /// Create a new Enrollment in a particular project and location.
@@ -458,12 +374,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_enrollment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateEnrollment {
+    pub fn create_enrollment(&self) -> super::builder::eventarc::CreateEnrollment {
         super::builder::eventarc::CreateEnrollment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a single Enrollment.
@@ -477,12 +389,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_enrollment(
-        &self,
-        enrollment: impl Into<crate::model::Enrollment>,
-    ) -> super::builder::eventarc::UpdateEnrollment {
+    pub fn update_enrollment(&self) -> super::builder::eventarc::UpdateEnrollment {
         super::builder::eventarc::UpdateEnrollment::new(self.inner.clone())
-            .set_enrollment(enrollment.into())
     }
 
     /// Delete a single Enrollment.
@@ -496,27 +404,18 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_enrollment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteEnrollment {
-        super::builder::eventarc::DeleteEnrollment::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_enrollment(&self) -> super::builder::eventarc::DeleteEnrollment {
+        super::builder::eventarc::DeleteEnrollment::new(self.inner.clone())
     }
 
     /// Get a single Pipeline.
-    pub fn get_pipeline(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetPipeline {
-        super::builder::eventarc::GetPipeline::new(self.inner.clone()).set_name(name.into())
+    pub fn get_pipeline(&self) -> super::builder::eventarc::GetPipeline {
+        super::builder::eventarc::GetPipeline::new(self.inner.clone())
     }
 
     /// List pipelines.
-    pub fn list_pipelines(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListPipelines {
-        super::builder::eventarc::ListPipelines::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_pipelines(&self) -> super::builder::eventarc::ListPipelines {
+        super::builder::eventarc::ListPipelines::new(self.inner.clone())
     }
 
     /// Create a new Pipeline in a particular project and location.
@@ -530,11 +429,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_pipeline(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreatePipeline {
-        super::builder::eventarc::CreatePipeline::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_pipeline(&self) -> super::builder::eventarc::CreatePipeline {
+        super::builder::eventarc::CreatePipeline::new(self.inner.clone())
     }
 
     /// Update a single pipeline.
@@ -548,12 +444,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_pipeline(
-        &self,
-        pipeline: impl Into<crate::model::Pipeline>,
-    ) -> super::builder::eventarc::UpdatePipeline {
+    pub fn update_pipeline(&self) -> super::builder::eventarc::UpdatePipeline {
         super::builder::eventarc::UpdatePipeline::new(self.inner.clone())
-            .set_pipeline(pipeline.into())
     }
 
     /// Delete a single pipeline.
@@ -567,28 +459,18 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_pipeline(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeletePipeline {
-        super::builder::eventarc::DeletePipeline::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_pipeline(&self) -> super::builder::eventarc::DeletePipeline {
+        super::builder::eventarc::DeletePipeline::new(self.inner.clone())
     }
 
     /// Get a single GoogleApiSource.
-    pub fn get_google_api_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetGoogleApiSource {
-        super::builder::eventarc::GetGoogleApiSource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_google_api_source(&self) -> super::builder::eventarc::GetGoogleApiSource {
+        super::builder::eventarc::GetGoogleApiSource::new(self.inner.clone())
     }
 
     /// List GoogleApiSources.
-    pub fn list_google_api_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListGoogleApiSources {
+    pub fn list_google_api_sources(&self) -> super::builder::eventarc::ListGoogleApiSources {
         super::builder::eventarc::ListGoogleApiSources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new GoogleApiSource in a particular project and location.
@@ -602,12 +484,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_google_api_source(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CreateGoogleApiSource {
+    pub fn create_google_api_source(&self) -> super::builder::eventarc::CreateGoogleApiSource {
         super::builder::eventarc::CreateGoogleApiSource::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a single GoogleApiSource.
@@ -621,12 +499,8 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_google_api_source(
-        &self,
-        google_api_source: impl Into<crate::model::GoogleApiSource>,
-    ) -> super::builder::eventarc::UpdateGoogleApiSource {
+    pub fn update_google_api_source(&self) -> super::builder::eventarc::UpdateGoogleApiSource {
         super::builder::eventarc::UpdateGoogleApiSource::new(self.inner.clone())
-            .set_google_api_source(google_api_source.into())
     }
 
     /// Delete a single GoogleApiSource.
@@ -640,28 +514,18 @@ impl Eventarc {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_google_api_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteGoogleApiSource {
+    pub fn delete_google_api_source(&self) -> super::builder::eventarc::DeleteGoogleApiSource {
         super::builder::eventarc::DeleteGoogleApiSource::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListLocations {
-        super::builder::eventarc::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::eventarc::ListLocations {
+        super::builder::eventarc::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetLocation {
-        super::builder::eventarc::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::eventarc::GetLocation {
+        super::builder::eventarc::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -669,22 +533,14 @@ impl Eventarc {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::eventarc::SetIamPolicy {
         super::builder::eventarc::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::eventarc::GetIamPolicy {
         super::builder::eventarc::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -694,51 +550,35 @@ impl Eventarc {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::eventarc::TestIamPermissions {
         super::builder::eventarc::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::ListOperations {
-        super::builder::eventarc::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::eventarc::ListOperations {
+        super::builder::eventarc::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::GetOperation {
-        super::builder::eventarc::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::eventarc::GetOperation {
+        super::builder::eventarc::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::DeleteOperation {
-        super::builder::eventarc::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::eventarc::DeleteOperation {
+        super::builder::eventarc::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::eventarc::CancelOperation {
-        super::builder::eventarc::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::eventarc::CancelOperation {
+        super::builder::eventarc::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Trigger>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTriggersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/triggers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/triggers", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +102,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/triggers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/triggers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,18 +130,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.trigger
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("trigger"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.trigger
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("trigger"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +163,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +192,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Channel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,9 +218,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListChannelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/channels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/channels", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,12 +247,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/channels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/channels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,18 +275,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.channel
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.channel
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +307,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +334,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Provider>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -309,12 +360,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProvidersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/providers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/providers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,9 +390,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ChannelConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -354,12 +416,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListChannelConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/channelConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/channelConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -378,12 +444,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/channelConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/channelConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -401,9 +471,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -420,9 +497,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GoogleChannelConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -439,18 +523,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GoogleChannelConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.google_channel_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("google_channel_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.google_channel_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("google_channel_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -473,9 +554,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MessageBus>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -492,12 +580,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMessageBusesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/messageBuses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/messageBuses", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -518,12 +610,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMessageBusEnrollmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listEnrollments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listEnrollments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -542,12 +638,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/messageBuses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/messageBuses", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -566,18 +666,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.message_bus
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("message_bus"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.message_bus
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("message_bus"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -602,9 +699,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -624,9 +728,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Enrollment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -643,12 +754,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnrollmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/enrollments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/enrollments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -669,12 +784,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/enrollments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/enrollments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -693,18 +812,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.enrollment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("enrollment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.enrollment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("enrollment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -729,9 +845,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -751,9 +874,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Pipeline>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -770,12 +900,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPipelinesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/pipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/pipelines", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -796,12 +930,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/pipelines", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/pipelines", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -820,18 +958,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.pipeline
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("pipeline"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.pipeline
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("pipeline"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -856,9 +991,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -878,9 +1020,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GoogleApiSource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -897,12 +1046,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGoogleApiSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/googleApiSources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/googleApiSources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -923,12 +1076,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/googleApiSources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/googleApiSources", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -947,18 +1104,15 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.google_api_source
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("google_api_source"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.google_api_source
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("google_api_source"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -983,9 +1137,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1005,9 +1166,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1027,9 +1195,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1046,12 +1221,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1066,12 +1245,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1098,12 +1281,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1118,9 +1305,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1140,9 +1334,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1159,9 +1360,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1182,9 +1390,16 @@ impl super::stub::Eventarc for Eventarc {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.trigger
+            let arg = &req
+                .trigger
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("trigger"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("trigger.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -276,10 +281,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.channel
+            let arg = &req
+                .channel
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("channel.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -524,10 +534,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<crate::model::GoogleChannelConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.google_channel_config
+            let arg = &req
+                .google_channel_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("google_channel_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("google_channel_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -667,10 +682,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.message_bus
+            let arg = &req
+                .message_bus
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("message_bus"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("message_bus.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -813,10 +833,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.enrollment
+            let arg = &req
+                .enrollment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("enrollment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("enrollment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -959,10 +984,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.pipeline
+            let arg = &req
+                .pipeline
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("pipeline"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("pipeline.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1105,10 +1135,15 @@ impl super::stub::Eventarc for Eventarc {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.google_api_source
+            let arg = &req
+                .google_api_source
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("google_api_source"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("google_api_source.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/filestore/v1/src/client.rs
+++ b/src/generated/cloud/filestore/v1/src/client.rs
@@ -142,21 +142,13 @@ impl CloudFilestoreManager {
 
     /// Lists all instances in a project for either a specified location
     /// or for all locations.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::ListInstances {
+    pub fn list_instances(&self) -> super::builder::cloud_filestore_manager::ListInstances {
         super::builder::cloud_filestore_manager::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::GetInstance {
+    pub fn get_instance(&self) -> super::builder::cloud_filestore_manager::GetInstance {
         super::builder::cloud_filestore_manager::GetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an instance.
@@ -173,12 +165,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::cloud_filestore_manager::CreateInstance {
         super::builder::cloud_filestore_manager::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the settings of a specific instance.
@@ -192,12 +180,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::cloud_filestore_manager::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::cloud_filestore_manager::UpdateInstance {
         super::builder::cloud_filestore_manager::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Restores an existing instance's file share from a backup.
@@ -215,12 +199,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::RestoreInstance {
+    pub fn restore_instance(&self) -> super::builder::cloud_filestore_manager::RestoreInstance {
         super::builder::cloud_filestore_manager::RestoreInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Revert an existing instance's file system to a specified snapshot.
@@ -234,12 +214,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn revert_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::RevertInstance {
+    pub fn revert_instance(&self) -> super::builder::cloud_filestore_manager::RevertInstance {
         super::builder::cloud_filestore_manager::RevertInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an instance.
@@ -253,31 +229,19 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::cloud_filestore_manager::DeleteInstance {
         super::builder::cloud_filestore_manager::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all snapshots in a project for either a specified location
     /// or for all locations.
-    pub fn list_snapshots(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::ListSnapshots {
+    pub fn list_snapshots(&self) -> super::builder::cloud_filestore_manager::ListSnapshots {
         super::builder::cloud_filestore_manager::ListSnapshots::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific snapshot.
-    pub fn get_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::GetSnapshot {
+    pub fn get_snapshot(&self) -> super::builder::cloud_filestore_manager::GetSnapshot {
         super::builder::cloud_filestore_manager::GetSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a snapshot.
@@ -291,12 +255,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_snapshot(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::CreateSnapshot {
+    pub fn create_snapshot(&self) -> super::builder::cloud_filestore_manager::CreateSnapshot {
         super::builder::cloud_filestore_manager::CreateSnapshot::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a snapshot.
@@ -310,12 +270,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::DeleteSnapshot {
+    pub fn delete_snapshot(&self) -> super::builder::cloud_filestore_manager::DeleteSnapshot {
         super::builder::cloud_filestore_manager::DeleteSnapshot::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the settings of a specific snapshot.
@@ -329,31 +285,19 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_snapshot(
-        &self,
-        snapshot: impl Into<crate::model::Snapshot>,
-    ) -> super::builder::cloud_filestore_manager::UpdateSnapshot {
+    pub fn update_snapshot(&self) -> super::builder::cloud_filestore_manager::UpdateSnapshot {
         super::builder::cloud_filestore_manager::UpdateSnapshot::new(self.inner.clone())
-            .set_snapshot(snapshot.into())
     }
 
     /// Lists all backups in a project for either a specified location or for all
     /// locations.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::ListBackups {
+    pub fn list_backups(&self) -> super::builder::cloud_filestore_manager::ListBackups {
         super::builder::cloud_filestore_manager::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::GetBackup {
+    pub fn get_backup(&self) -> super::builder::cloud_filestore_manager::GetBackup {
         super::builder::cloud_filestore_manager::GetBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a backup.
@@ -367,12 +311,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::cloud_filestore_manager::CreateBackup {
         super::builder::cloud_filestore_manager::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a backup.
@@ -386,12 +326,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::DeleteBackup {
+    pub fn delete_backup(&self) -> super::builder::cloud_filestore_manager::DeleteBackup {
         super::builder::cloud_filestore_manager::DeleteBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the settings of a specific backup.
@@ -405,12 +341,8 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::cloud_filestore_manager::UpdateBackup {
+    pub fn update_backup(&self) -> super::builder::cloud_filestore_manager::UpdateBackup {
         super::builder::cloud_filestore_manager::UpdateBackup::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Promote the standby instance (replica).
@@ -424,73 +356,45 @@ impl CloudFilestoreManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn promote_replica(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::PromoteReplica {
+    pub fn promote_replica(&self) -> super::builder::cloud_filestore_manager::PromoteReplica {
         super::builder::cloud_filestore_manager::PromoteReplica::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::cloud_filestore_manager::ListLocations {
         super::builder::cloud_filestore_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::GetLocation {
+    pub fn get_location(&self) -> super::builder::cloud_filestore_manager::GetLocation {
         super::builder::cloud_filestore_manager::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::cloud_filestore_manager::ListOperations {
         super::builder::cloud_filestore_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::cloud_filestore_manager::GetOperation {
         super::builder::cloud_filestore_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::cloud_filestore_manager::DeleteOperation {
         super::builder::cloud_filestore_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_filestore_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::cloud_filestore_manager::CancelOperation {
         super::builder::cloud_filestore_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,9 +184,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revert", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revert", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -182,9 +208,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,12 +235,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSnapshotsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -229,9 +266,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snapshot>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -248,12 +292,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,9 +319,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,18 +345,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.snapshot
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.snapshot
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,9 +376,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +406,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -366,9 +432,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,9 +457,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -403,18 +483,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -435,12 +512,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:promoteReplica", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:promoteReplica", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -455,9 +536,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,9 +565,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -496,9 +591,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -518,9 +620,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -537,9 +646,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -560,9 +676,16 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -346,10 +351,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.snapshot
+            let arg = &req
+                .snapshot
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("snapshot.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -484,10 +494,15 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/financialservices/v1/src/client.rs
+++ b/src/generated/cloud/financialservices/v1/src/client.rs
@@ -118,19 +118,13 @@ impl Aml {
     }
 
     /// Lists instances.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListInstances {
-        super::builder::aml::ListInstances::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_instances(&self) -> super::builder::aml::ListInstances {
+        super::builder::aml::ListInstances::new(self.inner.clone())
     }
 
     /// Gets an instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetInstance {
-        super::builder::aml::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::aml::GetInstance {
+        super::builder::aml::GetInstance::new(self.inner.clone())
     }
 
     /// Creates an instance.
@@ -144,11 +138,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreateInstance {
-        super::builder::aml::CreateInstance::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_instance(&self) -> super::builder::aml::CreateInstance {
+        super::builder::aml::CreateInstance::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Instance.
@@ -162,11 +153,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::aml::UpdateInstance {
-        super::builder::aml::UpdateInstance::new(self.inner.clone()).set_instance(instance.into())
+    pub fn update_instance(&self) -> super::builder::aml::UpdateInstance {
+        super::builder::aml::UpdateInstance::new(self.inner.clone())
     }
 
     /// Deletes an instance.
@@ -180,11 +168,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteInstance {
-        super::builder::aml::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::aml::DeleteInstance {
+        super::builder::aml::DeleteInstance::new(self.inner.clone())
     }
 
     /// Imports the list of registered parties. See
@@ -201,11 +186,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_registered_parties(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::ImportRegisteredParties {
-        super::builder::aml::ImportRegisteredParties::new(self.inner.clone()).set_name(name.into())
+    pub fn import_registered_parties(&self) -> super::builder::aml::ImportRegisteredParties {
+        super::builder::aml::ImportRegisteredParties::new(self.inner.clone())
     }
 
     /// Exports the list of registered parties. See
@@ -222,27 +204,18 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_registered_parties(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::ExportRegisteredParties {
-        super::builder::aml::ExportRegisteredParties::new(self.inner.clone()).set_name(name.into())
+    pub fn export_registered_parties(&self) -> super::builder::aml::ExportRegisteredParties {
+        super::builder::aml::ExportRegisteredParties::new(self.inner.clone())
     }
 
     /// Lists datasets.
-    pub fn list_datasets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListDatasets {
-        super::builder::aml::ListDatasets::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_datasets(&self) -> super::builder::aml::ListDatasets {
+        super::builder::aml::ListDatasets::new(self.inner.clone())
     }
 
     /// Gets a dataset.
-    pub fn get_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetDataset {
-        super::builder::aml::GetDataset::new(self.inner.clone()).set_name(name.into())
+    pub fn get_dataset(&self) -> super::builder::aml::GetDataset {
+        super::builder::aml::GetDataset::new(self.inner.clone())
     }
 
     /// Creates a dataset.
@@ -256,11 +229,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_dataset(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreateDataset {
-        super::builder::aml::CreateDataset::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_dataset(&self) -> super::builder::aml::CreateDataset {
+        super::builder::aml::CreateDataset::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Dataset.
@@ -274,11 +244,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_dataset(
-        &self,
-        dataset: impl Into<crate::model::Dataset>,
-    ) -> super::builder::aml::UpdateDataset {
-        super::builder::aml::UpdateDataset::new(self.inner.clone()).set_dataset(dataset.into())
+    pub fn update_dataset(&self) -> super::builder::aml::UpdateDataset {
+        super::builder::aml::UpdateDataset::new(self.inner.clone())
     }
 
     /// Deletes a dataset.
@@ -292,24 +259,18 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteDataset {
-        super::builder::aml::DeleteDataset::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_dataset(&self) -> super::builder::aml::DeleteDataset {
+        super::builder::aml::DeleteDataset::new(self.inner.clone())
     }
 
     /// Lists models.
-    pub fn list_models(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListModels {
-        super::builder::aml::ListModels::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_models(&self) -> super::builder::aml::ListModels {
+        super::builder::aml::ListModels::new(self.inner.clone())
     }
 
     /// Gets a model.
-    pub fn get_model(&self, name: impl Into<std::string::String>) -> super::builder::aml::GetModel {
-        super::builder::aml::GetModel::new(self.inner.clone()).set_name(name.into())
+    pub fn get_model(&self) -> super::builder::aml::GetModel {
+        super::builder::aml::GetModel::new(self.inner.clone())
     }
 
     /// Creates a model.
@@ -323,11 +284,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreateModel {
-        super::builder::aml::CreateModel::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_model(&self) -> super::builder::aml::CreateModel {
+        super::builder::aml::CreateModel::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Model.
@@ -341,11 +299,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_model(
-        &self,
-        model: impl Into<crate::model::Model>,
-    ) -> super::builder::aml::UpdateModel {
-        super::builder::aml::UpdateModel::new(self.inner.clone()).set_model(model.into())
+    pub fn update_model(&self) -> super::builder::aml::UpdateModel {
+        super::builder::aml::UpdateModel::new(self.inner.clone())
     }
 
     /// Export governance information for a Model resource. For
@@ -362,11 +317,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_model_metadata(
-        &self,
-        model: impl Into<std::string::String>,
-    ) -> super::builder::aml::ExportModelMetadata {
-        super::builder::aml::ExportModelMetadata::new(self.inner.clone()).set_model(model.into())
+    pub fn export_model_metadata(&self) -> super::builder::aml::ExportModelMetadata {
+        super::builder::aml::ExportModelMetadata::new(self.inner.clone())
     }
 
     /// Deletes a model.
@@ -380,27 +332,18 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteModel {
-        super::builder::aml::DeleteModel::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_model(&self) -> super::builder::aml::DeleteModel {
+        super::builder::aml::DeleteModel::new(self.inner.clone())
     }
 
     /// Lists engine configs.
-    pub fn list_engine_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListEngineConfigs {
-        super::builder::aml::ListEngineConfigs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_engine_configs(&self) -> super::builder::aml::ListEngineConfigs {
+        super::builder::aml::ListEngineConfigs::new(self.inner.clone())
     }
 
     /// Gets an engine config.
-    pub fn get_engine_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetEngineConfig {
-        super::builder::aml::GetEngineConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_engine_config(&self) -> super::builder::aml::GetEngineConfig {
+        super::builder::aml::GetEngineConfig::new(self.inner.clone())
     }
 
     /// Creates an engine config.
@@ -414,11 +357,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_engine_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreateEngineConfig {
-        super::builder::aml::CreateEngineConfig::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_engine_config(&self) -> super::builder::aml::CreateEngineConfig {
+        super::builder::aml::CreateEngineConfig::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single EngineConfig.
@@ -432,12 +372,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_engine_config(
-        &self,
-        engine_config: impl Into<crate::model::EngineConfig>,
-    ) -> super::builder::aml::UpdateEngineConfig {
+    pub fn update_engine_config(&self) -> super::builder::aml::UpdateEngineConfig {
         super::builder::aml::UpdateEngineConfig::new(self.inner.clone())
-            .set_engine_config(engine_config.into())
     }
 
     /// Export governance information for an EngineConfig resource. For
@@ -454,12 +390,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_engine_config_metadata(
-        &self,
-        engine_config: impl Into<std::string::String>,
-    ) -> super::builder::aml::ExportEngineConfigMetadata {
+    pub fn export_engine_config_metadata(&self) -> super::builder::aml::ExportEngineConfigMetadata {
         super::builder::aml::ExportEngineConfigMetadata::new(self.inner.clone())
-            .set_engine_config(engine_config.into())
     }
 
     /// Deletes an engine config.
@@ -473,44 +405,28 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_engine_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteEngineConfig {
-        super::builder::aml::DeleteEngineConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_engine_config(&self) -> super::builder::aml::DeleteEngineConfig {
+        super::builder::aml::DeleteEngineConfig::new(self.inner.clone())
     }
 
     /// Gets a single EngineVersion.
-    pub fn get_engine_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetEngineVersion {
-        super::builder::aml::GetEngineVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_engine_version(&self) -> super::builder::aml::GetEngineVersion {
+        super::builder::aml::GetEngineVersion::new(self.inner.clone())
     }
 
     /// Lists EngineVersions for given location.
-    pub fn list_engine_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListEngineVersions {
-        super::builder::aml::ListEngineVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_engine_versions(&self) -> super::builder::aml::ListEngineVersions {
+        super::builder::aml::ListEngineVersions::new(self.inner.clone())
     }
 
     /// List PredictionResults.
-    pub fn list_prediction_results(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListPredictionResults {
+    pub fn list_prediction_results(&self) -> super::builder::aml::ListPredictionResults {
         super::builder::aml::ListPredictionResults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a PredictionResult.
-    pub fn get_prediction_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetPredictionResult {
-        super::builder::aml::GetPredictionResult::new(self.inner.clone()).set_name(name.into())
+    pub fn get_prediction_result(&self) -> super::builder::aml::GetPredictionResult {
+        super::builder::aml::GetPredictionResult::new(self.inner.clone())
     }
 
     /// Create a PredictionResult.
@@ -524,12 +440,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_prediction_result(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreatePredictionResult {
+    pub fn create_prediction_result(&self) -> super::builder::aml::CreatePredictionResult {
         super::builder::aml::CreatePredictionResult::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single PredictionResult.
@@ -543,12 +455,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_prediction_result(
-        &self,
-        prediction_result: impl Into<crate::model::PredictionResult>,
-    ) -> super::builder::aml::UpdatePredictionResult {
+    pub fn update_prediction_result(&self) -> super::builder::aml::UpdatePredictionResult {
         super::builder::aml::UpdatePredictionResult::new(self.inner.clone())
-            .set_prediction_result(prediction_result.into())
     }
 
     /// Export governance information for a PredictionResult resource. For
@@ -567,10 +475,8 @@ impl Aml {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn export_prediction_result_metadata(
         &self,
-        prediction_result: impl Into<std::string::String>,
     ) -> super::builder::aml::ExportPredictionResultMetadata {
         super::builder::aml::ExportPredictionResultMetadata::new(self.inner.clone())
-            .set_prediction_result(prediction_result.into())
     }
 
     /// Deletes a PredictionResult.
@@ -584,27 +490,18 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_prediction_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeletePredictionResult {
-        super::builder::aml::DeletePredictionResult::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_prediction_result(&self) -> super::builder::aml::DeletePredictionResult {
+        super::builder::aml::DeletePredictionResult::new(self.inner.clone())
     }
 
     /// List BacktestResults.
-    pub fn list_backtest_results(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListBacktestResults {
-        super::builder::aml::ListBacktestResults::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_backtest_results(&self) -> super::builder::aml::ListBacktestResults {
+        super::builder::aml::ListBacktestResults::new(self.inner.clone())
     }
 
     /// Gets a BacktestResult.
-    pub fn get_backtest_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetBacktestResult {
-        super::builder::aml::GetBacktestResult::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backtest_result(&self) -> super::builder::aml::GetBacktestResult {
+        super::builder::aml::GetBacktestResult::new(self.inner.clone())
     }
 
     /// Create a BacktestResult.
@@ -618,11 +515,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backtest_result(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aml::CreateBacktestResult {
-        super::builder::aml::CreateBacktestResult::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_backtest_result(&self) -> super::builder::aml::CreateBacktestResult {
+        super::builder::aml::CreateBacktestResult::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single BacktestResult.
@@ -636,12 +530,8 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backtest_result(
-        &self,
-        backtest_result: impl Into<crate::model::BacktestResult>,
-    ) -> super::builder::aml::UpdateBacktestResult {
+    pub fn update_backtest_result(&self) -> super::builder::aml::UpdateBacktestResult {
         super::builder::aml::UpdateBacktestResult::new(self.inner.clone())
-            .set_backtest_result(backtest_result.into())
     }
 
     /// Export governance information for a BacktestResult resource. For
@@ -660,10 +550,8 @@ impl Aml {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn export_backtest_result_metadata(
         &self,
-        backtest_result: impl Into<std::string::String>,
     ) -> super::builder::aml::ExportBacktestResultMetadata {
         super::builder::aml::ExportBacktestResultMetadata::new(self.inner.clone())
-            .set_backtest_result(backtest_result.into())
     }
 
     /// Deletes a BacktestResult.
@@ -677,66 +565,45 @@ impl Aml {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backtest_result(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteBacktestResult {
-        super::builder::aml::DeleteBacktestResult::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backtest_result(&self) -> super::builder::aml::DeleteBacktestResult {
+        super::builder::aml::DeleteBacktestResult::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListLocations {
-        super::builder::aml::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::aml::ListLocations {
+        super::builder::aml::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetLocation {
-        super::builder::aml::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::aml::GetLocation {
+        super::builder::aml::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::ListOperations {
-        super::builder::aml::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::aml::ListOperations {
+        super::builder::aml::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::GetOperation {
-        super::builder::aml::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::aml::GetOperation {
+        super::builder::aml::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::DeleteOperation {
-        super::builder::aml::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::aml::DeleteOperation {
+        super::builder::aml::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aml::CancelOperation {
-        super::builder::aml::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::aml::CancelOperation {
+        super::builder::aml::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -129,10 +129,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -320,10 +325,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dataset
+            let arg = &req
+                .dataset
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -461,10 +471,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.model
+            let arg = &req
+                .model
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -626,10 +641,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.engine_config
+            let arg = &req
+                .engine_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("engine_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("engine_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -849,10 +869,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.prediction_result
+            let arg = &req
+                .prediction_result
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("prediction_result"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("prediction_result.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1016,10 +1041,15 @@ impl super::stub::Aml for Aml {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backtest_result
+            let arg = &req
+                .backtest_result
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backtest_result"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backtest_result.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -44,12 +44,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,18 +128,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,12 +187,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importRegisteredParties", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importRegisteredParties", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -188,12 +211,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportRegisteredParties", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportRegisteredParties", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,9 +235,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatasetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,9 +265,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,12 +291,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,18 +319,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dataset
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dataset
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dataset"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -309,9 +351,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +378,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/models", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,9 +408,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -371,9 +434,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/models", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -390,18 +460,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.model
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("model"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.model
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -423,12 +490,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportMetadata", {
+            let arg = &req.model;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportMetadata", req.model),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,9 +514,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,12 +541,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEngineConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/engineConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/engineConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,9 +571,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EngineConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +597,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/engineConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/engineConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,18 +625,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.engine_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("engine_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.engine_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("engine_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -567,12 +657,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportMetadata", {
+            let arg = &req.engine_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("engine_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportMetadata", req.engine_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -587,9 +681,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -607,9 +708,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EngineVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,12 +734,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEngineVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/engineVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/engineVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -652,12 +764,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPredictionResultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/predictionResults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/predictionResults", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -678,9 +794,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PredictionResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -697,12 +820,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/predictionResults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/predictionResults", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -721,18 +848,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.prediction_result
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("prediction_result"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.prediction_result
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("prediction_result"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -756,12 +880,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportMetadata", {
+            let arg = &req.prediction_result;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("prediction_result"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportMetadata", req.prediction_result),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -776,9 +904,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -796,12 +931,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBacktestResultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backtestResults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backtestResults", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -822,9 +961,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BacktestResult>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -841,12 +987,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backtestResults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backtestResults", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -865,18 +1015,15 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backtest_result
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backtest_result"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backtest_result
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backtest_result"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -900,12 +1047,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportMetadata", {
+            let arg = &req.backtest_result;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backtest_result"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportMetadata", req.backtest_result),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -920,9 +1071,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -940,9 +1098,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -962,9 +1127,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -981,9 +1153,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1003,9 +1182,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1022,9 +1208,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1045,9 +1238,16 @@ impl super::stub::Aml for Aml {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/functions/v2/src/client.rs
+++ b/src/generated/cloud/functions/v2/src/client.rs
@@ -126,20 +126,13 @@ impl FunctionService {
     }
 
     /// Returns a function with the given name from the requested project.
-    pub fn get_function(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::GetFunction {
-        super::builder::function_service::GetFunction::new(self.inner.clone()).set_name(name.into())
+    pub fn get_function(&self) -> super::builder::function_service::GetFunction {
+        super::builder::function_service::GetFunction::new(self.inner.clone())
     }
 
     /// Returns a list of functions that belong to the requested project.
-    pub fn list_functions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::function_service::ListFunctions {
+    pub fn list_functions(&self) -> super::builder::function_service::ListFunctions {
         super::builder::function_service::ListFunctions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new function. If a function with the given name already exists in
@@ -155,12 +148,8 @@ impl FunctionService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_function(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::function_service::CreateFunction {
+    pub fn create_function(&self) -> super::builder::function_service::CreateFunction {
         super::builder::function_service::CreateFunction::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates existing function.
@@ -174,12 +163,8 @@ impl FunctionService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_function(
-        &self,
-        function: impl Into<crate::model::Function>,
-    ) -> super::builder::function_service::UpdateFunction {
+    pub fn update_function(&self) -> super::builder::function_service::UpdateFunction {
         super::builder::function_service::UpdateFunction::new(self.inner.clone())
-            .set_function(function.into())
     }
 
     /// Deletes a function with the given name from the specified project. If the
@@ -195,12 +180,8 @@ impl FunctionService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_function(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::DeleteFunction {
+    pub fn delete_function(&self) -> super::builder::function_service::DeleteFunction {
         super::builder::function_service::DeleteFunction::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a signed URL for uploading a function source code.
@@ -226,12 +207,8 @@ impl FunctionService {
     /// Do not specify this header:
     ///
     /// * `Authorization: Bearer YOUR_TOKEN`
-    pub fn generate_upload_url(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::function_service::GenerateUploadUrl {
+    pub fn generate_upload_url(&self) -> super::builder::function_service::GenerateUploadUrl {
         super::builder::function_service::GenerateUploadUrl::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a signed URL for downloading deployed function source code.
@@ -239,30 +216,18 @@ impl FunctionService {
     /// 30 minutes of generation.
     /// For more information about the signed URL usage see:
     /// <https://cloud.google.com/storage/docs/access-control/signed-urls>
-    pub fn generate_download_url(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::GenerateDownloadUrl {
+    pub fn generate_download_url(&self) -> super::builder::function_service::GenerateDownloadUrl {
         super::builder::function_service::GenerateDownloadUrl::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of runtimes that are supported for the requested project.
-    pub fn list_runtimes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::function_service::ListRuntimes {
+    pub fn list_runtimes(&self) -> super::builder::function_service::ListRuntimes {
         super::builder::function_service::ListRuntimes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::function_service::ListLocations {
         super::builder::function_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -270,22 +235,14 @@ impl FunctionService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::function_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::function_service::SetIamPolicy {
         super::builder::function_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::function_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::function_service::GetIamPolicy {
         super::builder::function_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -295,33 +252,21 @@ impl FunctionService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::function_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::function_service::TestIamPermissions {
         super::builder::function_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::function_service::ListOperations {
         super::builder::function_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::function_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::function_service::GetOperation {
         super::builder::function_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Function>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +73,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFunctionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/functions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/functions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,12 +103,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/functions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/functions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.function
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("function"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.function
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("function"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,9 +161,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,12 +187,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateUploadUrlResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/functions:generateUploadUrl", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/functions:generateUploadUrl", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -188,12 +211,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateDownloadUrlResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:generateDownloadUrl", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:generateDownloadUrl", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,9 +235,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuntimesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/runtimes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/runtimes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -228,9 +262,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,12 +291,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,12 +315,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -302,12 +351,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,9 +375,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -344,9 +404,16 @@ impl super::stub::FunctionService for FunctionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::FunctionService for FunctionService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.function
+            let arg = &req
+                .function
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("function"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("function.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/gkebackup/v1/src/client.rs
+++ b/src/generated/cloud/gkebackup/v1/src/client.rs
@@ -130,29 +130,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_plan(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateBackupPlan {
+    pub fn create_backup_plan(&self) -> super::builder::backup_for_gke::CreateBackupPlan {
         super::builder::backup_for_gke::CreateBackupPlan::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists BackupPlans in a given location.
-    pub fn list_backup_plans(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListBackupPlans {
+    pub fn list_backup_plans(&self) -> super::builder::backup_for_gke::ListBackupPlans {
         super::builder::backup_for_gke::ListBackupPlans::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single BackupPlan.
-    pub fn get_backup_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetBackupPlan {
-        super::builder::backup_for_gke::GetBackupPlan::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup_plan(&self) -> super::builder::backup_for_gke::GetBackupPlan {
+        super::builder::backup_for_gke::GetBackupPlan::new(self.inner.clone())
     }
 
     /// Update a BackupPlan.
@@ -166,12 +155,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup_plan(
-        &self,
-        backup_plan: impl Into<crate::model::BackupPlan>,
-    ) -> super::builder::backup_for_gke::UpdateBackupPlan {
+    pub fn update_backup_plan(&self) -> super::builder::backup_for_gke::UpdateBackupPlan {
         super::builder::backup_for_gke::UpdateBackupPlan::new(self.inner.clone())
-            .set_backup_plan(backup_plan.into())
     }
 
     /// Deletes an existing BackupPlan.
@@ -185,12 +170,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteBackupPlan {
+    pub fn delete_backup_plan(&self) -> super::builder::backup_for_gke::DeleteBackupPlan {
         super::builder::backup_for_gke::DeleteBackupPlan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new BackupChannel in a given location.
@@ -204,30 +185,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_channel(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateBackupChannel {
+    pub fn create_backup_channel(&self) -> super::builder::backup_for_gke::CreateBackupChannel {
         super::builder::backup_for_gke::CreateBackupChannel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists BackupChannels in a given location.
-    pub fn list_backup_channels(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListBackupChannels {
+    pub fn list_backup_channels(&self) -> super::builder::backup_for_gke::ListBackupChannels {
         super::builder::backup_for_gke::ListBackupChannels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single BackupChannel.
-    pub fn get_backup_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetBackupChannel {
+    pub fn get_backup_channel(&self) -> super::builder::backup_for_gke::GetBackupChannel {
         super::builder::backup_for_gke::GetBackupChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a BackupChannel.
@@ -241,12 +210,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup_channel(
-        &self,
-        backup_channel: impl Into<crate::model::BackupChannel>,
-    ) -> super::builder::backup_for_gke::UpdateBackupChannel {
+    pub fn update_backup_channel(&self) -> super::builder::backup_for_gke::UpdateBackupChannel {
         super::builder::backup_for_gke::UpdateBackupChannel::new(self.inner.clone())
-            .set_backup_channel(backup_channel.into())
     }
 
     /// Deletes an existing BackupChannel.
@@ -260,30 +225,20 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteBackupChannel {
+    pub fn delete_backup_channel(&self) -> super::builder::backup_for_gke::DeleteBackupChannel {
         super::builder::backup_for_gke::DeleteBackupChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists BackupPlanBindings in a given location.
     pub fn list_backup_plan_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::backup_for_gke::ListBackupPlanBindings {
         super::builder::backup_for_gke::ListBackupPlanBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single BackupPlanBinding.
-    pub fn get_backup_plan_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetBackupPlanBinding {
+    pub fn get_backup_plan_binding(&self) -> super::builder::backup_for_gke::GetBackupPlanBinding {
         super::builder::backup_for_gke::GetBackupPlanBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Backup for the given BackupPlan.
@@ -297,29 +252,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::backup_for_gke::CreateBackup {
         super::builder::backup_for_gke::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the Backups for a given BackupPlan.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListBackups {
+    pub fn list_backups(&self) -> super::builder::backup_for_gke::ListBackups {
         super::builder::backup_for_gke::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single Backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetBackup {
-        super::builder::backup_for_gke::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::backup_for_gke::GetBackup {
+        super::builder::backup_for_gke::GetBackup::new(self.inner.clone())
     }
 
     /// Update a Backup.
@@ -333,12 +277,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::backup_for_gke::UpdateBackup {
+    pub fn update_backup(&self) -> super::builder::backup_for_gke::UpdateBackup {
         super::builder::backup_for_gke::UpdateBackup::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Deletes an existing Backup.
@@ -352,29 +292,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteBackup {
-        super::builder::backup_for_gke::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::backup_for_gke::DeleteBackup {
+        super::builder::backup_for_gke::DeleteBackup::new(self.inner.clone())
     }
 
     /// Lists the VolumeBackups for a given Backup.
-    pub fn list_volume_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListVolumeBackups {
+    pub fn list_volume_backups(&self) -> super::builder::backup_for_gke::ListVolumeBackups {
         super::builder::backup_for_gke::ListVolumeBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single VolumeBackup.
-    pub fn get_volume_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetVolumeBackup {
+    pub fn get_volume_backup(&self) -> super::builder::backup_for_gke::GetVolumeBackup {
         super::builder::backup_for_gke::GetVolumeBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new RestorePlan in a given location.
@@ -388,30 +317,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_restore_plan(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateRestorePlan {
+    pub fn create_restore_plan(&self) -> super::builder::backup_for_gke::CreateRestorePlan {
         super::builder::backup_for_gke::CreateRestorePlan::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists RestorePlans in a given location.
-    pub fn list_restore_plans(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListRestorePlans {
+    pub fn list_restore_plans(&self) -> super::builder::backup_for_gke::ListRestorePlans {
         super::builder::backup_for_gke::ListRestorePlans::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single RestorePlan.
-    pub fn get_restore_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetRestorePlan {
+    pub fn get_restore_plan(&self) -> super::builder::backup_for_gke::GetRestorePlan {
         super::builder::backup_for_gke::GetRestorePlan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a RestorePlan.
@@ -425,12 +342,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_restore_plan(
-        &self,
-        restore_plan: impl Into<crate::model::RestorePlan>,
-    ) -> super::builder::backup_for_gke::UpdateRestorePlan {
+    pub fn update_restore_plan(&self) -> super::builder::backup_for_gke::UpdateRestorePlan {
         super::builder::backup_for_gke::UpdateRestorePlan::new(self.inner.clone())
-            .set_restore_plan(restore_plan.into())
     }
 
     /// Deletes an existing RestorePlan.
@@ -444,12 +357,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_restore_plan(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteRestorePlan {
+    pub fn delete_restore_plan(&self) -> super::builder::backup_for_gke::DeleteRestorePlan {
         super::builder::backup_for_gke::DeleteRestorePlan::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new RestoreChannel in a given location.
@@ -463,30 +372,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_restore_channel(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateRestoreChannel {
+    pub fn create_restore_channel(&self) -> super::builder::backup_for_gke::CreateRestoreChannel {
         super::builder::backup_for_gke::CreateRestoreChannel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists RestoreChannels in a given location.
-    pub fn list_restore_channels(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListRestoreChannels {
+    pub fn list_restore_channels(&self) -> super::builder::backup_for_gke::ListRestoreChannels {
         super::builder::backup_for_gke::ListRestoreChannels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single RestoreChannel.
-    pub fn get_restore_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetRestoreChannel {
+    pub fn get_restore_channel(&self) -> super::builder::backup_for_gke::GetRestoreChannel {
         super::builder::backup_for_gke::GetRestoreChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a RestoreChannel.
@@ -500,12 +397,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_restore_channel(
-        &self,
-        restore_channel: impl Into<crate::model::RestoreChannel>,
-    ) -> super::builder::backup_for_gke::UpdateRestoreChannel {
+    pub fn update_restore_channel(&self) -> super::builder::backup_for_gke::UpdateRestoreChannel {
         super::builder::backup_for_gke::UpdateRestoreChannel::new(self.inner.clone())
-            .set_restore_channel(restore_channel.into())
     }
 
     /// Deletes an existing RestoreChannel.
@@ -519,30 +412,22 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_restore_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteRestoreChannel {
+    pub fn delete_restore_channel(&self) -> super::builder::backup_for_gke::DeleteRestoreChannel {
         super::builder::backup_for_gke::DeleteRestoreChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists RestorePlanBindings in a given location.
     pub fn list_restore_plan_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::backup_for_gke::ListRestorePlanBindings {
         super::builder::backup_for_gke::ListRestorePlanBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single RestorePlanBinding.
     pub fn get_restore_plan_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::backup_for_gke::GetRestorePlanBinding {
         super::builder::backup_for_gke::GetRestorePlanBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Restore for the given RestorePlan.
@@ -556,29 +441,18 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_restore(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CreateRestore {
+    pub fn create_restore(&self) -> super::builder::backup_for_gke::CreateRestore {
         super::builder::backup_for_gke::CreateRestore::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the Restores for a given RestorePlan.
-    pub fn list_restores(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListRestores {
+    pub fn list_restores(&self) -> super::builder::backup_for_gke::ListRestores {
         super::builder::backup_for_gke::ListRestores::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the details of a single Restore.
-    pub fn get_restore(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetRestore {
-        super::builder::backup_for_gke::GetRestore::new(self.inner.clone()).set_name(name.into())
+    pub fn get_restore(&self) -> super::builder::backup_for_gke::GetRestore {
+        super::builder::backup_for_gke::GetRestore::new(self.inner.clone())
     }
 
     /// Update a Restore.
@@ -592,12 +466,8 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_restore(
-        &self,
-        restore: impl Into<crate::model::Restore>,
-    ) -> super::builder::backup_for_gke::UpdateRestore {
+    pub fn update_restore(&self) -> super::builder::backup_for_gke::UpdateRestore {
         super::builder::backup_for_gke::UpdateRestore::new(self.inner.clone())
-            .set_restore(restore.into())
     }
 
     /// Deletes an existing Restore.
@@ -611,54 +481,35 @@ impl BackupForGKE {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_restore(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteRestore {
-        super::builder::backup_for_gke::DeleteRestore::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_restore(&self) -> super::builder::backup_for_gke::DeleteRestore {
+        super::builder::backup_for_gke::DeleteRestore::new(self.inner.clone())
     }
 
     /// Lists the VolumeRestores for a given Restore.
-    pub fn list_volume_restores(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListVolumeRestores {
+    pub fn list_volume_restores(&self) -> super::builder::backup_for_gke::ListVolumeRestores {
         super::builder::backup_for_gke::ListVolumeRestores::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieve the details of a single VolumeRestore.
-    pub fn get_volume_restore(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetVolumeRestore {
+    pub fn get_volume_restore(&self) -> super::builder::backup_for_gke::GetVolumeRestore {
         super::builder::backup_for_gke::GetVolumeRestore::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieve the link to the backupIndex.
     pub fn get_backup_index_download_url(
         &self,
-        backup: impl Into<std::string::String>,
     ) -> super::builder::backup_for_gke::GetBackupIndexDownloadUrl {
         super::builder::backup_for_gke::GetBackupIndexDownloadUrl::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListLocations {
-        super::builder::backup_for_gke::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::backup_for_gke::ListLocations {
+        super::builder::backup_for_gke::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetLocation {
-        super::builder::backup_for_gke::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::backup_for_gke::GetLocation {
+        super::builder::backup_for_gke::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -666,22 +517,14 @@ impl BackupForGKE {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::backup_for_gke::SetIamPolicy {
         super::builder::backup_for_gke::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::backup_for_gke::GetIamPolicy {
         super::builder::backup_for_gke::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -691,54 +534,35 @@ impl BackupForGKE {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::backup_for_gke::TestIamPermissions {
         super::builder::backup_for_gke::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::ListOperations {
+    pub fn list_operations(&self) -> super::builder::backup_for_gke::ListOperations {
         super::builder::backup_for_gke::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::GetOperation {
-        super::builder::backup_for_gke::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::backup_for_gke::GetOperation {
+        super::builder::backup_for_gke::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::backup_for_gke::DeleteOperation {
         super::builder::backup_for_gke::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::backup_for_gke::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::backup_for_gke::CancelOperation {
         super::builder::backup_for_gke::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_plan
+            let arg = &req
+                .backup_plan
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_plan"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_plan.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -271,10 +276,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_channel
+            let arg = &req
+                .backup_channel
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_channel"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_channel.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -468,10 +478,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -664,10 +679,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.restore_plan
+            let arg = &req
+                .restore_plan
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("restore_plan"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("restore_plan.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -806,10 +826,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.restore_channel
+            let arg = &req
+                .restore_channel
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("restore_channel"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("restore_channel.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1003,10 +1028,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.restore
+            let arg = &req
+                .restore
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("restore"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("restore.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupPlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupPlans", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +73,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupPlansResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupPlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupPlans", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,9 +103,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupPlan>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_plan
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_plan"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_plan
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_plan"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,12 +187,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupChannels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupChannels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,12 +214,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupChannelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupChannels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupChannels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -217,9 +244,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,18 +270,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_channel
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_channel"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_channel
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_channel"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +301,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,12 +329,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupPlanBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupPlanBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupPlanBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -317,9 +359,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupPlanBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -336,9 +385,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -354,9 +410,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -378,9 +441,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,18 +467,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,9 +496,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -450,12 +524,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVolumeBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/volumeBackups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/volumeBackups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,9 +554,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VolumeBackup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -495,12 +580,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/restorePlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/restorePlans", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -518,12 +607,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRestorePlansResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/restorePlans", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/restorePlans", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -544,9 +637,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RestorePlan>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,18 +663,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.restore_plan
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("restore_plan"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.restore_plan
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("restore_plan"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -597,9 +694,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -618,12 +722,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/restoreChannels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/restoreChannels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -641,12 +749,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRestoreChannelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/restoreChannels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/restoreChannels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,9 +779,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RestoreChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -686,18 +805,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.restore_channel
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("restore_channel"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.restore_channel
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("restore_channel"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -720,9 +836,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -740,12 +863,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRestorePlanBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/restorePlanBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/restorePlanBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -766,9 +893,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RestorePlanBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -785,12 +919,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/restores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/restores", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -808,9 +946,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRestoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/restores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/restores", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -831,9 +976,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Restore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -850,18 +1002,15 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.restore
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("restore"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.restore
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("restore"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -884,9 +1033,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -905,12 +1061,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVolumeRestoresResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/volumeRestores", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/volumeRestores", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -931,9 +1091,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VolumeRestore>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -950,12 +1117,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetBackupIndexDownloadUrlResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getBackupIndexDownloadUrl", {
+            let arg = &req.backup;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getBackupIndexDownloadUrl", req.backup),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -972,9 +1143,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -994,9 +1172,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1013,12 +1198,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1033,12 +1222,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1065,12 +1258,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1085,9 +1282,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1107,9 +1311,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1126,9 +1337,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1149,9 +1367,16 @@ impl super::stub::BackupForGKE for BackupForGKE {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
@@ -120,11 +120,7 @@ impl GatewayControl {
 
     /// GenerateCredentials provides connection information that allows a user to
     /// access the specified membership using Connect Gateway.
-    pub fn generate_credentials(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gateway_control::GenerateCredentials {
+    pub fn generate_credentials(&self) -> super::builder::gateway_control::GenerateCredentials {
         super::builder::gateway_control::GenerateCredentials::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::GatewayControl for GatewayControl {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateCredentialsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateCredentials", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateCredentials", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/gkehub/v1/src/client.rs
+++ b/src/generated/cloud/gkehub/v1/src/client.rs
@@ -138,35 +138,23 @@ impl GkeHub {
     }
 
     /// Lists Memberships in a given project and location.
-    pub fn list_memberships(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::ListMemberships {
-        super::builder::gke_hub::ListMemberships::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_memberships(&self) -> super::builder::gke_hub::ListMemberships {
+        super::builder::gke_hub::ListMemberships::new(self.inner.clone())
     }
 
     /// Lists Features in a given project and location.
-    pub fn list_features(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::ListFeatures {
-        super::builder::gke_hub::ListFeatures::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_features(&self) -> super::builder::gke_hub::ListFeatures {
+        super::builder::gke_hub::ListFeatures::new(self.inner.clone())
     }
 
     /// Gets the details of a Membership.
-    pub fn get_membership(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::GetMembership {
-        super::builder::gke_hub::GetMembership::new(self.inner.clone()).set_name(name.into())
+    pub fn get_membership(&self) -> super::builder::gke_hub::GetMembership {
+        super::builder::gke_hub::GetMembership::new(self.inner.clone())
     }
 
     /// Gets details of a single Feature.
-    pub fn get_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::GetFeature {
-        super::builder::gke_hub::GetFeature::new(self.inner.clone()).set_name(name.into())
+    pub fn get_feature(&self) -> super::builder::gke_hub::GetFeature {
+        super::builder::gke_hub::GetFeature::new(self.inner.clone())
     }
 
     /// Creates a new Membership.
@@ -184,11 +172,8 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_membership(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::CreateMembership {
-        super::builder::gke_hub::CreateMembership::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_membership(&self) -> super::builder::gke_hub::CreateMembership {
+        super::builder::gke_hub::CreateMembership::new(self.inner.clone())
     }
 
     /// Adds a new Feature.
@@ -202,11 +187,8 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_feature(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::CreateFeature {
-        super::builder::gke_hub::CreateFeature::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_feature(&self) -> super::builder::gke_hub::CreateFeature {
+        super::builder::gke_hub::CreateFeature::new(self.inner.clone())
     }
 
     /// Removes a Membership.
@@ -224,11 +206,8 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_membership(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::DeleteMembership {
-        super::builder::gke_hub::DeleteMembership::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_membership(&self) -> super::builder::gke_hub::DeleteMembership {
+        super::builder::gke_hub::DeleteMembership::new(self.inner.clone())
     }
 
     /// Removes a Feature.
@@ -242,11 +221,8 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::DeleteFeature {
-        super::builder::gke_hub::DeleteFeature::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_feature(&self) -> super::builder::gke_hub::DeleteFeature {
+        super::builder::gke_hub::DeleteFeature::new(self.inner.clone())
     }
 
     /// Updates an existing Membership.
@@ -260,11 +236,8 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_membership(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::UpdateMembership {
-        super::builder::gke_hub::UpdateMembership::new(self.inner.clone()).set_name(name.into())
+    pub fn update_membership(&self) -> super::builder::gke_hub::UpdateMembership {
+        super::builder::gke_hub::UpdateMembership::new(self.inner.clone())
     }
 
     /// Updates an existing Feature.
@@ -278,62 +251,43 @@ impl GkeHub {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_feature(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::UpdateFeature {
-        super::builder::gke_hub::UpdateFeature::new(self.inner.clone()).set_name(name.into())
+    pub fn update_feature(&self) -> super::builder::gke_hub::UpdateFeature {
+        super::builder::gke_hub::UpdateFeature::new(self.inner.clone())
     }
 
     /// Generates the manifest for deployment of the GKE connect agent.
     ///
     /// **This method is used internally by Google-provided libraries.**
     /// Most clients should not need to call this method directly.
-    pub fn generate_connect_manifest(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::GenerateConnectManifest {
+    pub fn generate_connect_manifest(&self) -> super::builder::gke_hub::GenerateConnectManifest {
         super::builder::gke_hub::GenerateConnectManifest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::ListOperations {
-        super::builder::gke_hub::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::gke_hub::ListOperations {
+        super::builder::gke_hub::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::GetOperation {
-        super::builder::gke_hub::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::gke_hub::GetOperation {
+        super::builder::gke_hub::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::DeleteOperation {
-        super::builder::gke_hub::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::gke_hub::DeleteOperation {
+        super::builder::gke_hub::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::gke_hub::CancelOperation {
-        super::builder::gke_hub::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::gke_hub::CancelOperation {
+        super::builder::gke_hub::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/transport.rs
+++ b/src/generated/cloud/gkehub/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMembershipsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/memberships", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/memberships", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFeaturesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/features", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,9 +106,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Membership>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,9 +132,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Feature>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,12 +158,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/memberships", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/memberships", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -157,12 +186,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/features", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/features", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -181,9 +214,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,9 +242,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -223,9 +270,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -249,9 +303,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,12 +336,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateConnectManifestResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateConnectManifest", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateConnectManifest", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -303,9 +368,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -325,9 +397,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -344,9 +423,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -367,9 +453,16 @@ impl super::stub::GkeHub for GkeHub {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/gkemulticloud/v1/src/client.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/client.rs
@@ -144,10 +144,8 @@ impl AttachedClusters {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_attached_cluster(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::CreateAttachedCluster {
         super::builder::attached_clusters::CreateAttachedCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an
@@ -166,10 +164,8 @@ impl AttachedClusters {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_attached_cluster(
         &self,
-        attached_cluster: impl Into<crate::model::AttachedCluster>,
     ) -> super::builder::attached_clusters::UpdateAttachedCluster {
         super::builder::attached_clusters::UpdateAttachedCluster::new(self.inner.clone())
-            .set_attached_cluster(attached_cluster.into())
     }
 
     /// Imports creates a new
@@ -197,22 +193,16 @@ impl AttachedClusters {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_attached_cluster(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::ImportAttachedCluster {
         super::builder::attached_clusters::ImportAttachedCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Describes a specific
     /// [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AttachedCluster]: crate::model::AttachedCluster
-    pub fn get_attached_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::attached_clusters::GetAttachedCluster {
+    pub fn get_attached_cluster(&self) -> super::builder::attached_clusters::GetAttachedCluster {
         super::builder::attached_clusters::GetAttachedCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster]
@@ -221,10 +211,8 @@ impl AttachedClusters {
     /// [google.cloud.gkemulticloud.v1.AttachedCluster]: crate::model::AttachedCluster
     pub fn list_attached_clusters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::ListAttachedClusters {
         super::builder::attached_clusters::ListAttachedClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific
@@ -248,86 +236,62 @@ impl AttachedClusters {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_attached_cluster(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::DeleteAttachedCluster {
         super::builder::attached_clusters::DeleteAttachedCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns information, such as supported Kubernetes versions, on a given
     /// Google Cloud location.
     pub fn get_attached_server_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::GetAttachedServerConfig {
         super::builder::attached_clusters::GetAttachedServerConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates the install manifest to be installed on the target cluster.
     pub fn generate_attached_cluster_install_manifest(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::GenerateAttachedClusterInstallManifest {
         super::builder::attached_clusters::GenerateAttachedClusterInstallManifest::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Generates an access token for a cluster agent.
     pub fn generate_attached_cluster_agent_token(
         &self,
-        attached_cluster: impl Into<std::string::String>,
     ) -> super::builder::attached_clusters::GenerateAttachedClusterAgentToken {
         super::builder::attached_clusters::GenerateAttachedClusterAgentToken::new(
             self.inner.clone(),
         )
-        .set_attached_cluster(attached_cluster.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::attached_clusters::ListOperations {
+    pub fn list_operations(&self) -> super::builder::attached_clusters::ListOperations {
         super::builder::attached_clusters::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::attached_clusters::GetOperation {
+    pub fn get_operation(&self) -> super::builder::attached_clusters::GetOperation {
         super::builder::attached_clusters::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::attached_clusters::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::attached_clusters::DeleteOperation {
         super::builder::attached_clusters::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::attached_clusters::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::attached_clusters::CancelOperation {
         super::builder::attached_clusters::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -451,12 +415,8 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_aws_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::CreateAwsCluster {
+    pub fn create_aws_cluster(&self) -> super::builder::aws_clusters::CreateAwsCluster {
         super::builder::aws_clusters::CreateAwsCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster].
@@ -472,35 +432,24 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_aws_cluster(
-        &self,
-        aws_cluster: impl Into<crate::model::AwsCluster>,
-    ) -> super::builder::aws_clusters::UpdateAwsCluster {
+    pub fn update_aws_cluster(&self) -> super::builder::aws_clusters::UpdateAwsCluster {
         super::builder::aws_clusters::UpdateAwsCluster::new(self.inner.clone())
-            .set_aws_cluster(aws_cluster.into())
     }
 
     /// Describes a specific [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster]
     /// resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
-    pub fn get_aws_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetAwsCluster {
-        super::builder::aws_clusters::GetAwsCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn get_aws_cluster(&self) -> super::builder::aws_clusters::GetAwsCluster {
+        super::builder::aws_clusters::GetAwsCluster::new(self.inner.clone())
     }
 
     /// Lists all [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resources
     /// on a given Google Cloud project and region.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
-    pub fn list_aws_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::ListAwsClusters {
+    pub fn list_aws_clusters(&self) -> super::builder::aws_clusters::ListAwsClusters {
         super::builder::aws_clusters::ListAwsClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster]
@@ -526,21 +475,15 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_aws_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::DeleteAwsCluster {
+    pub fn delete_aws_cluster(&self) -> super::builder::aws_clusters::DeleteAwsCluster {
         super::builder::aws_clusters::DeleteAwsCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates an access token for a cluster agent.
     pub fn generate_aws_cluster_agent_token(
         &self,
-        aws_cluster: impl Into<std::string::String>,
     ) -> super::builder::aws_clusters::GenerateAwsClusterAgentToken {
         super::builder::aws_clusters::GenerateAwsClusterAgentToken::new(self.inner.clone())
-            .set_aws_cluster(aws_cluster.into())
     }
 
     /// Generates a short-lived access token to authenticate to a given
@@ -549,10 +492,8 @@ impl AwsClusters {
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
     pub fn generate_aws_access_token(
         &self,
-        aws_cluster: impl Into<std::string::String>,
     ) -> super::builder::aws_clusters::GenerateAwsAccessToken {
         super::builder::aws_clusters::GenerateAwsAccessToken::new(self.inner.clone())
-            .set_aws_cluster(aws_cluster.into())
     }
 
     /// Creates a new [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool],
@@ -575,12 +516,8 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_aws_node_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::CreateAwsNodePool {
+    pub fn create_aws_node_pool(&self) -> super::builder::aws_clusters::CreateAwsNodePool {
         super::builder::aws_clusters::CreateAwsNodePool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool].
@@ -596,12 +533,8 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_aws_node_pool(
-        &self,
-        aws_node_pool: impl Into<crate::model::AwsNodePool>,
-    ) -> super::builder::aws_clusters::UpdateAwsNodePool {
+    pub fn update_aws_node_pool(&self) -> super::builder::aws_clusters::UpdateAwsNodePool {
         super::builder::aws_clusters::UpdateAwsNodePool::new(self.inner.clone())
-            .set_aws_node_pool(aws_node_pool.into())
     }
 
     /// Rolls back a previously aborted or failed
@@ -624,21 +557,16 @@ impl AwsClusters {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn rollback_aws_node_pool_update(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::aws_clusters::RollbackAwsNodePoolUpdate {
         super::builder::aws_clusters::RollbackAwsNodePoolUpdate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Describes a specific
     /// [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsNodePool]: crate::model::AwsNodePool
-    pub fn get_aws_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetAwsNodePool {
-        super::builder::aws_clusters::GetAwsNodePool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_aws_node_pool(&self) -> super::builder::aws_clusters::GetAwsNodePool {
+        super::builder::aws_clusters::GetAwsNodePool::new(self.inner.clone())
     }
 
     /// Lists all [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool]
@@ -647,12 +575,8 @@ impl AwsClusters {
     ///
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
     /// [google.cloud.gkemulticloud.v1.AwsNodePool]: crate::model::AwsNodePool
-    pub fn list_aws_node_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::ListAwsNodePools {
+    pub fn list_aws_node_pools(&self) -> super::builder::aws_clusters::ListAwsNodePools {
         super::builder::aws_clusters::ListAwsNodePools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool]
@@ -674,12 +598,8 @@ impl AwsClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_aws_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::DeleteAwsNodePool {
+    pub fn delete_aws_node_pool(&self) -> super::builder::aws_clusters::DeleteAwsNodePool {
         super::builder::aws_clusters::DeleteAwsNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the OIDC discovery document for the cluster.
@@ -687,72 +607,48 @@ impl AwsClusters {
     /// [OpenID Connect Discovery 1.0
     /// specification](https://openid.net/specs/openid-connect-discovery-1_0.html)
     /// for details.
-    pub fn get_aws_open_id_config(
-        &self,
-        aws_cluster: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetAwsOpenIdConfig {
+    pub fn get_aws_open_id_config(&self) -> super::builder::aws_clusters::GetAwsOpenIdConfig {
         super::builder::aws_clusters::GetAwsOpenIdConfig::new(self.inner.clone())
-            .set_aws_cluster(aws_cluster.into())
     }
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
-    pub fn get_aws_json_web_keys(
-        &self,
-        aws_cluster: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetAwsJsonWebKeys {
+    pub fn get_aws_json_web_keys(&self) -> super::builder::aws_clusters::GetAwsJsonWebKeys {
         super::builder::aws_clusters::GetAwsJsonWebKeys::new(self.inner.clone())
-            .set_aws_cluster(aws_cluster.into())
     }
 
     /// Returns information, such as supported AWS regions and Kubernetes
     /// versions, on a given Google Cloud location.
-    pub fn get_aws_server_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetAwsServerConfig {
+    pub fn get_aws_server_config(&self) -> super::builder::aws_clusters::GetAwsServerConfig {
         super::builder::aws_clusters::GetAwsServerConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::ListOperations {
-        super::builder::aws_clusters::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::aws_clusters::ListOperations {
+        super::builder::aws_clusters::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::GetOperation {
-        super::builder::aws_clusters::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::aws_clusters::GetOperation {
+        super::builder::aws_clusters::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::DeleteOperation {
-        super::builder::aws_clusters::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::aws_clusters::DeleteOperation {
+        super::builder::aws_clusters::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::aws_clusters::CancelOperation {
-        super::builder::aws_clusters::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::aws_clusters::CancelOperation {
+        super::builder::aws_clusters::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -880,36 +776,24 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_azure_client(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::CreateAzureClient {
+    pub fn create_azure_client(&self) -> super::builder::azure_clusters::CreateAzureClient {
         super::builder::azure_clusters::CreateAzureClient::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Describes a specific
     /// [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureClient]: crate::model::AzureClient
-    pub fn get_azure_client(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureClient {
+    pub fn get_azure_client(&self) -> super::builder::azure_clusters::GetAzureClient {
         super::builder::azure_clusters::GetAzureClient::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all [AzureClient][google.cloud.gkemulticloud.v1.AzureClient]
     /// resources on a given Google Cloud project and region.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureClient]: crate::model::AzureClient
-    pub fn list_azure_clients(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::ListAzureClients {
+    pub fn list_azure_clients(&self) -> super::builder::azure_clusters::ListAzureClients {
         super::builder::azure_clusters::ListAzureClients::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific [AzureClient][google.cloud.gkemulticloud.v1.AzureClient]
@@ -934,12 +818,8 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_azure_client(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::DeleteAzureClient {
+    pub fn delete_azure_client(&self) -> super::builder::azure_clusters::DeleteAzureClient {
         super::builder::azure_clusters::DeleteAzureClient::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster]
@@ -961,12 +841,8 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_azure_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::CreateAzureCluster {
+    pub fn create_azure_cluster(&self) -> super::builder::azure_clusters::CreateAzureCluster {
         super::builder::azure_clusters::CreateAzureCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster].
@@ -982,36 +858,24 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_azure_cluster(
-        &self,
-        azure_cluster: impl Into<crate::model::AzureCluster>,
-    ) -> super::builder::azure_clusters::UpdateAzureCluster {
+    pub fn update_azure_cluster(&self) -> super::builder::azure_clusters::UpdateAzureCluster {
         super::builder::azure_clusters::UpdateAzureCluster::new(self.inner.clone())
-            .set_azure_cluster(azure_cluster.into())
     }
 
     /// Describes a specific
     /// [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
-    pub fn get_azure_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureCluster {
+    pub fn get_azure_cluster(&self) -> super::builder::azure_clusters::GetAzureCluster {
         super::builder::azure_clusters::GetAzureCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster]
     /// resources on a given Google Cloud project and region.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
-    pub fn list_azure_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::ListAzureClusters {
+    pub fn list_azure_clusters(&self) -> super::builder::azure_clusters::ListAzureClusters {
         super::builder::azure_clusters::ListAzureClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific
@@ -1037,21 +901,15 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_azure_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::DeleteAzureCluster {
+    pub fn delete_azure_cluster(&self) -> super::builder::azure_clusters::DeleteAzureCluster {
         super::builder::azure_clusters::DeleteAzureCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates an access token for a cluster agent.
     pub fn generate_azure_cluster_agent_token(
         &self,
-        azure_cluster: impl Into<std::string::String>,
     ) -> super::builder::azure_clusters::GenerateAzureClusterAgentToken {
         super::builder::azure_clusters::GenerateAzureClusterAgentToken::new(self.inner.clone())
-            .set_azure_cluster(azure_cluster.into())
     }
 
     /// Generates a short-lived access token to authenticate to a given
@@ -1060,10 +918,8 @@ impl AzureClusters {
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
     pub fn generate_azure_access_token(
         &self,
-        azure_cluster: impl Into<std::string::String>,
     ) -> super::builder::azure_clusters::GenerateAzureAccessToken {
         super::builder::azure_clusters::GenerateAzureAccessToken::new(self.inner.clone())
-            .set_azure_cluster(azure_cluster.into())
     }
 
     /// Creates a new [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool],
@@ -1087,12 +943,8 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_azure_node_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::CreateAzureNodePool {
+    pub fn create_azure_node_pool(&self) -> super::builder::azure_clusters::CreateAzureNodePool {
         super::builder::azure_clusters::CreateAzureNodePool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool].
@@ -1108,24 +960,16 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_azure_node_pool(
-        &self,
-        azure_node_pool: impl Into<crate::model::AzureNodePool>,
-    ) -> super::builder::azure_clusters::UpdateAzureNodePool {
+    pub fn update_azure_node_pool(&self) -> super::builder::azure_clusters::UpdateAzureNodePool {
         super::builder::azure_clusters::UpdateAzureNodePool::new(self.inner.clone())
-            .set_azure_node_pool(azure_node_pool.into())
     }
 
     /// Describes a specific
     /// [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureNodePool]: crate::model::AzureNodePool
-    pub fn get_azure_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureNodePool {
+    pub fn get_azure_node_pool(&self) -> super::builder::azure_clusters::GetAzureNodePool {
         super::builder::azure_clusters::GetAzureNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool]
@@ -1134,12 +978,8 @@ impl AzureClusters {
     ///
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
     /// [google.cloud.gkemulticloud.v1.AzureNodePool]: crate::model::AzureNodePool
-    pub fn list_azure_node_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::ListAzureNodePools {
+    pub fn list_azure_node_pools(&self) -> super::builder::azure_clusters::ListAzureNodePools {
         super::builder::azure_clusters::ListAzureNodePools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a specific
@@ -1161,12 +1001,8 @@ impl AzureClusters {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_azure_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::DeleteAzureNodePool {
+    pub fn delete_azure_node_pool(&self) -> super::builder::azure_clusters::DeleteAzureNodePool {
         super::builder::azure_clusters::DeleteAzureNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the OIDC discovery document for the cluster.
@@ -1174,74 +1010,47 @@ impl AzureClusters {
     /// [OpenID Connect Discovery 1.0
     /// specification](https://openid.net/specs/openid-connect-discovery-1_0.html)
     /// for details.
-    pub fn get_azure_open_id_config(
-        &self,
-        azure_cluster: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureOpenIdConfig {
+    pub fn get_azure_open_id_config(&self) -> super::builder::azure_clusters::GetAzureOpenIdConfig {
         super::builder::azure_clusters::GetAzureOpenIdConfig::new(self.inner.clone())
-            .set_azure_cluster(azure_cluster.into())
     }
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
-    pub fn get_azure_json_web_keys(
-        &self,
-        azure_cluster: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureJsonWebKeys {
+    pub fn get_azure_json_web_keys(&self) -> super::builder::azure_clusters::GetAzureJsonWebKeys {
         super::builder::azure_clusters::GetAzureJsonWebKeys::new(self.inner.clone())
-            .set_azure_cluster(azure_cluster.into())
     }
 
     /// Returns information, such as supported Azure regions and Kubernetes
     /// versions, on a given Google Cloud location.
-    pub fn get_azure_server_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetAzureServerConfig {
+    pub fn get_azure_server_config(&self) -> super::builder::azure_clusters::GetAzureServerConfig {
         super::builder::azure_clusters::GetAzureServerConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::ListOperations {
+    pub fn list_operations(&self) -> super::builder::azure_clusters::ListOperations {
         super::builder::azure_clusters::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::GetOperation {
-        super::builder::azure_clusters::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::azure_clusters::GetOperation {
+        super::builder::azure_clusters::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::azure_clusters::DeleteOperation {
         super::builder::azure_clusters::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::azure_clusters::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::azure_clusters::CancelOperation {
         super::builder::azure_clusters::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attachedClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attachedClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,18 +74,15 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.attached_cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("attached_cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.attached_cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("attached_cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,12 +106,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attachedClusters:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attachedClusters:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -125,9 +130,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttachedCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -144,12 +156,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttachedClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/attachedClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/attachedClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +184,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,9 +214,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttachedServerConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,12 +241,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
     ) -> Result<gax::response::Response<crate::model::GenerateAttachedClusterInstallManifestResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateAttachedClusterInstallManifest", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateAttachedClusterInstallManifest", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,15 +280,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
     ) -> Result<gax::response::Response<crate::model::GenerateAttachedClusterAgentTokenResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateAttachedClusterAgentToken", {
+            let arg = &req.attached_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attached_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/{}:generateAttachedClusterAgentToken",
-                    req.attached_cluster
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -269,9 +304,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,9 +333,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +359,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -333,9 +389,16 @@ impl super::stub::AttachedClusters for AttachedClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -392,12 +455,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/awsClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/awsClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,18 +483,15 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.aws_cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("aws_cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.aws_cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("aws_cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -451,9 +515,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AwsCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,12 +541,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAwsClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/awsClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/awsClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -494,9 +569,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -517,12 +599,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAwsClusterAgentTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateAwsClusterAgentToken", {
+            let arg = &req.aws_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateAwsClusterAgentToken", req.aws_cluster),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -537,12 +623,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAwsAccessTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateAwsAccessToken", {
+            let arg = &req.aws_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateAwsAccessToken", req.aws_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,12 +649,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/awsNodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/awsNodePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -583,18 +677,15 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.aws_node_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("aws_node_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.aws_node_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("aws_node_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -618,9 +709,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rollback", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -635,9 +733,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AwsNodePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -654,12 +759,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAwsNodePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/awsNodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/awsNodePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -678,9 +787,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,12 +817,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AwsOpenIdConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/.well-known/openid-configuration", {
+            let arg = &req.aws_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/.well-known/openid-configuration", req.aws_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -723,12 +843,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AwsJsonWebKeys>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jwks", {
+            let arg = &req.aws_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/jwks", req.aws_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -745,9 +869,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AwsServerConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -764,9 +895,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -786,9 +924,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -805,9 +950,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -828,9 +980,16 @@ impl super::stub::AwsClusters for AwsClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -887,12 +1046,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/azureClients", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/azureClients", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -911,9 +1074,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureClient>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -930,12 +1100,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAzureClientsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/azureClients", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/azureClients", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -954,9 +1128,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -975,12 +1156,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/azureClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/azureClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -999,18 +1184,15 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.azure_cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("azure_cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.azure_cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("azure_cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1034,9 +1216,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1053,12 +1242,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAzureClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/azureClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/azureClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1077,9 +1270,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1100,12 +1300,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAzureClusterAgentTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateAzureClusterAgentToken", {
+            let arg = &req.azure_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateAzureClusterAgentToken", req.azure_cluster),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1120,12 +1324,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAzureAccessTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:generateAzureAccessToken", {
+            let arg = &req.azure_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:generateAzureAccessToken", req.azure_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1142,12 +1350,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/azureNodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/azureNodePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1166,18 +1378,15 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.azure_node_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("azure_node_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.azure_node_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("azure_node_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1201,9 +1410,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureNodePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1220,12 +1436,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAzureNodePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/azureNodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/azureNodePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1244,9 +1464,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1267,12 +1494,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureOpenIdConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/.well-known/openid-configuration", {
+            let arg = &req.azure_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/.well-known/openid-configuration", req.azure_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1289,12 +1520,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureJsonWebKeys>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jwks", {
+            let arg = &req.azure_cluster;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_cluster"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/jwks", req.azure_cluster),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1311,9 +1546,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AzureServerConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1330,9 +1572,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1352,9 +1601,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1371,9 +1627,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1394,9 +1657,16 @@ impl super::stub::AzureClusters for AzureClusters {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -75,10 +75,15 @@ impl super::stub::AttachedClusters for AttachedClusters {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.attached_cluster
+            let arg = &req
+                .attached_cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("attached_cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attached_cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -484,10 +489,15 @@ impl super::stub::AwsClusters for AwsClusters {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.aws_cluster
+            let arg = &req
+                .aws_cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("aws_cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -678,10 +688,15 @@ impl super::stub::AwsClusters for AwsClusters {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.aws_node_pool
+            let arg = &req
+                .aws_node_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("aws_node_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("aws_node_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1185,10 +1200,15 @@ impl super::stub::AzureClusters for AzureClusters {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.azure_cluster
+            let arg = &req
+                .azure_cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("azure_cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1379,10 +1399,15 @@ impl super::stub::AzureClusters for AzureClusters {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.azure_node_pool
+            let arg = &req
+                .azure_node_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("azure_node_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("azure_node_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/gsuiteaddons/v1/src/client.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/client.rs
@@ -146,87 +146,51 @@ impl GSuiteAddOns {
     }
 
     /// Gets the authorization information for deployments in a given project.
-    pub fn get_authorization(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::GetAuthorization {
+    pub fn get_authorization(&self) -> super::builder::g_suite_add_ons::GetAuthorization {
         super::builder::g_suite_add_ons::GetAuthorization::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a deployment with the specified name and configuration.
-    pub fn create_deployment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::CreateDeployment {
+    pub fn create_deployment(&self) -> super::builder::g_suite_add_ons::CreateDeployment {
         super::builder::g_suite_add_ons::CreateDeployment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates or replaces a deployment with the specified name.
-    pub fn replace_deployment(
-        &self,
-        deployment: impl Into<crate::model::Deployment>,
-    ) -> super::builder::g_suite_add_ons::ReplaceDeployment {
+    pub fn replace_deployment(&self) -> super::builder::g_suite_add_ons::ReplaceDeployment {
         super::builder::g_suite_add_ons::ReplaceDeployment::new(self.inner.clone())
-            .set_deployment(deployment.into())
     }
 
     /// Gets the deployment with the specified name.
-    pub fn get_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::GetDeployment {
+    pub fn get_deployment(&self) -> super::builder::g_suite_add_ons::GetDeployment {
         super::builder::g_suite_add_ons::GetDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all deployments in a particular project.
-    pub fn list_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::ListDeployments {
+    pub fn list_deployments(&self) -> super::builder::g_suite_add_ons::ListDeployments {
         super::builder::g_suite_add_ons::ListDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the deployment with the given name.
-    pub fn delete_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::DeleteDeployment {
+    pub fn delete_deployment(&self) -> super::builder::g_suite_add_ons::DeleteDeployment {
         super::builder::g_suite_add_ons::DeleteDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Installs a deployment in developer mode.
     /// See:
     /// <https://developers.google.com/gsuite/add-ons/how-tos/testing-gsuite-addons>.
-    pub fn install_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::InstallDeployment {
+    pub fn install_deployment(&self) -> super::builder::g_suite_add_ons::InstallDeployment {
         super::builder::g_suite_add_ons::InstallDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Uninstalls a developer mode deployment.
     /// See:
     /// <https://developers.google.com/gsuite/add-ons/how-tos/testing-gsuite-addons>.
-    pub fn uninstall_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::UninstallDeployment {
+    pub fn uninstall_deployment(&self) -> super::builder::g_suite_add_ons::UninstallDeployment {
         super::builder::g_suite_add_ons::UninstallDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fetches the install status of a developer mode deployment.
-    pub fn get_install_status(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::g_suite_add_ons::GetInstallStatus {
+    pub fn get_install_status(&self) -> super::builder::g_suite_add_ons::GetInstallStatus {
         super::builder::g_suite_add_ons::GetInstallStatus::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Authorization>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,12 +72,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,18 +99,15 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,9 +124,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,12 +150,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +178,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -183,9 +209,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:install", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:install", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -205,9 +238,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:uninstall", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:uninstall", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -227,9 +267,16 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstallStatus>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -100,10 +100,15 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.deployment
+            let arg = &req
+                .deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/iap/v1/src/client.rs
+++ b/src/generated/cloud/iap/v1/src/client.rs
@@ -126,10 +126,8 @@ impl IdentityAwareProxyAdminService {
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
     pub fn set_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::SetIamPolicy {
         super::builder::identity_aware_proxy_admin_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for an Identity-Aware Proxy protected
@@ -138,10 +136,8 @@ impl IdentityAwareProxyAdminService {
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
     pub fn get_iam_policy(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::GetIamPolicy {
         super::builder::identity_aware_proxy_admin_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the Identity-Aware Proxy protected
@@ -150,44 +146,36 @@ impl IdentityAwareProxyAdminService {
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::TestIamPermissions {
         super::builder::identity_aware_proxy_admin_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Gets the IAP settings on a particular IAP protected resource.
     pub fn get_iap_settings(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::GetIapSettings {
         super::builder::identity_aware_proxy_admin_service::GetIapSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the IAP settings on a particular IAP protected resource. It
     /// replaces all fields unless the `update_mask` is set.
     pub fn update_iap_settings(
         &self,
-        iap_settings: impl Into<crate::model::IapSettings>,
     ) -> super::builder::identity_aware_proxy_admin_service::UpdateIapSettings {
         super::builder::identity_aware_proxy_admin_service::UpdateIapSettings::new(
             self.inner.clone(),
         )
-        .set_iap_settings(iap_settings.into())
     }
 
     /// Validates that a given CEL expression conforms to IAP restrictions.
     pub fn validate_iap_attribute_expression(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::ValidateIapAttributeExpression {
         super::builder::identity_aware_proxy_admin_service::ValidateIapAttributeExpression::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists the existing TunnelDestGroups. To group across all locations, use a
@@ -195,56 +183,46 @@ impl IdentityAwareProxyAdminService {
     /// `/v1/projects/123/iap_tunnel/locations/-/destGroups`
     pub fn list_tunnel_dest_groups(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::ListTunnelDestGroups {
         super::builder::identity_aware_proxy_admin_service::ListTunnelDestGroups::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Creates a new TunnelDestGroup.
     pub fn create_tunnel_dest_group(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::CreateTunnelDestGroup {
         super::builder::identity_aware_proxy_admin_service::CreateTunnelDestGroup::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Retrieves an existing TunnelDestGroup.
     pub fn get_tunnel_dest_group(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::GetTunnelDestGroup {
         super::builder::identity_aware_proxy_admin_service::GetTunnelDestGroup::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Deletes a TunnelDestGroup.
     pub fn delete_tunnel_dest_group(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_admin_service::DeleteTunnelDestGroup {
         super::builder::identity_aware_proxy_admin_service::DeleteTunnelDestGroup::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Updates a TunnelDestGroup.
     pub fn update_tunnel_dest_group(
         &self,
-        tunnel_dest_group: impl Into<crate::model::TunnelDestGroup>,
     ) -> super::builder::identity_aware_proxy_admin_service::UpdateTunnelDestGroup {
         super::builder::identity_aware_proxy_admin_service::UpdateTunnelDestGroup::new(
             self.inner.clone(),
         )
-        .set_tunnel_dest_group(tunnel_dest_group.into())
     }
 }
 
@@ -353,12 +331,8 @@ impl IdentityAwareProxyOAuthService {
     }
 
     /// Lists the existing brands for the project.
-    pub fn list_brands(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::identity_aware_proxy_o_auth_service::ListBrands {
+    pub fn list_brands(&self) -> super::builder::identity_aware_proxy_o_auth_service::ListBrands {
         super::builder::identity_aware_proxy_o_auth_service::ListBrands::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Constructs a new OAuth brand for the project if one does not exist.
@@ -369,21 +343,13 @@ impl IdentityAwareProxyOAuthService {
     /// changed in the Google Cloud Console. Requires that a brand does not already
     /// exist for the project, and that the specified support email is owned by the
     /// caller.
-    pub fn create_brand(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::identity_aware_proxy_o_auth_service::CreateBrand {
+    pub fn create_brand(&self) -> super::builder::identity_aware_proxy_o_auth_service::CreateBrand {
         super::builder::identity_aware_proxy_o_auth_service::CreateBrand::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the OAuth brand of the project.
-    pub fn get_brand(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity_aware_proxy_o_auth_service::GetBrand {
+    pub fn get_brand(&self) -> super::builder::identity_aware_proxy_o_auth_service::GetBrand {
         super::builder::identity_aware_proxy_o_auth_service::GetBrand::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an Identity Aware Proxy (IAP) OAuth client. The client is owned
@@ -391,46 +357,38 @@ impl IdentityAwareProxyOAuthService {
     /// set for internal-only use.
     pub fn create_identity_aware_proxy_client(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_o_auth_service::CreateIdentityAwareProxyClient {
         super::builder::identity_aware_proxy_o_auth_service::CreateIdentityAwareProxyClient::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Lists the existing clients for the brand.
     pub fn list_identity_aware_proxy_clients(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_o_auth_service::ListIdentityAwareProxyClients {
         super::builder::identity_aware_proxy_o_auth_service::ListIdentityAwareProxyClients::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Retrieves an Identity Aware Proxy (IAP) OAuth client.
     /// Requires that the client is owned by IAP.
     pub fn get_identity_aware_proxy_client(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_o_auth_service::GetIdentityAwareProxyClient {
         super::builder::identity_aware_proxy_o_auth_service::GetIdentityAwareProxyClient::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Resets an Identity Aware Proxy (IAP) OAuth client secret. Useful if the
     /// secret was compromised. Requires that the client is owned by IAP.
     pub fn reset_identity_aware_proxy_client_secret(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_o_auth_service::ResetIdentityAwareProxyClientSecret
     {
         super::builder::identity_aware_proxy_o_auth_service::ResetIdentityAwareProxyClientSecret::new(self.inner.clone())
-            .set_name ( name.into() )
     }
 
     /// Deletes an Identity Aware Proxy (IAP) OAuth client. Useful for removing
@@ -438,11 +396,9 @@ impl IdentityAwareProxyOAuthService {
     /// cleaning up after tests. Requires that the client is owned by IAP.
     pub fn delete_identity_aware_proxy_client(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::identity_aware_proxy_o_auth_service::DeleteIdentityAwareProxyClient {
         super::builder::identity_aware_proxy_o_auth_service::DeleteIdentityAwareProxyClient::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 }

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -145,10 +145,15 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
     ) -> Result<gax::response::Response<crate::model::IapSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}:iapSettings", {
-            &req.iap_settings
+            let arg = &req
+                .iap_settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("iap_settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("iap_settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -314,10 +319,15 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
     ) -> Result<gax::response::Response<crate::model::TunnelDestGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tunnel_dest_group
+            let arg = &req
+                .tunnel_dest_group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tunnel_dest_group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tunnel_dest_group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +118,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IapSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:iapSettings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:iapSettings", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -128,18 +144,15 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IapSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:iapSettings", {
+            &req.iap_settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("iap_settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}:iapSettings",
-                    req.iap_settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("iap_settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -162,12 +175,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ValidateIapAttributeExpressionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:validateAttributeExpression", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:validateAttributeExpression", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -185,12 +202,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTunnelDestGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/destGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/destGroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -209,12 +230,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TunnelDestGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/destGroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/destGroups", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -232,9 +257,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TunnelDestGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -251,9 +283,16 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,18 +313,15 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TunnelDestGroup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tunnel_dest_group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tunnel_dest_group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tunnel_dest_group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tunnel_dest_group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -331,9 +367,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBrandsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/brands", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/brands", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -350,9 +393,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Brand>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/brands", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/brands", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -367,9 +417,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Brand>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -386,12 +443,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IdentityAwareProxyClient>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/identityAwareProxyClients", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/identityAwareProxyClients", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -408,12 +469,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIdentityAwareProxyClientsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/identityAwareProxyClients", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/identityAwareProxyClients", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -432,9 +497,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IdentityAwareProxyClient>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -451,12 +523,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::IdentityAwareProxyClient>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetSecret", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetSecret", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +547,16 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/ids/v1/src/client.rs
+++ b/src/generated/cloud/ids/v1/src/client.rs
@@ -117,19 +117,13 @@ impl Ids {
     }
 
     /// Lists Endpoints in a given project and location.
-    pub fn list_endpoints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::ids::ListEndpoints {
-        super::builder::ids::ListEndpoints::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_endpoints(&self) -> super::builder::ids::ListEndpoints {
+        super::builder::ids::ListEndpoints::new(self.inner.clone())
     }
 
     /// Gets details of a single Endpoint.
-    pub fn get_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::GetEndpoint {
-        super::builder::ids::GetEndpoint::new(self.inner.clone()).set_name(name.into())
+    pub fn get_endpoint(&self) -> super::builder::ids::GetEndpoint {
+        super::builder::ids::GetEndpoint::new(self.inner.clone())
     }
 
     /// Creates a new Endpoint in a given project and location.
@@ -143,11 +137,8 @@ impl Ids {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_endpoint(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::ids::CreateEndpoint {
-        super::builder::ids::CreateEndpoint::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_endpoint(&self) -> super::builder::ids::CreateEndpoint {
+        super::builder::ids::CreateEndpoint::new(self.inner.clone())
     }
 
     /// Deletes a single Endpoint.
@@ -161,50 +152,35 @@ impl Ids {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::DeleteEndpoint {
-        super::builder::ids::DeleteEndpoint::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_endpoint(&self) -> super::builder::ids::DeleteEndpoint {
+        super::builder::ids::DeleteEndpoint::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::ListOperations {
-        super::builder::ids::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::ids::ListOperations {
+        super::builder::ids::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::GetOperation {
-        super::builder::ids::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::ids::GetOperation {
+        super::builder::ids::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::DeleteOperation {
-        super::builder::ids::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::ids::DeleteOperation {
+        super::builder::ids::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ids::CancelOperation {
-        super::builder::ids::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::ids::CancelOperation {
+        super::builder::ids::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/ids/v1/src/transport.rs
+++ b/src/generated/cloud/ids/v1/src/transport.rs
@@ -44,12 +44,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEndpointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,9 +128,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,9 +155,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,9 +184,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +210,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +240,16 @@ impl super::stub::Ids for Ids {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/kms/inventory/v1/src/client.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/client.rs
@@ -123,12 +123,8 @@ impl KeyDashboardService {
     /// Returns cryptographic keys managed by Cloud KMS in a given Cloud project.
     /// Note that this data is sourced from snapshots, meaning it may not
     /// completely reflect the actual state of key metadata at call time.
-    pub fn list_crypto_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_dashboard_service::ListCryptoKeys {
+    pub fn list_crypto_keys(&self) -> super::builder::key_dashboard_service::ListCryptoKeys {
         super::builder::key_dashboard_service::ListCryptoKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }
 
@@ -244,10 +240,8 @@ impl KeyTrackingService {
     /// [google.cloud.kms.v1.CryptoKey]: kms::model::CryptoKey
     pub fn get_protected_resources_summary(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::key_tracking_service::GetProtectedResourcesSummary {
         super::builder::key_tracking_service::GetProtectedResourcesSummary::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns metadata about the resources protected by the given Cloud KMS
@@ -256,9 +250,7 @@ impl KeyTrackingService {
     /// [google.cloud.kms.v1.CryptoKey]: kms::model::CryptoKey
     pub fn search_protected_resources(
         &self,
-        scope: impl Into<std::string::String>,
     ) -> super::builder::key_tracking_service::SearchProtectedResources {
         super::builder::key_tracking_service::SearchProtectedResources::new(self.inner.clone())
-            .set_scope(scope.into())
     }
 }

--- a/src/generated/cloud/kms/inventory/v1/src/transport.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::KeyDashboardService for KeyDashboardService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCryptoKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cryptoKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cryptoKeys", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,12 +97,16 @@ impl super::stub::KeyTrackingService for KeyTrackingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProtectedResourcesSummary>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/protectedResourcesSummary", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/protectedResourcesSummary", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,12 +123,16 @@ impl super::stub::KeyTrackingService for KeyTrackingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchProtectedResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/protectedResources:search", {
+            let arg = &req.scope;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scope"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/protectedResources:search", req.scope),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -160,47 +160,32 @@ impl Autokey {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_key_handle(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::autokey::CreateKeyHandle {
-        super::builder::autokey::CreateKeyHandle::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_key_handle(&self) -> super::builder::autokey::CreateKeyHandle {
+        super::builder::autokey::CreateKeyHandle::new(self.inner.clone())
     }
 
     /// Returns the [KeyHandle][google.cloud.kms.v1.KeyHandle].
     ///
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
-    pub fn get_key_handle(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey::GetKeyHandle {
-        super::builder::autokey::GetKeyHandle::new(self.inner.clone()).set_name(name.into())
+    pub fn get_key_handle(&self) -> super::builder::autokey::GetKeyHandle {
+        super::builder::autokey::GetKeyHandle::new(self.inner.clone())
     }
 
     /// Lists [KeyHandles][google.cloud.kms.v1.KeyHandle].
     ///
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
-    pub fn list_key_handles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::autokey::ListKeyHandles {
-        super::builder::autokey::ListKeyHandles::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_key_handles(&self) -> super::builder::autokey::ListKeyHandles {
+        super::builder::autokey::ListKeyHandles::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey::ListLocations {
-        super::builder::autokey::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::autokey::ListLocations {
+        super::builder::autokey::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey::GetLocation {
-        super::builder::autokey::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::autokey::GetLocation {
+        super::builder::autokey::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -208,20 +193,14 @@ impl Autokey {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey::SetIamPolicy {
-        super::builder::autokey::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::autokey::SetIamPolicy {
+        super::builder::autokey::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey::GetIamPolicy {
-        super::builder::autokey::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::autokey::GetIamPolicy {
+        super::builder::autokey::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -231,22 +210,15 @@ impl Autokey {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::autokey::TestIamPermissions {
         super::builder::autokey::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey::GetOperation {
-        super::builder::autokey::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::autokey::GetOperation {
+        super::builder::autokey::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -370,49 +342,33 @@ impl AutokeyAdmin {
     /// [google.cloud.kms.v1.AutokeyConfig]: crate::model::AutokeyConfig
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
-    pub fn update_autokey_config(
-        &self,
-        autokey_config: impl Into<crate::model::AutokeyConfig>,
-    ) -> super::builder::autokey_admin::UpdateAutokeyConfig {
+    pub fn update_autokey_config(&self) -> super::builder::autokey_admin::UpdateAutokeyConfig {
         super::builder::autokey_admin::UpdateAutokeyConfig::new(self.inner.clone())
-            .set_autokey_config(autokey_config.into())
     }
 
     /// Returns the [AutokeyConfig][google.cloud.kms.v1.AutokeyConfig] for a
     /// folder.
     ///
     /// [google.cloud.kms.v1.AutokeyConfig]: crate::model::AutokeyConfig
-    pub fn get_autokey_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::GetAutokeyConfig {
+    pub fn get_autokey_config(&self) -> super::builder::autokey_admin::GetAutokeyConfig {
         super::builder::autokey_admin::GetAutokeyConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the effective Cloud KMS Autokey configuration for a given project.
     pub fn show_effective_autokey_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::autokey_admin::ShowEffectiveAutokeyConfig {
         super::builder::autokey_admin::ShowEffectiveAutokeyConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::ListLocations {
-        super::builder::autokey_admin::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::autokey_admin::ListLocations {
+        super::builder::autokey_admin::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::GetLocation {
-        super::builder::autokey_admin::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::autokey_admin::GetLocation {
+        super::builder::autokey_admin::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -420,22 +376,14 @@ impl AutokeyAdmin {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::autokey_admin::SetIamPolicy {
         super::builder::autokey_admin::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::autokey_admin::GetIamPolicy {
         super::builder::autokey_admin::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -445,22 +393,15 @@ impl AutokeyAdmin {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::autokey_admin::TestIamPermissions {
         super::builder::autokey_admin::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::autokey_admin::GetOperation {
-        super::builder::autokey_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::autokey_admin::GetOperation {
+        super::builder::autokey_admin::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -574,69 +515,47 @@ impl EkmService {
     /// Lists [EkmConnections][google.cloud.kms.v1.EkmConnection].
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-    pub fn list_ekm_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::ListEkmConnections {
+    pub fn list_ekm_connections(&self) -> super::builder::ekm_service::ListEkmConnections {
         super::builder::ekm_service::ListEkmConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns metadata for a given
     /// [EkmConnection][google.cloud.kms.v1.EkmConnection].
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-    pub fn get_ekm_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::GetEkmConnection {
-        super::builder::ekm_service::GetEkmConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn get_ekm_connection(&self) -> super::builder::ekm_service::GetEkmConnection {
+        super::builder::ekm_service::GetEkmConnection::new(self.inner.clone())
     }
 
     /// Creates a new [EkmConnection][google.cloud.kms.v1.EkmConnection] in a given
     /// Project and Location.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-    pub fn create_ekm_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::CreateEkmConnection {
+    pub fn create_ekm_connection(&self) -> super::builder::ekm_service::CreateEkmConnection {
         super::builder::ekm_service::CreateEkmConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [EkmConnection][google.cloud.kms.v1.EkmConnection]'s metadata.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-    pub fn update_ekm_connection(
-        &self,
-        ekm_connection: impl Into<crate::model::EkmConnection>,
-    ) -> super::builder::ekm_service::UpdateEkmConnection {
+    pub fn update_ekm_connection(&self) -> super::builder::ekm_service::UpdateEkmConnection {
         super::builder::ekm_service::UpdateEkmConnection::new(self.inner.clone())
-            .set_ekm_connection(ekm_connection.into())
     }
 
     /// Returns the [EkmConfig][google.cloud.kms.v1.EkmConfig] singleton resource
     /// for a given project and location.
     ///
     /// [google.cloud.kms.v1.EkmConfig]: crate::model::EkmConfig
-    pub fn get_ekm_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::GetEkmConfig {
-        super::builder::ekm_service::GetEkmConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_ekm_config(&self) -> super::builder::ekm_service::GetEkmConfig {
+        super::builder::ekm_service::GetEkmConfig::new(self.inner.clone())
     }
 
     /// Updates the [EkmConfig][google.cloud.kms.v1.EkmConfig] singleton resource
     /// for a given project and location.
     ///
     /// [google.cloud.kms.v1.EkmConfig]: crate::model::EkmConfig
-    pub fn update_ekm_config(
-        &self,
-        ekm_config: impl Into<crate::model::EkmConfig>,
-    ) -> super::builder::ekm_service::UpdateEkmConfig {
+    pub fn update_ekm_config(&self) -> super::builder::ekm_service::UpdateEkmConfig {
         super::builder::ekm_service::UpdateEkmConfig::new(self.inner.clone())
-            .set_ekm_config(ekm_config.into())
     }
 
     /// Verifies that Cloud KMS can successfully connect to the external key
@@ -646,28 +565,18 @@ impl EkmService {
     /// at <https://cloud.google.com/kms/docs/reference/ekm_errors>.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-    pub fn verify_connectivity(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::VerifyConnectivity {
+    pub fn verify_connectivity(&self) -> super::builder::ekm_service::VerifyConnectivity {
         super::builder::ekm_service::VerifyConnectivity::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::ListLocations {
-        super::builder::ekm_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::ekm_service::ListLocations {
+        super::builder::ekm_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::GetLocation {
-        super::builder::ekm_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::ekm_service::GetLocation {
+        super::builder::ekm_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -675,22 +584,14 @@ impl EkmService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::ekm_service::SetIamPolicy {
         super::builder::ekm_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::ekm_service::GetIamPolicy {
         super::builder::ekm_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -700,22 +601,15 @@ impl EkmService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::ekm_service::TestIamPermissions {
         super::builder::ekm_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::ekm_service::GetOperation {
-        super::builder::ekm_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::ekm_service::GetOperation {
+        super::builder::ekm_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -840,23 +734,15 @@ impl KeyManagementService {
     /// Lists [KeyRings][google.cloud.kms.v1.KeyRing].
     ///
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
-    pub fn list_key_rings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::ListKeyRings {
+    pub fn list_key_rings(&self) -> super::builder::key_management_service::ListKeyRings {
         super::builder::key_management_service::ListKeyRings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists [CryptoKeys][google.cloud.kms.v1.CryptoKey].
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-    pub fn list_crypto_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::ListCryptoKeys {
+    pub fn list_crypto_keys(&self) -> super::builder::key_management_service::ListCryptoKeys {
         super::builder::key_management_service::ListCryptoKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].
@@ -864,32 +750,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     pub fn list_crypto_key_versions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::ListCryptoKeyVersions {
         super::builder::key_management_service::ListCryptoKeyVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists [ImportJobs][google.cloud.kms.v1.ImportJob].
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-    pub fn list_import_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::ListImportJobs {
+    pub fn list_import_jobs(&self) -> super::builder::key_management_service::ListImportJobs {
         super::builder::key_management_service::ListImportJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].
     ///
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
-    pub fn get_key_ring(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetKeyRing {
+    pub fn get_key_ring(&self) -> super::builder::key_management_service::GetKeyRing {
         super::builder::key_management_service::GetKeyRing::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey], as
@@ -899,12 +775,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.primary]: crate::model::CryptoKey::primary
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    pub fn get_crypto_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetCryptoKey {
+    pub fn get_crypto_key(&self) -> super::builder::key_management_service::GetCryptoKey {
         super::builder::key_management_service::GetCryptoKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns metadata for a given
@@ -913,10 +785,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     pub fn get_crypto_key_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::GetCryptoKeyVersion {
         super::builder::key_management_service::GetCryptoKeyVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the public key for the given
@@ -930,35 +800,23 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricSign
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    pub fn get_public_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetPublicKey {
+    pub fn get_public_key(&self) -> super::builder::key_management_service::GetPublicKey {
         super::builder::key_management_service::GetPublicKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-    pub fn get_import_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetImportJob {
+    pub fn get_import_job(&self) -> super::builder::key_management_service::GetImportJob {
         super::builder::key_management_service::GetImportJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and
     /// Location.
     ///
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
-    pub fn create_key_ring(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::CreateKeyRing {
+    pub fn create_key_ring(&self) -> super::builder::key_management_service::CreateKeyRing {
         super::builder::key_management_service::CreateKeyRing::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a
@@ -972,12 +830,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm]: crate::model::CryptoKeyVersionTemplate::algorithm
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
-    pub fn create_crypto_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::CreateCryptoKey {
+    pub fn create_crypto_key(&self) -> super::builder::key_management_service::CreateCryptoKey {
         super::builder::key_management_service::CreateCryptoKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a
@@ -993,10 +847,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     pub fn create_crypto_key_version(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::CreateCryptoKeyVersion {
         super::builder::key_management_service::CreateCryptoKeyVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Import wrapped key material into a
@@ -1012,10 +864,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     pub fn import_crypto_key_version(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::ImportCryptoKeyVersion {
         super::builder::key_management_service::ImportCryptoKeyVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a
@@ -1027,23 +877,15 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     /// [google.cloud.kms.v1.ImportJob.import_method]: crate::model::ImportJob::import_method
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
-    pub fn create_import_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::CreateImportJob {
+    pub fn create_import_job(&self) -> super::builder::key_management_service::CreateImportJob {
         super::builder::key_management_service::CreateImportJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-    pub fn update_crypto_key(
-        &self,
-        crypto_key: impl Into<crate::model::CryptoKey>,
-    ) -> super::builder::key_management_service::UpdateCryptoKey {
+    pub fn update_crypto_key(&self) -> super::builder::key_management_service::UpdateCryptoKey {
         super::builder::key_management_service::UpdateCryptoKey::new(self.inner.clone())
-            .set_crypto_key(crypto_key.into())
     }
 
     /// Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s
@@ -1067,10 +909,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     pub fn update_crypto_key_version(
         &self,
-        crypto_key_version: impl Into<crate::model::CryptoKeyVersion>,
     ) -> super::builder::key_management_service::UpdateCryptoKeyVersion {
         super::builder::key_management_service::UpdateCryptoKeyVersion::new(self.inner.clone())
-            .set_crypto_key_version(crypto_key_version.into())
     }
 
     /// Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that
@@ -1085,12 +925,10 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn update_crypto_key_primary_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::UpdateCryptoKeyPrimaryVersion {
         super::builder::key_management_service::UpdateCryptoKeyPrimaryVersion::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for
@@ -1124,10 +962,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
     pub fn destroy_crypto_key_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::DestroyCryptoKeyVersion {
         super::builder::key_management_service::DestroyCryptoKeyVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the
@@ -1147,10 +983,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     pub fn restore_crypto_key_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::RestoreCryptoKeyVersion {
         super::builder::key_management_service::RestoreCryptoKeyVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Encrypts data, so that it can only be recovered by a call to
@@ -1161,12 +995,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
-    pub fn encrypt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::Encrypt {
+    pub fn encrypt(&self) -> super::builder::key_management_service::Encrypt {
         super::builder::key_management_service::Encrypt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Decrypts data that was protected by
@@ -1177,12 +1007,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
-    pub fn decrypt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::Decrypt {
+    pub fn decrypt(&self) -> super::builder::key_management_service::Decrypt {
         super::builder::key_management_service::Decrypt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Encrypts data using portable cryptographic primitives. Most users should
@@ -1196,12 +1022,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
-    pub fn raw_encrypt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::RawEncrypt {
+    pub fn raw_encrypt(&self) -> super::builder::key_management_service::RawEncrypt {
         super::builder::key_management_service::RawEncrypt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Decrypts data that was originally encrypted using a raw cryptographic
@@ -1211,12 +1033,8 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::RawEncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
-    pub fn raw_decrypt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::RawDecrypt {
+    pub fn raw_decrypt(&self) -> super::builder::key_management_service::RawDecrypt {
         super::builder::key_management_service::RawDecrypt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
@@ -1228,12 +1046,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-    pub fn asymmetric_sign(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::AsymmetricSign {
+    pub fn asymmetric_sign(&self) -> super::builder::key_management_service::AsymmetricSign {
         super::builder::key_management_service::AsymmetricSign::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Decrypts data that was encrypted with a public key retrieved from
@@ -1245,12 +1059,8 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-    pub fn asymmetric_decrypt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::AsymmetricDecrypt {
+    pub fn asymmetric_decrypt(&self) -> super::builder::key_management_service::AsymmetricDecrypt {
         super::builder::key_management_service::AsymmetricDecrypt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Signs data using a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]
@@ -1259,12 +1069,8 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    pub fn mac_sign(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::MacSign {
+    pub fn mac_sign(&self) -> super::builder::key_management_service::MacSign {
         super::builder::key_management_service::MacSign::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Verifies MAC tag using a
@@ -1274,40 +1080,26 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    pub fn mac_verify(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::MacVerify {
+    pub fn mac_verify(&self) -> super::builder::key_management_service::MacVerify {
         super::builder::key_management_service::MacVerify::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generate random bytes using the Cloud KMS randomness source in the provided
     /// location.
     pub fn generate_random_bytes(
         &self,
-        location: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::GenerateRandomBytes {
         super::builder::key_management_service::GenerateRandomBytes::new(self.inner.clone())
-            .set_location(location.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::key_management_service::ListLocations {
         super::builder::key_management_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::key_management_service::GetLocation {
         super::builder::key_management_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1315,22 +1107,14 @@ impl KeyManagementService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::key_management_service::SetIamPolicy {
         super::builder::key_management_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::key_management_service::GetIamPolicy {
         super::builder::key_management_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1342,20 +1126,14 @@ impl KeyManagementService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::key_management_service::TestIamPermissions {
         super::builder::key_management_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::key_management_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::key_management_service::GetOperation {
         super::builder::key_management_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -331,10 +331,15 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
     ) -> Result<gax::response::Response<crate::model::AutokeyConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.autokey_config
+            let arg = &req
+                .autokey_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("autokey_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("autokey_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -685,10 +690,15 @@ impl super::stub::EkmService for EkmService {
     ) -> Result<gax::response::Response<crate::model::EkmConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.ekm_connection
+            let arg = &req
+                .ekm_connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("ekm_connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("ekm_connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -742,10 +752,15 @@ impl super::stub::EkmService for EkmService {
     ) -> Result<gax::response::Response<crate::model::EkmConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.ekm_config
+            let arg = &req
+                .ekm_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("ekm_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("ekm_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1375,10 +1390,15 @@ impl super::stub::KeyManagementService for KeyManagementService {
     ) -> Result<gax::response::Response<crate::model::CryptoKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.crypto_key
+            let arg = &req
+                .crypto_key
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("crypto_key"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("crypto_key.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1406,10 +1426,15 @@ impl super::stub::KeyManagementService for KeyManagementService {
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.crypto_key_version
+            let arg = &req
+                .crypto_key_version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("crypto_key_version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("crypto_key_version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/keyHandles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/keyHandles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +73,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KeyHandle>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +99,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKeyHandlesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/keyHandles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/keyHandles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,9 +128,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +157,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -154,12 +183,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +207,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,12 +243,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,9 +267,16 @@ impl super::stub::Autokey for Autokey {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,18 +330,15 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutokeyConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.autokey_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("autokey_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.autokey_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("autokey_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +361,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutokeyConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,12 +387,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ShowEffectiveAutokeyConfigResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:showEffectiveAutokeyConfig", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:showEffectiveAutokeyConfig", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,9 +413,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -379,9 +442,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -398,12 +468,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -418,12 +492,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -450,12 +528,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,9 +552,16 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -512,12 +601,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEkmConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/ekmConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/ekmConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -538,9 +631,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -557,12 +657,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/ekmConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/ekmConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -580,18 +684,15 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.ekm_connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("ekm_connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.ekm_connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("ekm_connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -614,9 +715,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -633,18 +741,15 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EkmConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.ekm_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("ekm_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.ekm_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("ekm_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,12 +772,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyConnectivityResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:verifyConnectivity", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:verifyConnectivity", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -689,9 +798,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -711,9 +827,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -730,12 +853,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -750,12 +877,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -782,12 +913,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -802,9 +937,16 @@ impl super::stub::EkmService for EkmService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -844,9 +986,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKeyRingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/keyRings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/keyRings", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -867,12 +1016,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCryptoKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cryptoKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cryptoKeys", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -894,12 +1047,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCryptoKeyVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cryptoKeyVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cryptoKeyVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -921,12 +1078,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListImportJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/importJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/importJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -947,9 +1108,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KeyRing>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -966,9 +1134,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -985,9 +1160,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1004,9 +1186,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PublicKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/publicKey", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/publicKey", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1024,9 +1213,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1043,12 +1239,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KeyRing>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/keyRings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/keyRings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1066,12 +1266,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cryptoKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cryptoKeys", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1093,12 +1297,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cryptoKeyVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cryptoKeyVersions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1115,12 +1323,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cryptoKeyVersions:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cryptoKeyVersions:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1135,12 +1347,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/importJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/importJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1158,18 +1374,15 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.crypto_key
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("crypto_key"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.crypto_key
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("crypto_key"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1192,18 +1405,15 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.crypto_key_version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("crypto_key_version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.crypto_key_version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("crypto_key_version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1226,12 +1436,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:updatePrimaryVersion", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:updatePrimaryVersion", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1246,9 +1460,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:destroy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:destroy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1263,9 +1484,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CryptoKeyVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1280,9 +1508,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EncryptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:encrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:encrypt", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1297,9 +1532,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DecryptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:decrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:decrypt", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1314,12 +1556,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RawEncryptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rawEncrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rawEncrypt", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1334,12 +1580,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RawDecryptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rawDecrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rawDecrypt", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1354,12 +1604,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AsymmetricSignResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:asymmetricSign", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:asymmetricSign", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1374,12 +1628,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AsymmetricDecryptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:asymmetricDecrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:asymmetricDecrypt", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1394,9 +1652,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MacSignResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:macSign", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:macSign", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1411,9 +1676,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MacVerifyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:macVerify", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:macVerify", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1428,12 +1700,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateRandomBytesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateRandomBytes", {
+            let arg = &req.location;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("location"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateRandomBytes", req.location),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1448,9 +1724,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1470,9 +1753,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1489,12 +1779,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1509,12 +1803,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1541,12 +1839,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1561,9 +1863,16 @@ impl super::stub::KeyManagementService for KeyManagementService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/language/v2/src/transport.rs
+++ b/src/generated/cloud/language/v2/src/transport.rs
@@ -46,12 +46,10 @@ impl super::stub::LanguageService for LanguageService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeSentimentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/documents:analyzeSentiment".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v2/documents:analyzeSentiment".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +64,10 @@ impl super::stub::LanguageService for LanguageService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnalyzeEntitiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/documents:analyzeEntities".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v2/documents:analyzeEntities".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +82,10 @@ impl super::stub::LanguageService for LanguageService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ClassifyTextResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/documents:classifyText".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v2/documents:classifyText".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +100,10 @@ impl super::stub::LanguageService for LanguageService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ModerateTextResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/documents:moderateText".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v2/documents:moderateText".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -126,12 +118,10 @@ impl super::stub::LanguageService for LanguageService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnnotateTextResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/documents:annotateText".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v2/documents:annotateText".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/licensemanager/v1/src/client.rs
+++ b/src/generated/cloud/licensemanager/v1/src/client.rs
@@ -119,21 +119,13 @@ impl LicenseManager {
     }
 
     /// Lists Configurations in a given project and location.
-    pub fn list_configurations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::ListConfigurations {
+    pub fn list_configurations(&self) -> super::builder::license_manager::ListConfigurations {
         super::builder::license_manager::ListConfigurations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Configuration.
-    pub fn get_configuration(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::GetConfiguration {
+    pub fn get_configuration(&self) -> super::builder::license_manager::GetConfiguration {
         super::builder::license_manager::GetConfiguration::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Configuration in a given project and location.
@@ -147,12 +139,8 @@ impl LicenseManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_configuration(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::CreateConfiguration {
+    pub fn create_configuration(&self) -> super::builder::license_manager::CreateConfiguration {
         super::builder::license_manager::CreateConfiguration::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Configuration.
@@ -166,12 +154,8 @@ impl LicenseManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_configuration(
-        &self,
-        configuration: impl Into<crate::model::Configuration>,
-    ) -> super::builder::license_manager::UpdateConfiguration {
+    pub fn update_configuration(&self) -> super::builder::license_manager::UpdateConfiguration {
         super::builder::license_manager::UpdateConfiguration::new(self.inner.clone())
-            .set_configuration(configuration.into())
     }
 
     /// Deletes a single Configuration.
@@ -185,29 +169,18 @@ impl LicenseManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_configuration(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::DeleteConfiguration {
+    pub fn delete_configuration(&self) -> super::builder::license_manager::DeleteConfiguration {
         super::builder::license_manager::DeleteConfiguration::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::ListInstances {
+    pub fn list_instances(&self) -> super::builder::license_manager::ListInstances {
         super::builder::license_manager::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::GetInstance {
-        super::builder::license_manager::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::license_manager::GetInstance {
+        super::builder::license_manager::GetInstance::new(self.inner.clone())
     }
 
     /// Deactivates the given configuration.
@@ -223,10 +196,8 @@ impl LicenseManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn deactivate_configuration(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::license_manager::DeactivateConfiguration {
         super::builder::license_manager::DeactivateConfiguration::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reactivates the given configuration.
@@ -242,104 +213,67 @@ impl LicenseManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reactivate_configuration(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::license_manager::ReactivateConfiguration {
         super::builder::license_manager::ReactivateConfiguration::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// License Usage information for a Configuration.
     pub fn query_configuration_license_usage(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::license_manager::QueryConfigurationLicenseUsage {
         super::builder::license_manager::QueryConfigurationLicenseUsage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Aggregates Usage per Instance for a Configuration.
-    pub fn aggregate_usage(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::AggregateUsage {
+    pub fn aggregate_usage(&self) -> super::builder::license_manager::AggregateUsage {
         super::builder::license_manager::AggregateUsage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Products in a given project and location.
-    pub fn list_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::ListProducts {
+    pub fn list_products(&self) -> super::builder::license_manager::ListProducts {
         super::builder::license_manager::ListProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Product.
-    pub fn get_product(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::GetProduct {
-        super::builder::license_manager::GetProduct::new(self.inner.clone()).set_name(name.into())
+    pub fn get_product(&self) -> super::builder::license_manager::GetProduct {
+        super::builder::license_manager::GetProduct::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::license_manager::ListLocations {
         super::builder::license_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::GetLocation {
-        super::builder::license_manager::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::license_manager::GetLocation {
+        super::builder::license_manager::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::license_manager::ListOperations {
         super::builder::license_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::GetOperation {
-        super::builder::license_manager::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::license_manager::GetOperation {
+        super::builder::license_manager::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::license_manager::DeleteOperation {
         super::builder::license_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::license_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::license_manager::CancelOperation {
         super::builder::license_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/licensemanager/v1/src/transport.rs
+++ b/src/generated/cloud/licensemanager/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConfigurationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/configurations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/configurations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Configuration>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/configurations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/configurations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.configuration
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("configuration"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.configuration
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("configuration"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -196,9 +219,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -215,12 +245,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deactivate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:deactivate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,12 +269,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reactivate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:reactivate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,12 +293,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryConfigurationLicenseUsageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryLicenseUsage", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryLicenseUsage", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,12 +339,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AggregateUsageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:aggregateUsage", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:aggregateUsage", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -343,9 +389,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProductsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/products", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/products", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -366,9 +419,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -385,9 +445,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -407,9 +474,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -426,9 +500,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -448,9 +529,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -467,9 +555,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -490,9 +585,16 @@ impl super::stub::LicenseManager for LicenseManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/licensemanager/v1/src/transport.rs
+++ b/src/generated/cloud/licensemanager/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::LicenseManager for LicenseManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.configuration
+            let arg = &req
+                .configuration
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("configuration"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("configuration.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -123,18 +123,12 @@ impl Locations {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::locations::ListLocations {
-        super::builder::locations::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::locations::ListLocations {
+        super::builder::locations::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::locations::GetLocation {
-        super::builder::locations::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::locations::GetLocation {
+        super::builder::locations::GetLocation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Locations for Locations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +75,16 @@ impl super::stub::Locations for Locations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/lustre/v1/src/client.rs
+++ b/src/generated/cloud/lustre/v1/src/client.rs
@@ -119,19 +119,13 @@ impl Lustre {
     }
 
     /// Lists instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lustre::ListInstances {
-        super::builder::lustre::ListInstances::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_instances(&self) -> super::builder::lustre::ListInstances {
+        super::builder::lustre::ListInstances::new(self.inner.clone())
     }
 
     /// Gets details of a single instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::GetInstance {
-        super::builder::lustre::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::lustre::GetInstance {
+        super::builder::lustre::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new instance in a given project and location.
@@ -145,11 +139,8 @@ impl Lustre {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::lustre::CreateInstance {
-        super::builder::lustre::CreateInstance::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_instance(&self) -> super::builder::lustre::CreateInstance {
+        super::builder::lustre::CreateInstance::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single instance.
@@ -163,12 +154,8 @@ impl Lustre {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::lustre::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::lustre::UpdateInstance {
         super::builder::lustre::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes a single instance.
@@ -182,11 +169,8 @@ impl Lustre {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::DeleteInstance {
-        super::builder::lustre::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::lustre::DeleteInstance {
+        super::builder::lustre::DeleteInstance::new(self.inner.clone())
     }
 
     /// Imports data from Cloud Storage to a Managed Lustre instance.
@@ -200,11 +184,8 @@ impl Lustre {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::ImportData {
-        super::builder::lustre::ImportData::new(self.inner.clone()).set_name(name.into())
+    pub fn import_data(&self) -> super::builder::lustre::ImportData {
+        super::builder::lustre::ImportData::new(self.inner.clone())
     }
 
     /// Exports data from a Managed Lustre instance to Cloud Storage.
@@ -218,66 +199,45 @@ impl Lustre {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::ExportData {
-        super::builder::lustre::ExportData::new(self.inner.clone()).set_name(name.into())
+    pub fn export_data(&self) -> super::builder::lustre::ExportData {
+        super::builder::lustre::ExportData::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::ListLocations {
-        super::builder::lustre::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::lustre::ListLocations {
+        super::builder::lustre::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::GetLocation {
-        super::builder::lustre::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::lustre::GetLocation {
+        super::builder::lustre::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::ListOperations {
-        super::builder::lustre::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::lustre::ListOperations {
+        super::builder::lustre::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::GetOperation {
-        super::builder::lustre::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::lustre::GetOperation {
+        super::builder::lustre::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::DeleteOperation {
-        super::builder::lustre::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::lustre::DeleteOperation {
+        super::builder::lustre::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lustre::CancelOperation {
-        super::builder::lustre::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::lustre::CancelOperation {
+        super::builder::lustre::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/lustre/v1/src/transport.rs
+++ b/src/generated/cloud/lustre/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::Lustre for Lustre {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/lustre/v1/src/transport.rs
+++ b/src/generated/cloud/lustre/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importData", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importData", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,12 +213,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportData", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportData", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -210,9 +237,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -232,9 +266,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -251,9 +292,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,9 +321,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,9 +347,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -315,9 +377,16 @@ impl super::stub::Lustre for Lustre {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/managedidentities/v1/src/client.rs
+++ b/src/generated/cloud/managedidentities/v1/src/client.rs
@@ -165,37 +165,25 @@ impl ManagedIdentitiesService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_microsoft_ad_domain(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::managed_identities_service::CreateMicrosoftAdDomain {
         super::builder::managed_identities_service::CreateMicrosoftAdDomain::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Resets a domain's administrator password.
     pub fn reset_admin_password(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::managed_identities_service::ResetAdminPassword {
         super::builder::managed_identities_service::ResetAdminPassword::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists domains in a project.
-    pub fn list_domains(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::ListDomains {
+    pub fn list_domains(&self) -> super::builder::managed_identities_service::ListDomains {
         super::builder::managed_identities_service::ListDomains::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a domain.
-    pub fn get_domain(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::GetDomain {
+    pub fn get_domain(&self) -> super::builder::managed_identities_service::GetDomain {
         super::builder::managed_identities_service::GetDomain::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the metadata and configuration of a domain.
@@ -209,12 +197,8 @@ impl ManagedIdentitiesService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_domain(
-        &self,
-        domain: impl Into<crate::model::Domain>,
-    ) -> super::builder::managed_identities_service::UpdateDomain {
+    pub fn update_domain(&self) -> super::builder::managed_identities_service::UpdateDomain {
         super::builder::managed_identities_service::UpdateDomain::new(self.inner.clone())
-            .set_domain(domain.into())
     }
 
     /// Deletes a domain.
@@ -228,12 +212,8 @@ impl ManagedIdentitiesService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_domain(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::DeleteDomain {
+    pub fn delete_domain(&self) -> super::builder::managed_identities_service::DeleteDomain {
         super::builder::managed_identities_service::DeleteDomain::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds an AD trust to a domain.
@@ -247,12 +227,8 @@ impl ManagedIdentitiesService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn attach_trust(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::AttachTrust {
+    pub fn attach_trust(&self) -> super::builder::managed_identities_service::AttachTrust {
         super::builder::managed_identities_service::AttachTrust::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the DNS conditional forwarder.
@@ -268,10 +244,8 @@ impl ManagedIdentitiesService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reconfigure_trust(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::managed_identities_service::ReconfigureTrust {
         super::builder::managed_identities_service::ReconfigureTrust::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Removes an AD trust.
@@ -285,12 +259,8 @@ impl ManagedIdentitiesService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn detach_trust(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::DetachTrust {
+    pub fn detach_trust(&self) -> super::builder::managed_identities_service::DetachTrust {
         super::builder::managed_identities_service::DetachTrust::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Validates a trust state, that the target domain is reachable, and that the
@@ -305,55 +275,35 @@ impl ManagedIdentitiesService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn validate_trust(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::ValidateTrust {
+    pub fn validate_trust(&self) -> super::builder::managed_identities_service::ValidateTrust {
         super::builder::managed_identities_service::ValidateTrust::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::managed_identities_service::ListOperations {
         super::builder::managed_identities_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::managed_identities_service::GetOperation {
         super::builder::managed_identities_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::managed_identities_service::DeleteOperation {
         super::builder::managed_identities_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::managed_identities_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::managed_identities_service::CancelOperation {
         super::builder::managed_identities_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -152,10 +152,15 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.domain
+            let arg = &req
+                .domain
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("domain"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("domain.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/domains", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/domains", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -64,12 +71,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ResetAdminPasswordResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetAdminPassword", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetAdminPassword", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -84,9 +95,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDomainsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/domains", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/domains", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,9 +125,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Domain>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -126,18 +151,15 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.domain
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("domain"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.domain
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("domain"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +180,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -177,12 +206,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:attachTrust", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:attachTrust", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,12 +230,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reconfigureTrust", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:reconfigureTrust", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -217,12 +254,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:detachTrust", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:detachTrust", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -237,12 +278,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:validateTrust", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:validateTrust", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -257,9 +302,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -279,9 +331,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,9 +357,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -321,9 +387,16 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/memcache/v1/src/client.rs
+++ b/src/generated/cloud/memcache/v1/src/client.rs
@@ -134,20 +134,13 @@ impl CloudMemcache {
     }
 
     /// Lists Instances in a given location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::ListInstances {
+    pub fn list_instances(&self) -> super::builder::cloud_memcache::ListInstances {
         super::builder::cloud_memcache::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::GetInstance {
-        super::builder::cloud_memcache::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::cloud_memcache::GetInstance {
+        super::builder::cloud_memcache::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new Instance in a given location.
@@ -161,12 +154,8 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::cloud_memcache::CreateInstance {
         super::builder::cloud_memcache::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing Instance in a given project and location.
@@ -180,12 +169,8 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::cloud_memcache::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::cloud_memcache::UpdateInstance {
         super::builder::cloud_memcache::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Updates the defined Memcached parameters for an existing instance.
@@ -202,12 +187,8 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_parameters(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::UpdateParameters {
+    pub fn update_parameters(&self) -> super::builder::cloud_memcache::UpdateParameters {
         super::builder::cloud_memcache::UpdateParameters::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a single Instance.
@@ -221,12 +202,8 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::cloud_memcache::DeleteInstance {
         super::builder::cloud_memcache::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// `ApplyParameters` restarts the set of specified nodes in order to update
@@ -241,12 +218,8 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn apply_parameters(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::ApplyParameters {
+    pub fn apply_parameters(&self) -> super::builder::cloud_memcache::ApplyParameters {
         super::builder::cloud_memcache::ApplyParameters::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reschedules upcoming maintenance event.
@@ -260,70 +233,45 @@ impl CloudMemcache {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reschedule_maintenance(
-        &self,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::RescheduleMaintenance {
+    pub fn reschedule_maintenance(&self) -> super::builder::cloud_memcache::RescheduleMaintenance {
         super::builder::cloud_memcache::RescheduleMaintenance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::ListLocations {
-        super::builder::cloud_memcache::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::cloud_memcache::ListLocations {
+        super::builder::cloud_memcache::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::GetLocation {
-        super::builder::cloud_memcache::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cloud_memcache::GetLocation {
+        super::builder::cloud_memcache::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::ListOperations {
+    pub fn list_operations(&self) -> super::builder::cloud_memcache::ListOperations {
         super::builder::cloud_memcache::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::GetOperation {
-        super::builder::cloud_memcache::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cloud_memcache::GetOperation {
+        super::builder::cloud_memcache::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::cloud_memcache::DeleteOperation {
         super::builder::cloud_memcache::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_memcache::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::cloud_memcache::CancelOperation {
         super::builder::cloud_memcache::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::CloudMemcache for CloudMemcache {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,12 +160,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:updateParameters", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!("/v1/{}:updateParameters", req.name),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +184,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -187,12 +210,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:applyParameters", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:applyParameters", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -207,12 +234,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rescheduleMaintenance", {
+            let arg = &req.instance;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rescheduleMaintenance", req.instance),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -227,9 +258,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -249,9 +287,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -268,9 +313,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +342,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -309,9 +368,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,9 +398,16 @@ impl super::stub::CloudMemcache for CloudMemcache {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/memorystore/v1/src/client.rs
+++ b/src/generated/cloud/memorystore/v1/src/client.rs
@@ -119,20 +119,13 @@ impl Memorystore {
     }
 
     /// Lists Instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ListInstances {
+    pub fn list_instances(&self) -> super::builder::memorystore::ListInstances {
         super::builder::memorystore::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::GetInstance {
-        super::builder::memorystore::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::memorystore::GetInstance {
+        super::builder::memorystore::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new Instance in a given project and location.
@@ -146,12 +139,8 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::memorystore::CreateInstance {
         super::builder::memorystore::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Instance.
@@ -165,12 +154,8 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::memorystore::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::memorystore::UpdateInstance {
         super::builder::memorystore::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes a single Instance.
@@ -184,20 +169,15 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::DeleteInstance {
-        super::builder::memorystore::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::memorystore::DeleteInstance {
+        super::builder::memorystore::DeleteInstance::new(self.inner.clone())
     }
 
     /// Gets details about the certificate authority for an Instance.
     pub fn get_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::memorystore::GetCertificateAuthority {
         super::builder::memorystore::GetCertificateAuthority::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reschedules upcoming maintenance event.
@@ -211,12 +191,8 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reschedule_maintenance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::RescheduleMaintenance {
+    pub fn reschedule_maintenance(&self) -> super::builder::memorystore::RescheduleMaintenance {
         super::builder::memorystore::RescheduleMaintenance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all backup collections owned by a consumer project in either the
@@ -224,37 +200,23 @@ impl Memorystore {
     ///
     /// If `location_id` is specified as `-` (wildcard), then all regions
     /// available to the project are queried, and the results are aggregated.
-    pub fn list_backup_collections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ListBackupCollections {
+    pub fn list_backup_collections(&self) -> super::builder::memorystore::ListBackupCollections {
         super::builder::memorystore::ListBackupCollections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a backup collection.
-    pub fn get_backup_collection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::GetBackupCollection {
+    pub fn get_backup_collection(&self) -> super::builder::memorystore::GetBackupCollection {
         super::builder::memorystore::GetBackupCollection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all backups owned by a backup collection.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ListBackups {
-        super::builder::memorystore::ListBackups::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_backups(&self) -> super::builder::memorystore::ListBackups {
+        super::builder::memorystore::ListBackups::new(self.inner.clone())
     }
 
     /// Gets the details of a specific backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::GetBackup {
-        super::builder::memorystore::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::memorystore::GetBackup {
+        super::builder::memorystore::GetBackup::new(self.inner.clone())
     }
 
     /// Deletes a specific backup.
@@ -268,11 +230,8 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::DeleteBackup {
-        super::builder::memorystore::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::memorystore::DeleteBackup {
+        super::builder::memorystore::DeleteBackup::new(self.inner.clone())
     }
 
     /// Exports a specific backup to a customer target Cloud Storage URI.
@@ -286,11 +245,8 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ExportBackup {
-        super::builder::memorystore::ExportBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn export_backup(&self) -> super::builder::memorystore::ExportBackup {
+        super::builder::memorystore::ExportBackup::new(self.inner.clone())
     }
 
     /// Backup Instance.
@@ -315,66 +271,45 @@ impl Memorystore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn backup_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::BackupInstance {
-        super::builder::memorystore::BackupInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn backup_instance(&self) -> super::builder::memorystore::BackupInstance {
+        super::builder::memorystore::BackupInstance::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ListLocations {
-        super::builder::memorystore::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::memorystore::ListLocations {
+        super::builder::memorystore::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::GetLocation {
-        super::builder::memorystore::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::memorystore::GetLocation {
+        super::builder::memorystore::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::ListOperations {
-        super::builder::memorystore::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::memorystore::ListOperations {
+        super::builder::memorystore::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::GetOperation {
-        super::builder::memorystore::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::memorystore::GetOperation {
+        super::builder::memorystore::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::DeleteOperation {
-        super::builder::memorystore::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::memorystore::DeleteOperation {
+        super::builder::memorystore::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::memorystore::CancelOperation {
-        super::builder::memorystore::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::memorystore::CancelOperation {
+        super::builder::memorystore::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::Memorystore for Memorystore {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateAuthority>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateAuthority", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateAuthority", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,12 +215,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rescheduleMaintenance", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rescheduleMaintenance", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +239,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupCollectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupCollections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupCollections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,9 +267,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupCollection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,9 +293,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,9 +321,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,9 +347,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -315,9 +374,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,9 +398,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:backup", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:backup", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -349,9 +422,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -371,9 +451,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -390,9 +477,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,9 +506,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -431,9 +532,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,9 +562,16 @@ impl super::stub::Memorystore for Memorystore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/metastore/v1/src/client.rs
+++ b/src/generated/cloud/metastore/v1/src/client.rs
@@ -141,21 +141,13 @@ impl DataprocMetastore {
     }
 
     /// Lists services in a project and location.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ListServices {
+    pub fn list_services(&self) -> super::builder::dataproc_metastore::ListServices {
         super::builder::dataproc_metastore::ListServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a single service.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetService {
+    pub fn get_service(&self) -> super::builder::dataproc_metastore::GetService {
         super::builder::dataproc_metastore::GetService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a metastore service in a project and location.
@@ -169,12 +161,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::CreateService {
+    pub fn create_service(&self) -> super::builder::dataproc_metastore::CreateService {
         super::builder::dataproc_metastore::CreateService::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single service.
@@ -188,12 +176,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_service(
-        &self,
-        service: impl Into<crate::model::Service>,
-    ) -> super::builder::dataproc_metastore::UpdateService {
+    pub fn update_service(&self) -> super::builder::dataproc_metastore::UpdateService {
         super::builder::dataproc_metastore::UpdateService::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Deletes a single service.
@@ -207,30 +191,18 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::DeleteService {
+    pub fn delete_service(&self) -> super::builder::dataproc_metastore::DeleteService {
         super::builder::dataproc_metastore::DeleteService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists imports in a service.
-    pub fn list_metadata_imports(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ListMetadataImports {
+    pub fn list_metadata_imports(&self) -> super::builder::dataproc_metastore::ListMetadataImports {
         super::builder::dataproc_metastore::ListMetadataImports::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single import.
-    pub fn get_metadata_import(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetMetadataImport {
+    pub fn get_metadata_import(&self) -> super::builder::dataproc_metastore::GetMetadataImport {
         super::builder::dataproc_metastore::GetMetadataImport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new MetadataImport in a given project and location.
@@ -246,10 +218,8 @@ impl DataprocMetastore {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_metadata_import(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore::CreateMetadataImport {
         super::builder::dataproc_metastore::CreateMetadataImport::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a single import.
@@ -266,10 +236,8 @@ impl DataprocMetastore {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_metadata_import(
         &self,
-        metadata_import: impl Into<crate::model::MetadataImport>,
     ) -> super::builder::dataproc_metastore::UpdateMetadataImport {
         super::builder::dataproc_metastore::UpdateMetadataImport::new(self.inner.clone())
-            .set_metadata_import(metadata_import.into())
     }
 
     /// Exports metadata from a service.
@@ -283,12 +251,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_metadata(
-        &self,
-        service: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ExportMetadata {
+    pub fn export_metadata(&self) -> super::builder::dataproc_metastore::ExportMetadata {
         super::builder::dataproc_metastore::ExportMetadata::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Restores a service from a backup.
@@ -302,29 +266,18 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_service(
-        &self,
-        service: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::RestoreService {
+    pub fn restore_service(&self) -> super::builder::dataproc_metastore::RestoreService {
         super::builder::dataproc_metastore::RestoreService::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Lists backups in a service.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ListBackups {
+    pub fn list_backups(&self) -> super::builder::dataproc_metastore::ListBackups {
         super::builder::dataproc_metastore::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetBackup {
-        super::builder::dataproc_metastore::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::dataproc_metastore::GetBackup {
+        super::builder::dataproc_metastore::GetBackup::new(self.inner.clone())
     }
 
     /// Creates a new backup in a given project and location.
@@ -338,12 +291,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::dataproc_metastore::CreateBackup {
         super::builder::dataproc_metastore::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single backup.
@@ -357,12 +306,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::DeleteBackup {
+    pub fn delete_backup(&self) -> super::builder::dataproc_metastore::DeleteBackup {
         super::builder::dataproc_metastore::DeleteBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Query DPMS metadata.
@@ -376,12 +321,8 @@ impl DataprocMetastore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn query_metadata(
-        &self,
-        service: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::QueryMetadata {
+    pub fn query_metadata(&self) -> super::builder::dataproc_metastore::QueryMetadata {
         super::builder::dataproc_metastore::QueryMetadata::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Move a table to another database.
@@ -397,10 +338,8 @@ impl DataprocMetastore {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn move_table_to_database(
         &self,
-        service: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore::MoveTableToDatabase {
         super::builder::dataproc_metastore::MoveTableToDatabase::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Alter metadata resource location. The metadata resource can be a database,
@@ -419,28 +358,18 @@ impl DataprocMetastore {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn alter_metadata_resource_location(
         &self,
-        service: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore::AlterMetadataResourceLocation {
         super::builder::dataproc_metastore::AlterMetadataResourceLocation::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ListLocations {
+    pub fn list_locations(&self) -> super::builder::dataproc_metastore::ListLocations {
         super::builder::dataproc_metastore::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetLocation {
+    pub fn get_location(&self) -> super::builder::dataproc_metastore::GetLocation {
         super::builder::dataproc_metastore::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -448,22 +377,14 @@ impl DataprocMetastore {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::dataproc_metastore::SetIamPolicy {
         super::builder::dataproc_metastore::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::dataproc_metastore::GetIamPolicy {
         super::builder::dataproc_metastore::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -473,56 +394,36 @@ impl DataprocMetastore {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::dataproc_metastore::TestIamPermissions {
         super::builder::dataproc_metastore::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::ListOperations {
+    pub fn list_operations(&self) -> super::builder::dataproc_metastore::ListOperations {
         super::builder::dataproc_metastore::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::GetOperation {
+    pub fn get_operation(&self) -> super::builder::dataproc_metastore::GetOperation {
         super::builder::dataproc_metastore::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::dataproc_metastore::DeleteOperation {
         super::builder::dataproc_metastore::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::dataproc_metastore::CancelOperation {
         super::builder::dataproc_metastore::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -644,19 +545,13 @@ impl DataprocMetastoreFederation {
     /// Lists federations in a project and location.
     pub fn list_federations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::ListFederations {
         super::builder::dataproc_metastore_federation::ListFederations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a single federation.
-    pub fn get_federation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::GetFederation {
+    pub fn get_federation(&self) -> super::builder::dataproc_metastore_federation::GetFederation {
         super::builder::dataproc_metastore_federation::GetFederation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a metastore federation in a project and location.
@@ -672,10 +567,8 @@ impl DataprocMetastoreFederation {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_federation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::CreateFederation {
         super::builder::dataproc_metastore_federation::CreateFederation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the fields of a federation.
@@ -691,10 +584,8 @@ impl DataprocMetastoreFederation {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_federation(
         &self,
-        federation: impl Into<crate::model::Federation>,
     ) -> super::builder::dataproc_metastore_federation::UpdateFederation {
         super::builder::dataproc_metastore_federation::UpdateFederation::new(self.inner.clone())
-            .set_federation(federation.into())
     }
 
     /// Deletes a single federation.
@@ -710,28 +601,18 @@ impl DataprocMetastoreFederation {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_federation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::DeleteFederation {
         super::builder::dataproc_metastore_federation::DeleteFederation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::ListLocations {
+    pub fn list_locations(&self) -> super::builder::dataproc_metastore_federation::ListLocations {
         super::builder::dataproc_metastore_federation::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::GetLocation {
+    pub fn get_location(&self) -> super::builder::dataproc_metastore_federation::GetLocation {
         super::builder::dataproc_metastore_federation::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -739,22 +620,14 @@ impl DataprocMetastoreFederation {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::dataproc_metastore_federation::SetIamPolicy {
         super::builder::dataproc_metastore_federation::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::dataproc_metastore_federation::GetIamPolicy {
         super::builder::dataproc_metastore_federation::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -766,32 +639,22 @@ impl DataprocMetastoreFederation {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::TestIamPermissions {
         super::builder::dataproc_metastore_federation::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::ListOperations {
+    pub fn list_operations(&self) -> super::builder::dataproc_metastore_federation::ListOperations {
         super::builder::dataproc_metastore_federation::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dataproc_metastore_federation::GetOperation {
+    pub fn get_operation(&self) -> super::builder::dataproc_metastore_federation::GetOperation {
         super::builder::dataproc_metastore_federation::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -799,10 +662,8 @@ impl DataprocMetastoreFederation {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::DeleteOperation {
         super::builder::dataproc_metastore_federation::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -810,9 +671,7 @@ impl DataprocMetastoreFederation {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dataproc_metastore_federation::CancelOperation {
         super::builder::dataproc_metastore_federation::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +102,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/services", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,18 +130,15 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -147,9 +162,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,12 +189,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMetadataImportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/metadataImports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/metadataImports", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +219,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetadataImport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +245,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/metadataImports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/metadataImports", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,18 +273,15 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.metadata_import
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("metadata_import"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.metadata_import
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("metadata_import"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,12 +305,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportMetadata", {
+            let arg = &req.service;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportMetadata", req.service),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,12 +329,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.service;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:restore", req.service),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -311,9 +353,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -334,9 +383,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,9 +409,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -372,9 +435,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -392,12 +462,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:queryMetadata", {
+            let arg = &req.service;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:queryMetadata", req.service),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,12 +486,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:moveTableToDatabase", {
+            let arg = &req.service;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:moveTableToDatabase", req.service),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -432,12 +510,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:alterLocation", {
+            let arg = &req.service;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:alterLocation", req.service),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -452,9 +534,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -474,9 +563,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -493,12 +589,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -513,12 +613,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -545,12 +649,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -565,9 +673,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -587,9 +702,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -606,9 +728,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -629,9 +758,16 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -688,12 +824,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFederationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/federations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/federations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -714,9 +854,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Federation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -733,12 +880,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/federations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/federations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -757,18 +908,15 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.federation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("federation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.federation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("federation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -792,9 +940,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -812,9 +967,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -834,9 +996,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -853,12 +1022,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -873,12 +1046,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -905,12 +1082,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -925,9 +1106,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -947,9 +1135,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -966,9 +1161,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -989,9 +1191,16 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service
+            let arg = &req
+                .service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -274,10 +279,15 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.metadata_import
+            let arg = &req
+                .metadata_import
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("metadata_import"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("metadata_import.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -909,10 +919,15 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.federation
+            let arg = &req
+                .federation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("federation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("federation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/migrationcenter/v1/src/client.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/client.rs
@@ -121,73 +121,45 @@ impl MigrationCenter {
     }
 
     /// Lists all the assets in a given project and location.
-    pub fn list_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListAssets {
+    pub fn list_assets(&self) -> super::builder::migration_center::ListAssets {
         super::builder::migration_center::ListAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of an asset.
-    pub fn get_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetAsset {
-        super::builder::migration_center::GetAsset::new(self.inner.clone()).set_name(name.into())
+    pub fn get_asset(&self) -> super::builder::migration_center::GetAsset {
+        super::builder::migration_center::GetAsset::new(self.inner.clone())
     }
 
     /// Updates the parameters of an asset.
-    pub fn update_asset(
-        &self,
-        asset: impl Into<crate::model::Asset>,
-    ) -> super::builder::migration_center::UpdateAsset {
+    pub fn update_asset(&self) -> super::builder::migration_center::UpdateAsset {
         super::builder::migration_center::UpdateAsset::new(self.inner.clone())
-            .set_asset(asset.into())
     }
 
     /// Updates the parameters of a list of assets.
-    pub fn batch_update_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::BatchUpdateAssets {
+    pub fn batch_update_assets(&self) -> super::builder::migration_center::BatchUpdateAssets {
         super::builder::migration_center::BatchUpdateAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an asset.
-    pub fn delete_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteAsset {
-        super::builder::migration_center::DeleteAsset::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_asset(&self) -> super::builder::migration_center::DeleteAsset {
+        super::builder::migration_center::DeleteAsset::new(self.inner.clone())
     }
 
     /// Deletes list of Assets.
-    pub fn batch_delete_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::BatchDeleteAssets {
+    pub fn batch_delete_assets(&self) -> super::builder::migration_center::BatchDeleteAssets {
         super::builder::migration_center::BatchDeleteAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Reports a set of frames.
-    pub fn report_asset_frames(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ReportAssetFrames {
+    pub fn report_asset_frames(&self) -> super::builder::migration_center::ReportAssetFrames {
         super::builder::migration_center::ReportAssetFrames::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Aggregates the requested fields based on provided function.
     pub fn aggregate_assets_values(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_center::AggregateAssetsValues {
         super::builder::migration_center::AggregateAssetsValues::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an import job.
@@ -201,30 +173,18 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_import_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreateImportJob {
+    pub fn create_import_job(&self) -> super::builder::migration_center::CreateImportJob {
         super::builder::migration_center::CreateImportJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all import jobs.
-    pub fn list_import_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListImportJobs {
+    pub fn list_import_jobs(&self) -> super::builder::migration_center::ListImportJobs {
         super::builder::migration_center::ListImportJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of an import job.
-    pub fn get_import_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetImportJob {
+    pub fn get_import_job(&self) -> super::builder::migration_center::GetImportJob {
         super::builder::migration_center::GetImportJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an import job.
@@ -238,12 +198,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_import_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteImportJob {
+    pub fn delete_import_job(&self) -> super::builder::migration_center::DeleteImportJob {
         super::builder::migration_center::DeleteImportJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an import job.
@@ -257,12 +213,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_import_job(
-        &self,
-        import_job: impl Into<crate::model::ImportJob>,
-    ) -> super::builder::migration_center::UpdateImportJob {
+    pub fn update_import_job(&self) -> super::builder::migration_center::UpdateImportJob {
         super::builder::migration_center::UpdateImportJob::new(self.inner.clone())
-            .set_import_job(import_job.into())
     }
 
     /// Validates an import job.
@@ -276,12 +228,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn validate_import_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ValidateImportJob {
+    pub fn validate_import_job(&self) -> super::builder::migration_center::ValidateImportJob {
         super::builder::migration_center::ValidateImportJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Runs an import job.
@@ -295,30 +243,18 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_import_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::RunImportJob {
+    pub fn run_import_job(&self) -> super::builder::migration_center::RunImportJob {
         super::builder::migration_center::RunImportJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets an import data file.
-    pub fn get_import_data_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetImportDataFile {
+    pub fn get_import_data_file(&self) -> super::builder::migration_center::GetImportDataFile {
         super::builder::migration_center::GetImportDataFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List import data files.
-    pub fn list_import_data_files(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListImportDataFiles {
+    pub fn list_import_data_files(&self) -> super::builder::migration_center::ListImportDataFiles {
         super::builder::migration_center::ListImportDataFiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an import data file.
@@ -334,10 +270,8 @@ impl MigrationCenter {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_import_data_file(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::migration_center::CreateImportDataFile {
         super::builder::migration_center::CreateImportDataFile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete an import data file.
@@ -353,27 +287,18 @@ impl MigrationCenter {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_import_data_file(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::migration_center::DeleteImportDataFile {
         super::builder::migration_center::DeleteImportDataFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all groups in a given project and location.
-    pub fn list_groups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListGroups {
+    pub fn list_groups(&self) -> super::builder::migration_center::ListGroups {
         super::builder::migration_center::ListGroups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a group.
-    pub fn get_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetGroup {
-        super::builder::migration_center::GetGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_group(&self) -> super::builder::migration_center::GetGroup {
+        super::builder::migration_center::GetGroup::new(self.inner.clone())
     }
 
     /// Creates a new group in a given project and location.
@@ -387,12 +312,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_group(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreateGroup {
+    pub fn create_group(&self) -> super::builder::migration_center::CreateGroup {
         super::builder::migration_center::CreateGroup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a group.
@@ -406,12 +327,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_group(
-        &self,
-        group: impl Into<crate::model::Group>,
-    ) -> super::builder::migration_center::UpdateGroup {
+    pub fn update_group(&self) -> super::builder::migration_center::UpdateGroup {
         super::builder::migration_center::UpdateGroup::new(self.inner.clone())
-            .set_group(group.into())
     }
 
     /// Deletes a group.
@@ -425,11 +342,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteGroup {
-        super::builder::migration_center::DeleteGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_group(&self) -> super::builder::migration_center::DeleteGroup {
+        super::builder::migration_center::DeleteGroup::new(self.inner.clone())
     }
 
     /// Adds assets to a group.
@@ -443,12 +357,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn add_assets_to_group(
-        &self,
-        group: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::AddAssetsToGroup {
+    pub fn add_assets_to_group(&self) -> super::builder::migration_center::AddAssetsToGroup {
         super::builder::migration_center::AddAssetsToGroup::new(self.inner.clone())
-            .set_group(group.into())
     }
 
     /// Removes assets from a group.
@@ -464,45 +374,28 @@ impl MigrationCenter {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn remove_assets_from_group(
         &self,
-        group: impl Into<std::string::String>,
     ) -> super::builder::migration_center::RemoveAssetsFromGroup {
         super::builder::migration_center::RemoveAssetsFromGroup::new(self.inner.clone())
-            .set_group(group.into())
     }
 
     /// Lists all error frames in a given source and location.
-    pub fn list_error_frames(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListErrorFrames {
+    pub fn list_error_frames(&self) -> super::builder::migration_center::ListErrorFrames {
         super::builder::migration_center::ListErrorFrames::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of an error frame.
-    pub fn get_error_frame(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetErrorFrame {
+    pub fn get_error_frame(&self) -> super::builder::migration_center::GetErrorFrame {
         super::builder::migration_center::GetErrorFrame::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all the sources in a given project and location.
-    pub fn list_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListSources {
+    pub fn list_sources(&self) -> super::builder::migration_center::ListSources {
         super::builder::migration_center::ListSources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a source.
-    pub fn get_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetSource {
-        super::builder::migration_center::GetSource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_source(&self) -> super::builder::migration_center::GetSource {
+        super::builder::migration_center::GetSource::new(self.inner.clone())
     }
 
     /// Creates a new source in a given project and location.
@@ -516,12 +409,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_source(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreateSource {
+    pub fn create_source(&self) -> super::builder::migration_center::CreateSource {
         super::builder::migration_center::CreateSource::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a source.
@@ -535,12 +424,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_source(
-        &self,
-        source: impl Into<crate::model::Source>,
-    ) -> super::builder::migration_center::UpdateSource {
+    pub fn update_source(&self) -> super::builder::migration_center::UpdateSource {
         super::builder::migration_center::UpdateSource::new(self.inner.clone())
-            .set_source(source.into())
     }
 
     /// Deletes a source.
@@ -554,30 +439,18 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteSource {
+    pub fn delete_source(&self) -> super::builder::migration_center::DeleteSource {
         super::builder::migration_center::DeleteSource::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all the preference sets in a given project and location.
-    pub fn list_preference_sets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListPreferenceSets {
+    pub fn list_preference_sets(&self) -> super::builder::migration_center::ListPreferenceSets {
         super::builder::migration_center::ListPreferenceSets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a preference set.
-    pub fn get_preference_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetPreferenceSet {
+    pub fn get_preference_set(&self) -> super::builder::migration_center::GetPreferenceSet {
         super::builder::migration_center::GetPreferenceSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new preference set in a given project and location.
@@ -591,12 +464,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_preference_set(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreatePreferenceSet {
+    pub fn create_preference_set(&self) -> super::builder::migration_center::CreatePreferenceSet {
         super::builder::migration_center::CreatePreferenceSet::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a preference set.
@@ -610,12 +479,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_preference_set(
-        &self,
-        preference_set: impl Into<crate::model::PreferenceSet>,
-    ) -> super::builder::migration_center::UpdatePreferenceSet {
+    pub fn update_preference_set(&self) -> super::builder::migration_center::UpdatePreferenceSet {
         super::builder::migration_center::UpdatePreferenceSet::new(self.inner.clone())
-            .set_preference_set(preference_set.into())
     }
 
     /// Deletes a preference set.
@@ -629,20 +494,13 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_preference_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeletePreferenceSet {
+    pub fn delete_preference_set(&self) -> super::builder::migration_center::DeletePreferenceSet {
         super::builder::migration_center::DeletePreferenceSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the details of regional settings.
-    pub fn get_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetSettings {
-        super::builder::migration_center::GetSettings::new(self.inner.clone()).set_name(name.into())
+    pub fn get_settings(&self) -> super::builder::migration_center::GetSettings {
+        super::builder::migration_center::GetSettings::new(self.inner.clone())
     }
 
     /// Updates the regional-level project settings.
@@ -656,12 +514,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_settings(
-        &self,
-        settings: impl Into<crate::model::Settings>,
-    ) -> super::builder::migration_center::UpdateSettings {
+    pub fn update_settings(&self) -> super::builder::migration_center::UpdateSettings {
         super::builder::migration_center::UpdateSettings::new(self.inner.clone())
-            .set_settings(settings.into())
     }
 
     /// Creates a report configuration.
@@ -675,30 +529,18 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_report_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreateReportConfig {
+    pub fn create_report_config(&self) -> super::builder::migration_center::CreateReportConfig {
         super::builder::migration_center::CreateReportConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ReportConfig.
-    pub fn get_report_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetReportConfig {
+    pub fn get_report_config(&self) -> super::builder::migration_center::GetReportConfig {
         super::builder::migration_center::GetReportConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ReportConfigs in a given project and location.
-    pub fn list_report_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListReportConfigs {
+    pub fn list_report_configs(&self) -> super::builder::migration_center::ListReportConfigs {
         super::builder::migration_center::ListReportConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a ReportConfig.
@@ -712,12 +554,8 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_report_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteReportConfig {
+    pub fn delete_report_config(&self) -> super::builder::migration_center::DeleteReportConfig {
         super::builder::migration_center::DeleteReportConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a report.
@@ -731,29 +569,18 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_report(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CreateReport {
+    pub fn create_report(&self) -> super::builder::migration_center::CreateReport {
         super::builder::migration_center::CreateReport::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Report.
-    pub fn get_report(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetReport {
-        super::builder::migration_center::GetReport::new(self.inner.clone()).set_name(name.into())
+    pub fn get_report(&self) -> super::builder::migration_center::GetReport {
+        super::builder::migration_center::GetReport::new(self.inner.clone())
     }
 
     /// Lists Reports in a given ReportConfig.
-    pub fn list_reports(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListReports {
+    pub fn list_reports(&self) -> super::builder::migration_center::ListReports {
         super::builder::migration_center::ListReports::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Report.
@@ -767,72 +594,45 @@ impl MigrationCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_report(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteReport {
+    pub fn delete_report(&self) -> super::builder::migration_center::DeleteReport {
         super::builder::migration_center::DeleteReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListLocations {
+    pub fn list_locations(&self) -> super::builder::migration_center::ListLocations {
         super::builder::migration_center::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetLocation {
-        super::builder::migration_center::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::migration_center::GetLocation {
+        super::builder::migration_center::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::ListOperations {
+    pub fn list_operations(&self) -> super::builder::migration_center::ListOperations {
         super::builder::migration_center::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::GetOperation {
+    pub fn get_operation(&self) -> super::builder::migration_center::GetOperation {
         super::builder::migration_center::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::migration_center::DeleteOperation {
         super::builder::migration_center::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::migration_center::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::migration_center::CancelOperation {
         super::builder::migration_center::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +77,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Asset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,18 +104,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Asset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.asset
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.asset
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,12 +134,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchUpdateAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assets:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -143,9 +158,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,12 +189,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assets:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,12 +218,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportAssetFramesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets:reportAssetFrames", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assets:reportAssetFrames", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,12 +243,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AggregateAssetsValuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets:aggregateValues", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assets:aggregateValues", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -233,12 +267,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/importJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/importJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -257,12 +295,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListImportJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/importJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/importJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -284,9 +326,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,9 +353,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -325,18 +381,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.import_job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("import_job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.import_job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("import_job"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -360,9 +413,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:validate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:validate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +437,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -394,9 +461,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportDataFile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -413,12 +487,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListImportDataFilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/importDataFiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/importDataFiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -439,12 +517,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/importDataFiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/importDataFiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,9 +545,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -483,9 +572,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/groups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -506,9 +602,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -525,9 +628,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/groups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/groups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -544,18 +654,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -577,9 +684,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -597,12 +711,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addAssets", {
+            let arg = &req.group;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addAssets", req.group),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -617,12 +735,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeAssets", {
+            let arg = &req.group;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeAssets", req.group),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -637,12 +759,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListErrorFramesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/errorFrames", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/errorFrames", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -662,9 +788,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ErrorFrame>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -682,9 +815,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/sources", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -705,9 +845,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -724,9 +871,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/sources", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -743,18 +897,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.source
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("source"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.source
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -776,9 +927,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -796,12 +954,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPreferenceSetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/preferenceSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/preferenceSets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -821,9 +983,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PreferenceSet>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -840,12 +1009,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/preferenceSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/preferenceSets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -864,18 +1037,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.preference_set
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("preference_set"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.preference_set
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("preference_set"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -899,9 +1069,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -919,9 +1096,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -938,18 +1122,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -973,12 +1154,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/reportConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/reportConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -997,9 +1182,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1016,12 +1208,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReportConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reportConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/reportConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1042,9 +1238,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1063,9 +1266,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/reports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/reports", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1082,9 +1292,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Report>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1102,9 +1319,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/reports", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1126,9 +1350,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1377,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1168,9 +1406,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1187,9 +1432,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1209,9 +1461,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1228,9 +1487,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1251,9 +1517,16 @@ impl super::stub::MigrationCenter for MigrationCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -105,10 +105,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<crate::model::Asset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.asset
+            let arg = &req
+                .asset
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("asset"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("asset.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -382,10 +387,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.import_job
+            let arg = &req
+                .import_job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("import_job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("import_job.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -655,10 +665,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.group
+            let arg = &req
+                .group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -898,10 +913,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.source
+            let arg = &req
+                .source
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("source.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1038,10 +1058,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.preference_set
+            let arg = &req
+                .preference_set
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("preference_set"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("preference_set.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1123,10 +1148,15 @@ impl super::stub::MigrationCenter for MigrationCenter {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.settings
+            let arg = &req
+                .settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/modelarmor/v1/src/client.rs
+++ b/src/generated/cloud/modelarmor/v1/src/client.rs
@@ -119,96 +119,57 @@ impl ModelArmor {
     }
 
     /// Lists Templates in a given project and location.
-    pub fn list_templates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::ListTemplates {
+    pub fn list_templates(&self) -> super::builder::model_armor::ListTemplates {
         super::builder::model_armor::ListTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Template.
-    pub fn get_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::GetTemplate {
-        super::builder::model_armor::GetTemplate::new(self.inner.clone()).set_name(name.into())
+    pub fn get_template(&self) -> super::builder::model_armor::GetTemplate {
+        super::builder::model_armor::GetTemplate::new(self.inner.clone())
     }
 
     /// Creates a new Template in a given project and location.
-    pub fn create_template(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::CreateTemplate {
+    pub fn create_template(&self) -> super::builder::model_armor::CreateTemplate {
         super::builder::model_armor::CreateTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Template.
-    pub fn update_template(
-        &self,
-        template: impl Into<crate::model::Template>,
-    ) -> super::builder::model_armor::UpdateTemplate {
+    pub fn update_template(&self) -> super::builder::model_armor::UpdateTemplate {
         super::builder::model_armor::UpdateTemplate::new(self.inner.clone())
-            .set_template(template.into())
     }
 
     /// Deletes a single Template.
-    pub fn delete_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::DeleteTemplate {
-        super::builder::model_armor::DeleteTemplate::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_template(&self) -> super::builder::model_armor::DeleteTemplate {
+        super::builder::model_armor::DeleteTemplate::new(self.inner.clone())
     }
 
     /// Gets details of a single floor setting of a project
-    pub fn get_floor_setting(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::GetFloorSetting {
-        super::builder::model_armor::GetFloorSetting::new(self.inner.clone()).set_name(name.into())
+    pub fn get_floor_setting(&self) -> super::builder::model_armor::GetFloorSetting {
+        super::builder::model_armor::GetFloorSetting::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single floor setting of a project
-    pub fn update_floor_setting(
-        &self,
-        floor_setting: impl Into<crate::model::FloorSetting>,
-    ) -> super::builder::model_armor::UpdateFloorSetting {
+    pub fn update_floor_setting(&self) -> super::builder::model_armor::UpdateFloorSetting {
         super::builder::model_armor::UpdateFloorSetting::new(self.inner.clone())
-            .set_floor_setting(floor_setting.into())
     }
 
     /// Sanitizes User Prompt.
-    pub fn sanitize_user_prompt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::SanitizeUserPrompt {
+    pub fn sanitize_user_prompt(&self) -> super::builder::model_armor::SanitizeUserPrompt {
         super::builder::model_armor::SanitizeUserPrompt::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sanitizes Model Response.
-    pub fn sanitize_model_response(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::SanitizeModelResponse {
+    pub fn sanitize_model_response(&self) -> super::builder::model_armor::SanitizeModelResponse {
         super::builder::model_armor::SanitizeModelResponse::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::ListLocations {
-        super::builder::model_armor::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::model_armor::ListLocations {
+        super::builder::model_armor::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_armor::GetLocation {
-        super::builder::model_armor::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::model_armor::GetLocation {
+        super::builder::model_armor::GetLocation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::ModelArmor for ModelArmor {
     ) -> Result<gax::response::Response<crate::model::Template>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.template
+            let arg = &req
+                .template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("template.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -220,10 +225,15 @@ impl super::stub::ModelArmor for ModelArmor {
     ) -> Result<gax::response::Response<crate::model::FloorSetting>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.floor_setting
+            let arg = &req
+                .floor_setting
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("floor_setting"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("floor_setting.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/templates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/templates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Template>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Template>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/templates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/templates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Template>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +193,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FloorSetting>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,18 +219,15 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FloorSetting>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.floor_setting
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("floor_setting"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.floor_setting
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("floor_setting"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -227,12 +250,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SanitizeUserPromptResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:sanitizeUserPrompt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:sanitizeUserPrompt", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,12 +274,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SanitizeModelResponseResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:sanitizeModelResponse", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:sanitizeModelResponse", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -267,9 +298,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -289,9 +327,16 @@ impl super::stub::ModelArmor for ModelArmor {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/netapp/v1/src/client.rs
+++ b/src/generated/cloud/netapp/v1/src/client.rs
@@ -119,11 +119,8 @@ impl NetApp {
     }
 
     /// Returns descriptions of all storage pools owned by the caller.
-    pub fn list_storage_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListStoragePools {
-        super::builder::net_app::ListStoragePools::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_storage_pools(&self) -> super::builder::net_app::ListStoragePools {
+        super::builder::net_app::ListStoragePools::new(self.inner.clone())
     }
 
     /// Creates a new storage pool.
@@ -137,20 +134,13 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_storage_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateStoragePool {
+    pub fn create_storage_pool(&self) -> super::builder::net_app::CreateStoragePool {
         super::builder::net_app::CreateStoragePool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the description of the specified storage pool by poolId.
-    pub fn get_storage_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetStoragePool {
-        super::builder::net_app::GetStoragePool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_storage_pool(&self) -> super::builder::net_app::GetStoragePool {
+        super::builder::net_app::GetStoragePool::new(self.inner.clone())
     }
 
     /// Updates the storage pool properties with the full spec
@@ -164,12 +154,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_storage_pool(
-        &self,
-        storage_pool: impl Into<crate::model::StoragePool>,
-    ) -> super::builder::net_app::UpdateStoragePool {
+    pub fn update_storage_pool(&self) -> super::builder::net_app::UpdateStoragePool {
         super::builder::net_app::UpdateStoragePool::new(self.inner.clone())
-            .set_storage_pool(storage_pool.into())
     }
 
     /// Warning! This operation will permanently delete the storage pool.
@@ -183,11 +169,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_storage_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteStoragePool {
-        super::builder::net_app::DeleteStoragePool::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_storage_pool(&self) -> super::builder::net_app::DeleteStoragePool {
+        super::builder::net_app::DeleteStoragePool::new(self.inner.clone())
     }
 
     /// ValidateDirectoryService does a connectivity check for a directory service
@@ -202,12 +185,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn validate_directory_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ValidateDirectoryService {
+    pub fn validate_directory_service(&self) -> super::builder::net_app::ValidateDirectoryService {
         super::builder::net_app::ValidateDirectoryService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// This operation will switch the active/replica zone for a regional
@@ -222,28 +201,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn switch_active_replica_zone(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::SwitchActiveReplicaZone {
+    pub fn switch_active_replica_zone(&self) -> super::builder::net_app::SwitchActiveReplicaZone {
         super::builder::net_app::SwitchActiveReplicaZone::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Volumes in a given project.
-    pub fn list_volumes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListVolumes {
-        super::builder::net_app::ListVolumes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_volumes(&self) -> super::builder::net_app::ListVolumes {
+        super::builder::net_app::ListVolumes::new(self.inner.clone())
     }
 
     /// Gets details of a single Volume.
-    pub fn get_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetVolume {
-        super::builder::net_app::GetVolume::new(self.inner.clone()).set_name(name.into())
+    pub fn get_volume(&self) -> super::builder::net_app::GetVolume {
+        super::builder::net_app::GetVolume::new(self.inner.clone())
     }
 
     /// Creates a new Volume in a given project and location.
@@ -257,11 +226,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_volume(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateVolume {
-        super::builder::net_app::CreateVolume::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_volume(&self) -> super::builder::net_app::CreateVolume {
+        super::builder::net_app::CreateVolume::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Volume.
@@ -275,11 +241,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_volume(
-        &self,
-        volume: impl Into<crate::model::Volume>,
-    ) -> super::builder::net_app::UpdateVolume {
-        super::builder::net_app::UpdateVolume::new(self.inner.clone()).set_volume(volume.into())
+    pub fn update_volume(&self) -> super::builder::net_app::UpdateVolume {
+        super::builder::net_app::UpdateVolume::new(self.inner.clone())
     }
 
     /// Deletes a single Volume.
@@ -293,11 +256,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteVolume {
-        super::builder::net_app::DeleteVolume::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_volume(&self) -> super::builder::net_app::DeleteVolume {
+        super::builder::net_app::DeleteVolume::new(self.inner.clone())
     }
 
     /// Revert an existing volume to a specified snapshot.
@@ -313,27 +273,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn revert_volume(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::RevertVolume {
-        super::builder::net_app::RevertVolume::new(self.inner.clone()).set_name(name.into())
+    pub fn revert_volume(&self) -> super::builder::net_app::RevertVolume {
+        super::builder::net_app::RevertVolume::new(self.inner.clone())
     }
 
     /// Returns descriptions of all snapshots for a volume.
-    pub fn list_snapshots(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListSnapshots {
-        super::builder::net_app::ListSnapshots::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_snapshots(&self) -> super::builder::net_app::ListSnapshots {
+        super::builder::net_app::ListSnapshots::new(self.inner.clone())
     }
 
     /// Describe a snapshot for a volume.
-    pub fn get_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetSnapshot {
-        super::builder::net_app::GetSnapshot::new(self.inner.clone()).set_name(name.into())
+    pub fn get_snapshot(&self) -> super::builder::net_app::GetSnapshot {
+        super::builder::net_app::GetSnapshot::new(self.inner.clone())
     }
 
     /// Create a new snapshot for a volume.
@@ -347,11 +298,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_snapshot(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateSnapshot {
-        super::builder::net_app::CreateSnapshot::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_snapshot(&self) -> super::builder::net_app::CreateSnapshot {
+        super::builder::net_app::CreateSnapshot::new(self.inner.clone())
     }
 
     /// Deletes a snapshot.
@@ -365,11 +313,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_snapshot(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteSnapshot {
-        super::builder::net_app::DeleteSnapshot::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_snapshot(&self) -> super::builder::net_app::DeleteSnapshot {
+        super::builder::net_app::DeleteSnapshot::new(self.inner.clone())
     }
 
     /// Updates the settings of a specific snapshot.
@@ -383,29 +328,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_snapshot(
-        &self,
-        snapshot: impl Into<crate::model::Snapshot>,
-    ) -> super::builder::net_app::UpdateSnapshot {
+    pub fn update_snapshot(&self) -> super::builder::net_app::UpdateSnapshot {
         super::builder::net_app::UpdateSnapshot::new(self.inner.clone())
-            .set_snapshot(snapshot.into())
     }
 
     /// Lists active directories.
-    pub fn list_active_directories(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListActiveDirectories {
+    pub fn list_active_directories(&self) -> super::builder::net_app::ListActiveDirectories {
         super::builder::net_app::ListActiveDirectories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Describes a specified active directory.
-    pub fn get_active_directory(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetActiveDirectory {
-        super::builder::net_app::GetActiveDirectory::new(self.inner.clone()).set_name(name.into())
+    pub fn get_active_directory(&self) -> super::builder::net_app::GetActiveDirectory {
+        super::builder::net_app::GetActiveDirectory::new(self.inner.clone())
     }
 
     /// CreateActiveDirectory
@@ -420,12 +354,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_active_directory(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateActiveDirectory {
+    pub fn create_active_directory(&self) -> super::builder::net_app::CreateActiveDirectory {
         super::builder::net_app::CreateActiveDirectory::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update the parameters of an active directories.
@@ -439,12 +369,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_active_directory(
-        &self,
-        active_directory: impl Into<crate::model::ActiveDirectory>,
-    ) -> super::builder::net_app::UpdateActiveDirectory {
+    pub fn update_active_directory(&self) -> super::builder::net_app::UpdateActiveDirectory {
         super::builder::net_app::UpdateActiveDirectory::new(self.inner.clone())
-            .set_active_directory(active_directory.into())
     }
 
     /// Delete the active directory specified in the request.
@@ -458,20 +384,13 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_active_directory(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteActiveDirectory {
+    pub fn delete_active_directory(&self) -> super::builder::net_app::DeleteActiveDirectory {
         super::builder::net_app::DeleteActiveDirectory::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns descriptions of all KMS configs owned by the caller.
-    pub fn list_kms_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListKmsConfigs {
-        super::builder::net_app::ListKmsConfigs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_kms_configs(&self) -> super::builder::net_app::ListKmsConfigs {
+        super::builder::net_app::ListKmsConfigs::new(self.inner.clone())
     }
 
     /// Creates a new KMS config.
@@ -485,19 +404,13 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_kms_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateKmsConfig {
-        super::builder::net_app::CreateKmsConfig::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_kms_config(&self) -> super::builder::net_app::CreateKmsConfig {
+        super::builder::net_app::CreateKmsConfig::new(self.inner.clone())
     }
 
     /// Returns the description of the specified KMS config by kms_config_id.
-    pub fn get_kms_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetKmsConfig {
-        super::builder::net_app::GetKmsConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_kms_config(&self) -> super::builder::net_app::GetKmsConfig {
+        super::builder::net_app::GetKmsConfig::new(self.inner.clone())
     }
 
     /// Updates the Kms config properties with the full spec
@@ -511,12 +424,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_kms_config(
-        &self,
-        kms_config: impl Into<crate::model::KmsConfig>,
-    ) -> super::builder::net_app::UpdateKmsConfig {
+    pub fn update_kms_config(&self) -> super::builder::net_app::UpdateKmsConfig {
         super::builder::net_app::UpdateKmsConfig::new(self.inner.clone())
-            .set_kms_config(kms_config.into())
     }
 
     /// Encrypt the existing volumes without CMEK encryption with the desired the
@@ -531,19 +440,13 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn encrypt_volumes(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::EncryptVolumes {
-        super::builder::net_app::EncryptVolumes::new(self.inner.clone()).set_name(name.into())
+    pub fn encrypt_volumes(&self) -> super::builder::net_app::EncryptVolumes {
+        super::builder::net_app::EncryptVolumes::new(self.inner.clone())
     }
 
     /// Verifies KMS config reachability.
-    pub fn verify_kms_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::VerifyKmsConfig {
-        super::builder::net_app::VerifyKmsConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn verify_kms_config(&self) -> super::builder::net_app::VerifyKmsConfig {
+        super::builder::net_app::VerifyKmsConfig::new(self.inner.clone())
     }
 
     /// Warning! This operation will permanently delete the Kms config.
@@ -557,27 +460,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_kms_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteKmsConfig {
-        super::builder::net_app::DeleteKmsConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_kms_config(&self) -> super::builder::net_app::DeleteKmsConfig {
+        super::builder::net_app::DeleteKmsConfig::new(self.inner.clone())
     }
 
     /// Returns descriptions of all replications for a volume.
-    pub fn list_replications(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListReplications {
-        super::builder::net_app::ListReplications::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_replications(&self) -> super::builder::net_app::ListReplications {
+        super::builder::net_app::ListReplications::new(self.inner.clone())
     }
 
     /// Describe a replication for a volume.
-    pub fn get_replication(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetReplication {
-        super::builder::net_app::GetReplication::new(self.inner.clone()).set_name(name.into())
+    pub fn get_replication(&self) -> super::builder::net_app::GetReplication {
+        super::builder::net_app::GetReplication::new(self.inner.clone())
     }
 
     /// Create a new replication for a volume.
@@ -591,12 +485,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_replication(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateReplication {
+    pub fn create_replication(&self) -> super::builder::net_app::CreateReplication {
         super::builder::net_app::CreateReplication::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a replication.
@@ -610,11 +500,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_replication(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteReplication {
-        super::builder::net_app::DeleteReplication::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_replication(&self) -> super::builder::net_app::DeleteReplication {
+        super::builder::net_app::DeleteReplication::new(self.inner.clone())
     }
 
     /// Updates the settings of a specific replication.
@@ -628,12 +515,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_replication(
-        &self,
-        replication: impl Into<crate::model::Replication>,
-    ) -> super::builder::net_app::UpdateReplication {
+    pub fn update_replication(&self) -> super::builder::net_app::UpdateReplication {
         super::builder::net_app::UpdateReplication::new(self.inner.clone())
-            .set_replication(replication.into())
     }
 
     /// Stop Cross Region Replication.
@@ -647,11 +530,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_replication(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::StopReplication {
-        super::builder::net_app::StopReplication::new(self.inner.clone()).set_name(name.into())
+    pub fn stop_replication(&self) -> super::builder::net_app::StopReplication {
+        super::builder::net_app::StopReplication::new(self.inner.clone())
     }
 
     /// Resume Cross Region Replication.
@@ -665,11 +545,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn resume_replication(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ResumeReplication {
-        super::builder::net_app::ResumeReplication::new(self.inner.clone()).set_name(name.into())
+    pub fn resume_replication(&self) -> super::builder::net_app::ResumeReplication {
+        super::builder::net_app::ResumeReplication::new(self.inner.clone())
     }
 
     /// Reverses direction of replication. Source becomes destination and
@@ -686,10 +563,8 @@ impl NetApp {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reverse_replication_direction(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::net_app::ReverseReplicationDirection {
         super::builder::net_app::ReverseReplicationDirection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Establish replication peering.
@@ -703,11 +578,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn establish_peering(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::EstablishPeering {
-        super::builder::net_app::EstablishPeering::new(self.inner.clone()).set_name(name.into())
+    pub fn establish_peering(&self) -> super::builder::net_app::EstablishPeering {
+        super::builder::net_app::EstablishPeering::new(self.inner.clone())
     }
 
     /// Syncs the replication. This will invoke one time volume data transfer from
@@ -722,11 +594,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn sync_replication(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::SyncReplication {
-        super::builder::net_app::SyncReplication::new(self.inner.clone()).set_name(name.into())
+    pub fn sync_replication(&self) -> super::builder::net_app::SyncReplication {
+        super::builder::net_app::SyncReplication::new(self.inner.clone())
     }
 
     /// Creates new backup vault
@@ -740,28 +609,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_vault(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateBackupVault {
+    pub fn create_backup_vault(&self) -> super::builder::net_app::CreateBackupVault {
         super::builder::net_app::CreateBackupVault::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the description of the specified backup vault
-    pub fn get_backup_vault(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetBackupVault {
-        super::builder::net_app::GetBackupVault::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup_vault(&self) -> super::builder::net_app::GetBackupVault {
+        super::builder::net_app::GetBackupVault::new(self.inner.clone())
     }
 
     /// Returns list of all available backup vaults.
-    pub fn list_backup_vaults(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListBackupVaults {
-        super::builder::net_app::ListBackupVaults::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_backup_vaults(&self) -> super::builder::net_app::ListBackupVaults {
+        super::builder::net_app::ListBackupVaults::new(self.inner.clone())
     }
 
     /// Updates the settings of a specific backup vault.
@@ -775,12 +634,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup_vault(
-        &self,
-        backup_vault: impl Into<crate::model::BackupVault>,
-    ) -> super::builder::net_app::UpdateBackupVault {
+    pub fn update_backup_vault(&self) -> super::builder::net_app::UpdateBackupVault {
         super::builder::net_app::UpdateBackupVault::new(self.inner.clone())
-            .set_backup_vault(backup_vault.into())
     }
 
     /// Warning! This operation will permanently delete the backup vault.
@@ -794,11 +649,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_vault(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteBackupVault {
-        super::builder::net_app::DeleteBackupVault::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup_vault(&self) -> super::builder::net_app::DeleteBackupVault {
+        super::builder::net_app::DeleteBackupVault::new(self.inner.clone())
     }
 
     /// Creates a backup from the volume specified in the request
@@ -815,27 +667,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateBackup {
-        super::builder::net_app::CreateBackup::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_backup(&self) -> super::builder::net_app::CreateBackup {
+        super::builder::net_app::CreateBackup::new(self.inner.clone())
     }
 
     /// Returns the description of the specified backup
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetBackup {
-        super::builder::net_app::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::net_app::GetBackup {
+        super::builder::net_app::GetBackup::new(self.inner.clone())
     }
 
     /// Returns descriptions of all backups for a backupVault.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListBackups {
-        super::builder::net_app::ListBackups::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_backups(&self) -> super::builder::net_app::ListBackups {
+        super::builder::net_app::ListBackups::new(self.inner.clone())
     }
 
     /// Warning! This operation will permanently delete the backup.
@@ -849,11 +692,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteBackup {
-        super::builder::net_app::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::net_app::DeleteBackup {
+        super::builder::net_app::DeleteBackup::new(self.inner.clone())
     }
 
     /// Update backup with full spec.
@@ -867,11 +707,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::net_app::UpdateBackup {
-        super::builder::net_app::UpdateBackup::new(self.inner.clone()).set_backup(backup.into())
+    pub fn update_backup(&self) -> super::builder::net_app::UpdateBackup {
+        super::builder::net_app::UpdateBackup::new(self.inner.clone())
     }
 
     /// Creates new backup policy
@@ -885,29 +722,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateBackupPolicy {
+    pub fn create_backup_policy(&self) -> super::builder::net_app::CreateBackupPolicy {
         super::builder::net_app::CreateBackupPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the description of the specified backup policy by backup_policy_id.
-    pub fn get_backup_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetBackupPolicy {
-        super::builder::net_app::GetBackupPolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup_policy(&self) -> super::builder::net_app::GetBackupPolicy {
+        super::builder::net_app::GetBackupPolicy::new(self.inner.clone())
     }
 
     /// Returns list of all available backup policies.
-    pub fn list_backup_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListBackupPolicies {
+    pub fn list_backup_policies(&self) -> super::builder::net_app::ListBackupPolicies {
         super::builder::net_app::ListBackupPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates settings of a specific backup policy.
@@ -921,12 +747,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_backup_policy(
-        &self,
-        backup_policy: impl Into<crate::model::BackupPolicy>,
-    ) -> super::builder::net_app::UpdateBackupPolicy {
+    pub fn update_backup_policy(&self) -> super::builder::net_app::UpdateBackupPolicy {
         super::builder::net_app::UpdateBackupPolicy::new(self.inner.clone())
-            .set_backup_policy(backup_policy.into())
     }
 
     /// Warning! This operation will permanently delete the backup policy.
@@ -940,27 +762,18 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteBackupPolicy {
-        super::builder::net_app::DeleteBackupPolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup_policy(&self) -> super::builder::net_app::DeleteBackupPolicy {
+        super::builder::net_app::DeleteBackupPolicy::new(self.inner.clone())
     }
 
     /// Returns list of all quota rules in a location.
-    pub fn list_quota_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListQuotaRules {
-        super::builder::net_app::ListQuotaRules::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_quota_rules(&self) -> super::builder::net_app::ListQuotaRules {
+        super::builder::net_app::ListQuotaRules::new(self.inner.clone())
     }
 
     /// Returns details of the specified quota rule.
-    pub fn get_quota_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetQuotaRule {
-        super::builder::net_app::GetQuotaRule::new(self.inner.clone()).set_name(name.into())
+    pub fn get_quota_rule(&self) -> super::builder::net_app::GetQuotaRule {
+        super::builder::net_app::GetQuotaRule::new(self.inner.clone())
     }
 
     /// Creates a new quota rule.
@@ -974,11 +787,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_quota_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CreateQuotaRule {
-        super::builder::net_app::CreateQuotaRule::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_quota_rule(&self) -> super::builder::net_app::CreateQuotaRule {
+        super::builder::net_app::CreateQuotaRule::new(self.inner.clone())
     }
 
     /// Updates a quota rule.
@@ -992,12 +802,8 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_quota_rule(
-        &self,
-        quota_rule: impl Into<crate::model::QuotaRule>,
-    ) -> super::builder::net_app::UpdateQuotaRule {
+    pub fn update_quota_rule(&self) -> super::builder::net_app::UpdateQuotaRule {
         super::builder::net_app::UpdateQuotaRule::new(self.inner.clone())
-            .set_quota_rule(quota_rule.into())
     }
 
     /// Deletes a quota rule.
@@ -1011,66 +817,45 @@ impl NetApp {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_quota_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteQuotaRule {
-        super::builder::net_app::DeleteQuotaRule::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_quota_rule(&self) -> super::builder::net_app::DeleteQuotaRule {
+        super::builder::net_app::DeleteQuotaRule::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListLocations {
-        super::builder::net_app::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::net_app::ListLocations {
+        super::builder::net_app::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetLocation {
-        super::builder::net_app::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::net_app::GetLocation {
+        super::builder::net_app::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::ListOperations {
-        super::builder::net_app::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::net_app::ListOperations {
+        super::builder::net_app::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::GetOperation {
-        super::builder::net_app::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::net_app::GetOperation {
+        super::builder::net_app::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::DeleteOperation {
-        super::builder::net_app::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::net_app::DeleteOperation {
+        super::builder::net_app::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::net_app::CancelOperation {
-        super::builder::net_app::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::net_app::CancelOperation {
+        super::builder::net_app::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListStoragePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/storagePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/storagePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,12 +76,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/storagePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/storagePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,9 +103,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StoragePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.storage_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("storage_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.storage_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("storage_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,12 +186,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:validateDirectoryService", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:validateDirectoryService", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -187,9 +210,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:switch", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:switch", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,9 +234,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVolumesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/volumes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/volumes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -227,9 +264,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Volume>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,9 +290,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/volumes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/volumes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -264,18 +315,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.volume
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.volume
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -296,9 +344,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +371,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revert", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revert", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -333,12 +395,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSnapshotsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -359,9 +425,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snapshot>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -378,12 +451,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/snapshots", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/snapshots", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -401,9 +478,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -420,18 +504,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.snapshot
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.snapshot
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,12 +535,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListActiveDirectoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/activeDirectories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/activeDirectories", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -480,9 +565,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ActiveDirectory>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -499,12 +591,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/activeDirectories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/activeDirectories", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -522,18 +618,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.active_directory
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("active_directory"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.active_directory
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("active_directory"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -556,9 +649,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -575,12 +675,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKmsConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/kmsConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/kmsConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -601,12 +705,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/kmsConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/kmsConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -624,9 +732,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::KmsConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -643,18 +758,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.kms_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("kms_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.kms_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("kms_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -677,9 +789,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:encrypt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:encrypt", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -694,9 +813,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyKmsConfigResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:verify", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:verify", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -711,9 +837,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -730,12 +863,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReplicationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/replications", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/replications", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -756,9 +893,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Replication>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -775,12 +919,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/replications", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/replications", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -798,9 +946,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -817,18 +972,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.replication
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("replication"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.replication
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("replication"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -851,9 +1003,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -868,9 +1027,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -885,12 +1051,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reverseDirection", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:reverseDirection", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -905,12 +1075,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:establishPeering", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:establishPeering", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -925,9 +1099,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:sync", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:sync", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -942,12 +1123,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupVaults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupVaults", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -965,9 +1150,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupVault>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -984,12 +1176,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupVaultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupVaults", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupVaults", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1010,18 +1206,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_vault
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_vault
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1044,9 +1237,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1063,9 +1263,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1081,9 +1288,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1100,9 +1314,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1123,9 +1344,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1142,18 +1370,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1174,12 +1399,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1197,9 +1426,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1216,12 +1452,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1242,18 +1482,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1276,9 +1513,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1295,12 +1539,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQuotaRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/quotaRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/quotaRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1321,9 +1569,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QuotaRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1340,12 +1595,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/quotaRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/quotaRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1363,18 +1622,15 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.quota_rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("quota_rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.quota_rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("quota_rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1397,9 +1653,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1416,9 +1679,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1438,9 +1708,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1457,9 +1734,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1479,9 +1763,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1498,9 +1789,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1521,9 +1819,16 @@ impl super::stub::NetApp for NetApp {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.storage_pool
+            let arg = &req
+                .storage_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("storage_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("storage_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -316,10 +321,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.volume
+            let arg = &req
+                .volume
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("volume"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("volume.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -505,10 +515,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.snapshot
+            let arg = &req
+                .snapshot
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("snapshot"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("snapshot.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -619,10 +634,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.active_directory
+            let arg = &req
+                .active_directory
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("active_directory"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("active_directory.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -759,10 +779,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.kms_config
+            let arg = &req
+                .kms_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("kms_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("kms_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -973,10 +998,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.replication
+            let arg = &req
+                .replication
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("replication"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("replication.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1207,10 +1237,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_vault
+            let arg = &req
+                .backup_vault
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_vault"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_vault.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1371,10 +1406,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1483,10 +1523,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_policy
+            let arg = &req
+                .backup_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1623,10 +1668,15 @@ impl super::stub::NetApp for NetApp {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.quota_rule
+            let arg = &req
+                .quota_rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("quota_rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("quota_rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/networkconnectivity/v1/src/client.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/client.rs
@@ -123,23 +123,19 @@ impl CrossNetworkAutomationService {
     /// Lists ServiceConnectionMaps in a given project and location.
     pub fn list_service_connection_maps(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListServiceConnectionMaps {
         super::builder::cross_network_automation_service::ListServiceConnectionMaps::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single ServiceConnectionMap.
     pub fn get_service_connection_map(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionMap {
         super::builder::cross_network_automation_service::GetServiceConnectionMap::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a new ServiceConnectionMap in a given project and location.
@@ -155,12 +151,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_service_connection_map(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::CreateServiceConnectionMap {
         super::builder::cross_network_automation_service::CreateServiceConnectionMap::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ServiceConnectionMap.
@@ -176,12 +170,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_service_connection_map(
         &self,
-        service_connection_map: impl Into<crate::model::ServiceConnectionMap>,
     ) -> super::builder::cross_network_automation_service::UpdateServiceConnectionMap {
         super::builder::cross_network_automation_service::UpdateServiceConnectionMap::new(
             self.inner.clone(),
         )
-        .set_service_connection_map(service_connection_map.into())
     }
 
     /// Deletes a single ServiceConnectionMap.
@@ -197,34 +189,28 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_connection_map(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::DeleteServiceConnectionMap {
         super::builder::cross_network_automation_service::DeleteServiceConnectionMap::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists ServiceConnectionPolicies in a given project and location.
     pub fn list_service_connection_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListServiceConnectionPolicies {
         super::builder::cross_network_automation_service::ListServiceConnectionPolicies::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single ServiceConnectionPolicy.
     pub fn get_service_connection_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionPolicy {
         super::builder::cross_network_automation_service::GetServiceConnectionPolicy::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a new ServiceConnectionPolicy in a given project and location.
@@ -240,12 +226,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_service_connection_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::CreateServiceConnectionPolicy {
         super::builder::cross_network_automation_service::CreateServiceConnectionPolicy::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ServiceConnectionPolicy.
@@ -261,12 +245,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_service_connection_policy(
         &self,
-        service_connection_policy: impl Into<crate::model::ServiceConnectionPolicy>,
     ) -> super::builder::cross_network_automation_service::UpdateServiceConnectionPolicy {
         super::builder::cross_network_automation_service::UpdateServiceConnectionPolicy::new(
             self.inner.clone(),
         )
-        .set_service_connection_policy(service_connection_policy.into())
     }
 
     /// Deletes a single ServiceConnectionPolicy.
@@ -282,32 +264,26 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_connection_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::DeleteServiceConnectionPolicy {
         super::builder::cross_network_automation_service::DeleteServiceConnectionPolicy::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists ServiceClasses in a given project and location.
     pub fn list_service_classes(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListServiceClasses {
         super::builder::cross_network_automation_service::ListServiceClasses::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Gets details of a single ServiceClass.
     pub fn get_service_class(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::GetServiceClass {
         super::builder::cross_network_automation_service::GetServiceClass::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the parameters of a single ServiceClass.
@@ -323,12 +299,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_service_class(
         &self,
-        service_class: impl Into<crate::model::ServiceClass>,
     ) -> super::builder::cross_network_automation_service::UpdateServiceClass {
         super::builder::cross_network_automation_service::UpdateServiceClass::new(
             self.inner.clone(),
         )
-        .set_service_class(service_class.into())
     }
 
     /// Deletes a single ServiceClass.
@@ -344,34 +318,28 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_class(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::DeleteServiceClass {
         super::builder::cross_network_automation_service::DeleteServiceClass::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Gets details of a single ServiceConnectionToken.
     pub fn get_service_connection_token(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionToken {
         super::builder::cross_network_automation_service::GetServiceConnectionToken::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists ServiceConnectionTokens in a given project and location.
     pub fn list_service_connection_tokens(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListServiceConnectionTokens {
         super::builder::cross_network_automation_service::ListServiceConnectionTokens::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Creates a new ServiceConnectionToken in a given project and location.
@@ -387,12 +355,10 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_service_connection_token(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::CreateServiceConnectionToken {
         super::builder::cross_network_automation_service::CreateServiceConnectionToken::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Deletes a single ServiceConnectionToken.
@@ -408,30 +374,22 @@ impl CrossNetworkAutomationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_connection_token(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::DeleteServiceConnectionToken {
         super::builder::cross_network_automation_service::DeleteServiceConnectionToken::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
     pub fn list_locations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListLocations {
         super::builder::cross_network_automation_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cross_network_automation_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::cross_network_automation_service::GetLocation {
         super::builder::cross_network_automation_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -439,22 +397,14 @@ impl CrossNetworkAutomationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cross_network_automation_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cross_network_automation_service::SetIamPolicy {
         super::builder::cross_network_automation_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cross_network_automation_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cross_network_automation_service::GetIamPolicy {
         super::builder::cross_network_automation_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -466,12 +416,10 @@ impl CrossNetworkAutomationService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::TestIamPermissions {
         super::builder::cross_network_automation_service::TestIamPermissions::new(
             self.inner.clone(),
         )
-        .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -479,21 +427,15 @@ impl CrossNetworkAutomationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::ListOperations {
         super::builder::cross_network_automation_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cross_network_automation_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::cross_network_automation_service::GetOperation {
         super::builder::cross_network_automation_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -501,10 +443,8 @@ impl CrossNetworkAutomationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::DeleteOperation {
         super::builder::cross_network_automation_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -512,10 +452,8 @@ impl CrossNetworkAutomationService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cross_network_automation_service::CancelOperation {
         super::builder::cross_network_automation_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -622,19 +560,13 @@ impl HubService {
     }
 
     /// Lists the Network Connectivity Center hubs associated with a given project.
-    pub fn list_hubs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListHubs {
-        super::builder::hub_service::ListHubs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_hubs(&self) -> super::builder::hub_service::ListHubs {
+        super::builder::hub_service::ListHubs::new(self.inner.clone())
     }
 
     /// Gets details about a Network Connectivity Center hub.
-    pub fn get_hub(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetHub {
-        super::builder::hub_service::GetHub::new(self.inner.clone()).set_name(name.into())
+    pub fn get_hub(&self) -> super::builder::hub_service::GetHub {
+        super::builder::hub_service::GetHub::new(self.inner.clone())
     }
 
     /// Creates a new Network Connectivity Center hub in the specified project.
@@ -648,11 +580,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_hub(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::CreateHub {
-        super::builder::hub_service::CreateHub::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_hub(&self) -> super::builder::hub_service::CreateHub {
+        super::builder::hub_service::CreateHub::new(self.inner.clone())
     }
 
     /// Updates the description and/or labels of a Network Connectivity Center
@@ -667,11 +596,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_hub(
-        &self,
-        hub: impl Into<crate::model::Hub>,
-    ) -> super::builder::hub_service::UpdateHub {
-        super::builder::hub_service::UpdateHub::new(self.inner.clone()).set_hub(hub.into())
+    pub fn update_hub(&self) -> super::builder::hub_service::UpdateHub {
+        super::builder::hub_service::UpdateHub::new(self.inner.clone())
     }
 
     /// Deletes a Network Connectivity Center hub.
@@ -685,47 +611,32 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_hub(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::DeleteHub {
-        super::builder::hub_service::DeleteHub::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_hub(&self) -> super::builder::hub_service::DeleteHub {
+        super::builder::hub_service::DeleteHub::new(self.inner.clone())
     }
 
     /// Lists the Network Connectivity Center spokes associated with a
     /// specified hub and location. The list includes both spokes that are attached
     /// to the hub and spokes that have been proposed but not yet accepted.
-    pub fn list_hub_spokes(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListHubSpokes {
-        super::builder::hub_service::ListHubSpokes::new(self.inner.clone()).set_name(name.into())
+    pub fn list_hub_spokes(&self) -> super::builder::hub_service::ListHubSpokes {
+        super::builder::hub_service::ListHubSpokes::new(self.inner.clone())
     }
 
     /// Query the Private Service Connect propagation status of a Network
     /// Connectivity Center hub.
-    pub fn query_hub_status(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::QueryHubStatus {
-        super::builder::hub_service::QueryHubStatus::new(self.inner.clone()).set_name(name.into())
+    pub fn query_hub_status(&self) -> super::builder::hub_service::QueryHubStatus {
+        super::builder::hub_service::QueryHubStatus::new(self.inner.clone())
     }
 
     /// Lists the Network Connectivity Center spokes in a specified project and
     /// location.
-    pub fn list_spokes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListSpokes {
-        super::builder::hub_service::ListSpokes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_spokes(&self) -> super::builder::hub_service::ListSpokes {
+        super::builder::hub_service::ListSpokes::new(self.inner.clone())
     }
 
     /// Gets details about a Network Connectivity Center spoke.
-    pub fn get_spoke(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetSpoke {
-        super::builder::hub_service::GetSpoke::new(self.inner.clone()).set_name(name.into())
+    pub fn get_spoke(&self) -> super::builder::hub_service::GetSpoke {
+        super::builder::hub_service::GetSpoke::new(self.inner.clone())
     }
 
     /// Creates a Network Connectivity Center spoke.
@@ -739,11 +650,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_spoke(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::CreateSpoke {
-        super::builder::hub_service::CreateSpoke::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_spoke(&self) -> super::builder::hub_service::CreateSpoke {
+        super::builder::hub_service::CreateSpoke::new(self.inner.clone())
     }
 
     /// Updates the parameters of a Network Connectivity Center spoke.
@@ -757,11 +665,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_spoke(
-        &self,
-        spoke: impl Into<crate::model::Spoke>,
-    ) -> super::builder::hub_service::UpdateSpoke {
-        super::builder::hub_service::UpdateSpoke::new(self.inner.clone()).set_spoke(spoke.into())
+    pub fn update_spoke(&self) -> super::builder::hub_service::UpdateSpoke {
+        super::builder::hub_service::UpdateSpoke::new(self.inner.clone())
     }
 
     /// Rejects a Network Connectivity Center spoke from being attached to a hub.
@@ -778,11 +683,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reject_hub_spoke(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::RejectHubSpoke {
-        super::builder::hub_service::RejectHubSpoke::new(self.inner.clone()).set_name(name.into())
+    pub fn reject_hub_spoke(&self) -> super::builder::hub_service::RejectHubSpoke {
+        super::builder::hub_service::RejectHubSpoke::new(self.inner.clone())
     }
 
     /// Accepts a proposal to attach a Network Connectivity Center spoke
@@ -797,11 +699,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn accept_hub_spoke(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::AcceptHubSpoke {
-        super::builder::hub_service::AcceptHubSpoke::new(self.inner.clone()).set_name(name.into())
+    pub fn accept_hub_spoke(&self) -> super::builder::hub_service::AcceptHubSpoke {
+        super::builder::hub_service::AcceptHubSpoke::new(self.inner.clone())
     }
 
     /// Accepts a proposal to update a Network Connectivity Center spoke in a hub.
@@ -815,12 +714,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn accept_spoke_update(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::AcceptSpokeUpdate {
+    pub fn accept_spoke_update(&self) -> super::builder::hub_service::AcceptSpokeUpdate {
         super::builder::hub_service::AcceptSpokeUpdate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rejects a proposal to update a Network Connectivity Center spoke in a hub.
@@ -834,12 +729,8 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reject_spoke_update(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::RejectSpokeUpdate {
+    pub fn reject_spoke_update(&self) -> super::builder::hub_service::RejectSpokeUpdate {
         super::builder::hub_service::RejectSpokeUpdate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a Network Connectivity Center spoke.
@@ -853,60 +744,38 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_spoke(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::DeleteSpoke {
-        super::builder::hub_service::DeleteSpoke::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_spoke(&self) -> super::builder::hub_service::DeleteSpoke {
+        super::builder::hub_service::DeleteSpoke::new(self.inner.clone())
     }
 
     /// Gets details about a Network Connectivity Center route table.
-    pub fn get_route_table(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetRouteTable {
-        super::builder::hub_service::GetRouteTable::new(self.inner.clone()).set_name(name.into())
+    pub fn get_route_table(&self) -> super::builder::hub_service::GetRouteTable {
+        super::builder::hub_service::GetRouteTable::new(self.inner.clone())
     }
 
     /// Gets details about the specified route.
-    pub fn get_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetRoute {
-        super::builder::hub_service::GetRoute::new(self.inner.clone()).set_name(name.into())
+    pub fn get_route(&self) -> super::builder::hub_service::GetRoute {
+        super::builder::hub_service::GetRoute::new(self.inner.clone())
     }
 
     /// Lists routes in a given route table.
-    pub fn list_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListRoutes {
-        super::builder::hub_service::ListRoutes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_routes(&self) -> super::builder::hub_service::ListRoutes {
+        super::builder::hub_service::ListRoutes::new(self.inner.clone())
     }
 
     /// Lists route tables in a given hub.
-    pub fn list_route_tables(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListRouteTables {
+    pub fn list_route_tables(&self) -> super::builder::hub_service::ListRouteTables {
         super::builder::hub_service::ListRouteTables::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details about a Network Connectivity Center group.
-    pub fn get_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetGroup {
-        super::builder::hub_service::GetGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_group(&self) -> super::builder::hub_service::GetGroup {
+        super::builder::hub_service::GetGroup::new(self.inner.clone())
     }
 
     /// Lists groups in a given hub.
-    pub fn list_groups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListGroups {
-        super::builder::hub_service::ListGroups::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_groups(&self) -> super::builder::hub_service::ListGroups {
+        super::builder::hub_service::ListGroups::new(self.inner.clone())
     }
 
     /// Updates the parameters of a Network Connectivity Center group.
@@ -920,27 +789,18 @@ impl HubService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_group(
-        &self,
-        group: impl Into<crate::model::Group>,
-    ) -> super::builder::hub_service::UpdateGroup {
-        super::builder::hub_service::UpdateGroup::new(self.inner.clone()).set_group(group.into())
+    pub fn update_group(&self) -> super::builder::hub_service::UpdateGroup {
+        super::builder::hub_service::UpdateGroup::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListLocations {
-        super::builder::hub_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::hub_service::ListLocations {
+        super::builder::hub_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetLocation {
-        super::builder::hub_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::hub_service::GetLocation {
+        super::builder::hub_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -948,22 +808,14 @@ impl HubService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::hub_service::SetIamPolicy {
         super::builder::hub_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::hub_service::GetIamPolicy {
         super::builder::hub_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -973,52 +825,36 @@ impl HubService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::hub_service::TestIamPermissions {
         super::builder::hub_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::ListOperations {
-        super::builder::hub_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::hub_service::ListOperations {
+        super::builder::hub_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::GetOperation {
-        super::builder::hub_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::hub_service::GetOperation {
+        super::builder::hub_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::DeleteOperation {
-        super::builder::hub_service::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::hub_service::DeleteOperation {
+        super::builder::hub_service::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::hub_service::CancelOperation {
-        super::builder::hub_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::hub_service::CancelOperation {
+        super::builder::hub_service::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1128,19 +964,15 @@ impl PolicyBasedRoutingService {
     /// Lists policy-based routes in a given project and location.
     pub fn list_policy_based_routes(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::ListPolicyBasedRoutes {
         super::builder::policy_based_routing_service::ListPolicyBasedRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single policy-based route.
     pub fn get_policy_based_route(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::GetPolicyBasedRoute {
         super::builder::policy_based_routing_service::GetPolicyBasedRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new policy-based route in a given project and location.
@@ -1156,12 +988,10 @@ impl PolicyBasedRoutingService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_policy_based_route(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::CreatePolicyBasedRoute {
         super::builder::policy_based_routing_service::CreatePolicyBasedRoute::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Deletes a single policy-based route.
@@ -1177,30 +1007,20 @@ impl PolicyBasedRoutingService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_policy_based_route(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::DeletePolicyBasedRoute {
         super::builder::policy_based_routing_service::DeletePolicyBasedRoute::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::policy_based_routing_service::ListLocations {
         super::builder::policy_based_routing_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::policy_based_routing_service::GetLocation {
         super::builder::policy_based_routing_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1208,22 +1028,14 @@ impl PolicyBasedRoutingService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::policy_based_routing_service::SetIamPolicy {
         super::builder::policy_based_routing_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::policy_based_routing_service::GetIamPolicy {
         super::builder::policy_based_routing_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1235,32 +1047,22 @@ impl PolicyBasedRoutingService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::TestIamPermissions {
         super::builder::policy_based_routing_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::policy_based_routing_service::ListOperations {
         super::builder::policy_based_routing_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_based_routing_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::policy_based_routing_service::GetOperation {
         super::builder::policy_based_routing_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1268,10 +1070,8 @@ impl PolicyBasedRoutingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::DeleteOperation {
         super::builder::policy_based_routing_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1279,9 +1079,7 @@ impl PolicyBasedRoutingService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::policy_based_routing_service::CancelOperation {
         super::builder::policy_based_routing_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceConnectionMapsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceConnectionMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceConnectionMaps", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceConnectionMap>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceConnectionMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceConnectionMaps", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service_connection_map
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_connection_map"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service_connection_map
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_connection_map"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +193,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceConnectionPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceConnectionPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceConnectionPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,9 +223,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceConnectionPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,12 +249,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceConnectionPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceConnectionPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,18 +280,15 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service_connection_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_connection_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service_connection_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_connection_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -281,9 +312,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -305,12 +343,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceClassesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceClasses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceClasses", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -331,9 +373,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceClass>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -350,18 +399,15 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service_class
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_class"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service_class
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_class"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -385,9 +431,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,9 +462,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceConnectionToken>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -428,12 +488,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceConnectionTokensResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceConnectionTokens", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceConnectionTokens", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,12 +518,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceConnectionTokens", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceConnectionTokens", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -479,9 +547,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -503,9 +578,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -525,9 +607,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -544,12 +633,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -564,12 +657,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,12 +693,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -616,9 +717,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -638,9 +746,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -657,9 +772,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -680,9 +802,16 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -739,9 +868,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHubsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/hubs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/hubs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -762,9 +898,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Hub>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -781,9 +924,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/hubs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/hubs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -800,18 +950,15 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.hub
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("hub"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.hub
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("hub"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -833,9 +980,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -853,9 +1007,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHubSpokesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listSpokes", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:listSpokes", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -880,12 +1041,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryHubStatusResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:queryStatus", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:queryStatus", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -907,9 +1072,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSpokesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/spokes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/spokes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -930,9 +1102,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Spoke>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -949,9 +1128,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/spokes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/spokes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -968,18 +1154,15 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.spoke
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("spoke"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.spoke
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("spoke"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1001,12 +1184,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rejectSpoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rejectSpoke", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1021,12 +1208,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:acceptSpoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:acceptSpoke", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1041,12 +1232,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:acceptSpokeUpdate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:acceptSpokeUpdate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1061,12 +1256,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rejectSpokeUpdate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rejectSpokeUpdate", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1081,9 +1280,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1101,9 +1307,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RouteTable>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1120,9 +1333,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Route>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1139,9 +1359,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/routes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/routes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1162,12 +1389,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRouteTablesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/routeTables", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/routeTables", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1188,9 +1419,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1207,9 +1445,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/groups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1230,18 +1475,15 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1263,9 +1505,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1285,9 +1534,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1304,12 +1560,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1324,12 +1584,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1356,12 +1620,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1376,9 +1644,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1398,9 +1673,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1417,9 +1699,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1440,9 +1729,16 @@ impl super::stub::HubService for HubService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1499,12 +1795,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPolicyBasedRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/policyBasedRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/policyBasedRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1525,9 +1825,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PolicyBasedRoute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1544,12 +1851,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/policyBasedRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/policyBasedRoutes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1568,9 +1879,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1588,9 +1906,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1610,9 +1935,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1629,12 +1961,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1649,12 +1985,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1681,12 +2021,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1701,9 +2045,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1723,9 +2074,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1742,9 +2100,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1765,9 +2130,16 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service_connection_map
+            let arg = &req
+                .service_connection_map
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_connection_map"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_connection_map.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -281,10 +286,17 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service_connection_policy
+            let arg = &req
+                .service_connection_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_connection_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "service_connection_policy.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -400,10 +412,15 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service_class
+            let arg = &req
+                .service_class
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_class"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_class.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -951,10 +968,15 @@ impl super::stub::HubService for HubService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.hub
+            let arg = &req
+                .hub
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("hub"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("hub.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1155,10 +1177,15 @@ impl super::stub::HubService for HubService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.spoke
+            let arg = &req
+                .spoke
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("spoke"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("spoke.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1476,10 +1503,15 @@ impl super::stub::HubService for HubService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.group
+            let arg = &req
+                .group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/networkmanagement/v1/src/client.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/client.rs
@@ -130,19 +130,15 @@ impl ReachabilityService {
     /// Lists all Connectivity Tests owned by a project.
     pub fn list_connectivity_tests(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reachability_service::ListConnectivityTests {
         super::builder::reachability_service::ListConnectivityTests::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific Connectivity Test.
     pub fn get_connectivity_test(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reachability_service::GetConnectivityTest {
         super::builder::reachability_service::GetConnectivityTest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Connectivity Test.
@@ -170,10 +166,8 @@ impl ReachabilityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_connectivity_test(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::reachability_service::CreateConnectivityTest {
         super::builder::reachability_service::CreateConnectivityTest::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the configuration of an existing `ConnectivityTest`.
@@ -202,10 +196,8 @@ impl ReachabilityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_connectivity_test(
         &self,
-        resource: impl Into<crate::model::ConnectivityTest>,
     ) -> super::builder::reachability_service::UpdateConnectivityTest {
         super::builder::reachability_service::UpdateConnectivityTest::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Rerun an existing `ConnectivityTest`.
@@ -232,10 +224,8 @@ impl ReachabilityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn rerun_connectivity_test(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reachability_service::RerunConnectivityTest {
         super::builder::reachability_service::RerunConnectivityTest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a specific `ConnectivityTest`.
@@ -251,28 +241,18 @@ impl ReachabilityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_connectivity_test(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::reachability_service::DeleteConnectivityTest {
         super::builder::reachability_service::DeleteConnectivityTest::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::reachability_service::ListLocations {
         super::builder::reachability_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::reachability_service::GetLocation {
         super::builder::reachability_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -280,22 +260,14 @@ impl ReachabilityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::reachability_service::SetIamPolicy {
         super::builder::reachability_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::reachability_service::GetIamPolicy {
         super::builder::reachability_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -305,56 +277,36 @@ impl ReachabilityService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::reachability_service::TestIamPermissions {
         super::builder::reachability_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::reachability_service::ListOperations {
         super::builder::reachability_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::reachability_service::GetOperation {
         super::builder::reachability_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::reachability_service::DeleteOperation {
         super::builder::reachability_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::reachability_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::reachability_service::CancelOperation {
         super::builder::reachability_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -465,19 +417,15 @@ impl VpcFlowLogsService {
     /// Lists all `VpcFlowLogsConfigs` in a given project.
     pub fn list_vpc_flow_logs_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vpc_flow_logs_service::ListVpcFlowLogsConfigs {
         super::builder::vpc_flow_logs_service::ListVpcFlowLogsConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific `VpcFlowLogsConfig`.
     pub fn get_vpc_flow_logs_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vpc_flow_logs_service::GetVpcFlowLogsConfig {
         super::builder::vpc_flow_logs_service::GetVpcFlowLogsConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `VpcFlowLogsConfig`.
@@ -507,10 +455,8 @@ impl VpcFlowLogsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_vpc_flow_logs_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vpc_flow_logs_service::CreateVpcFlowLogsConfig {
         super::builder::vpc_flow_logs_service::CreateVpcFlowLogsConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing `VpcFlowLogsConfig`.
@@ -540,10 +486,8 @@ impl VpcFlowLogsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_vpc_flow_logs_config(
         &self,
-        vpc_flow_logs_config: impl Into<crate::model::VpcFlowLogsConfig>,
     ) -> super::builder::vpc_flow_logs_service::UpdateVpcFlowLogsConfig {
         super::builder::vpc_flow_logs_service::UpdateVpcFlowLogsConfig::new(self.inner.clone())
-            .set_vpc_flow_logs_config(vpc_flow_logs_config.into())
     }
 
     /// Deletes a specific `VpcFlowLogsConfig`.
@@ -559,28 +503,18 @@ impl VpcFlowLogsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_vpc_flow_logs_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vpc_flow_logs_service::DeleteVpcFlowLogsConfig {
         super::builder::vpc_flow_logs_service::DeleteVpcFlowLogsConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::vpc_flow_logs_service::ListLocations {
         super::builder::vpc_flow_logs_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::vpc_flow_logs_service::GetLocation {
         super::builder::vpc_flow_logs_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -588,22 +522,14 @@ impl VpcFlowLogsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::vpc_flow_logs_service::SetIamPolicy {
         super::builder::vpc_flow_logs_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::vpc_flow_logs_service::GetIamPolicy {
         super::builder::vpc_flow_logs_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -615,53 +541,35 @@ impl VpcFlowLogsService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::vpc_flow_logs_service::TestIamPermissions {
         super::builder::vpc_flow_logs_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::vpc_flow_logs_service::ListOperations {
         super::builder::vpc_flow_logs_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::vpc_flow_logs_service::GetOperation {
         super::builder::vpc_flow_logs_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::vpc_flow_logs_service::DeleteOperation {
         super::builder::vpc_flow_logs_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_flow_logs_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::vpc_flow_logs_service::CancelOperation {
         super::builder::vpc_flow_logs_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::ReachabilityService for ReachabilityService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.resource
+            let arg = &req
+                .resource
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("resource"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -584,10 +589,15 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.vpc_flow_logs_config
+            let arg = &req
+                .vpc_flow_logs_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("vpc_flow_logs_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("vpc_flow_logs_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectivityTestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectivityTests", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectivityTests", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectivityTest>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connectivityTests", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connectivityTests", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.resource
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("resource"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.resource
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("resource"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rerun", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rerun", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,9 +184,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,9 +210,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,9 +239,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,12 +265,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -245,12 +289,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,12 +325,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,9 +349,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,9 +378,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,9 +404,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,9 +434,16 @@ impl super::stub::ReachabilityService for ReachabilityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -420,12 +500,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVpcFlowLogsConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vpcFlowLogsConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vpcFlowLogsConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -446,9 +530,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VpcFlowLogsConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -465,12 +556,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/vpcFlowLogsConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/vpcFlowLogsConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -488,18 +583,15 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.vpc_flow_logs_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("vpc_flow_logs_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.vpc_flow_logs_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("vpc_flow_logs_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -522,9 +614,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -541,9 +640,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,9 +669,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -582,12 +695,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -602,12 +719,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -634,12 +755,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -654,9 +779,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -676,9 +808,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -695,9 +834,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -718,9 +864,16 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/networksecurity/v1/src/client.rs
+++ b/src/generated/cloud/networksecurity/v1/src/client.rs
@@ -125,19 +125,15 @@ impl NetworkSecurity {
     /// Lists AuthorizationPolicies in a given project and location.
     pub fn list_authorization_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::ListAuthorizationPolicies {
         super::builder::network_security::ListAuthorizationPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single AuthorizationPolicy.
     pub fn get_authorization_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::network_security::GetAuthorizationPolicy {
         super::builder::network_security::GetAuthorizationPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new AuthorizationPolicy in a given project and location.
@@ -153,10 +149,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_authorization_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::CreateAuthorizationPolicy {
         super::builder::network_security::CreateAuthorizationPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single AuthorizationPolicy.
@@ -172,10 +166,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_authorization_policy(
         &self,
-        authorization_policy: impl Into<crate::model::AuthorizationPolicy>,
     ) -> super::builder::network_security::UpdateAuthorizationPolicy {
         super::builder::network_security::UpdateAuthorizationPolicy::new(self.inner.clone())
-            .set_authorization_policy(authorization_policy.into())
     }
 
     /// Deletes a single AuthorizationPolicy.
@@ -191,28 +183,20 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_authorization_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::network_security::DeleteAuthorizationPolicy {
         super::builder::network_security::DeleteAuthorizationPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ServerTlsPolicies in a given project and location.
     pub fn list_server_tls_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::ListServerTlsPolicies {
         super::builder::network_security::ListServerTlsPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ServerTlsPolicy.
-    pub fn get_server_tls_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::GetServerTlsPolicy {
+    pub fn get_server_tls_policy(&self) -> super::builder::network_security::GetServerTlsPolicy {
         super::builder::network_security::GetServerTlsPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ServerTlsPolicy in a given project and location.
@@ -228,10 +212,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_server_tls_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::CreateServerTlsPolicy {
         super::builder::network_security::CreateServerTlsPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ServerTlsPolicy.
@@ -247,10 +229,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_server_tls_policy(
         &self,
-        server_tls_policy: impl Into<crate::model::ServerTlsPolicy>,
     ) -> super::builder::network_security::UpdateServerTlsPolicy {
         super::builder::network_security::UpdateServerTlsPolicy::new(self.inner.clone())
-            .set_server_tls_policy(server_tls_policy.into())
     }
 
     /// Deletes a single ServerTlsPolicy.
@@ -266,28 +246,20 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_server_tls_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::network_security::DeleteServerTlsPolicy {
         super::builder::network_security::DeleteServerTlsPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ClientTlsPolicies in a given project and location.
     pub fn list_client_tls_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::ListClientTlsPolicies {
         super::builder::network_security::ListClientTlsPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ClientTlsPolicy.
-    pub fn get_client_tls_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::GetClientTlsPolicy {
+    pub fn get_client_tls_policy(&self) -> super::builder::network_security::GetClientTlsPolicy {
         super::builder::network_security::GetClientTlsPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ClientTlsPolicy in a given project and location.
@@ -303,10 +275,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_client_tls_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::network_security::CreateClientTlsPolicy {
         super::builder::network_security::CreateClientTlsPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ClientTlsPolicy.
@@ -322,10 +292,8 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_client_tls_policy(
         &self,
-        client_tls_policy: impl Into<crate::model::ClientTlsPolicy>,
     ) -> super::builder::network_security::UpdateClientTlsPolicy {
         super::builder::network_security::UpdateClientTlsPolicy::new(self.inner.clone())
-            .set_client_tls_policy(client_tls_policy.into())
     }
 
     /// Deletes a single ClientTlsPolicy.
@@ -341,27 +309,18 @@ impl NetworkSecurity {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_client_tls_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::network_security::DeleteClientTlsPolicy {
         super::builder::network_security::DeleteClientTlsPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::ListLocations {
+    pub fn list_locations(&self) -> super::builder::network_security::ListLocations {
         super::builder::network_security::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::GetLocation {
-        super::builder::network_security::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::network_security::GetLocation {
+        super::builder::network_security::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -369,22 +328,14 @@ impl NetworkSecurity {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_security::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::network_security::SetIamPolicy {
         super::builder::network_security::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_security::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::network_security::GetIamPolicy {
         super::builder::network_security::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -394,55 +345,35 @@ impl NetworkSecurity {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_security::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::network_security::TestIamPermissions {
         super::builder::network_security::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::ListOperations {
+    pub fn list_operations(&self) -> super::builder::network_security::ListOperations {
         super::builder::network_security::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::GetOperation {
+    pub fn get_operation(&self) -> super::builder::network_security::GetOperation {
         super::builder::network_security::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::network_security::DeleteOperation {
         super::builder::network_security::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_security::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::network_security::CancelOperation {
         super::builder::network_security::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -128,10 +128,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.authorization_policy
+            let arg = &req
+                .authorization_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("authorization_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("authorization_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -266,10 +271,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.server_tls_policy
+            let arg = &req
+                .server_tls_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("server_tls_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("server_tls_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -404,10 +414,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.client_tls_policy
+            let arg = &req
+                .client_tls_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("client_tls_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("client_tls_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAuthorizationPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/authorizationPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/authorizationPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AuthorizationPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/authorizationPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/authorizationPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,18 +127,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.authorization_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("authorization_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.authorization_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("authorization_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -146,9 +158,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,12 +184,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServerTlsPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serverTlsPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serverTlsPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,9 +212,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServerTlsPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,12 +238,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serverTlsPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serverTlsPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,18 +265,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.server_tls_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("server_tls_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.server_tls_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("server_tls_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -265,9 +296,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -284,12 +322,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClientTlsPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clientTlsPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/clientTlsPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -308,9 +350,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ClientTlsPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -327,12 +376,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clientTlsPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clientTlsPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -350,18 +403,15 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.client_tls_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("client_tls_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.client_tls_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("client_tls_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,9 +434,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -403,9 +460,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -425,9 +489,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -444,12 +515,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -464,12 +539,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -496,12 +575,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -516,9 +599,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -538,9 +628,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -557,9 +654,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -580,9 +684,16 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/networkservices/v1/src/client.rs
+++ b/src/generated/cloud/networkservices/v1/src/client.rs
@@ -121,19 +121,13 @@ impl DepService {
     /// Lists `LbTrafficExtension` resources in a given project and location.
     pub fn list_lb_traffic_extensions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dep_service::ListLbTrafficExtensions {
         super::builder::dep_service::ListLbTrafficExtensions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of the specified `LbTrafficExtension` resource.
-    pub fn get_lb_traffic_extension(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::GetLbTrafficExtension {
+    pub fn get_lb_traffic_extension(&self) -> super::builder::dep_service::GetLbTrafficExtension {
         super::builder::dep_service::GetLbTrafficExtension::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `LbTrafficExtension` resource in a given project and
@@ -150,10 +144,8 @@ impl DepService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_lb_traffic_extension(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dep_service::CreateLbTrafficExtension {
         super::builder::dep_service::CreateLbTrafficExtension::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of the specified `LbTrafficExtension` resource.
@@ -169,10 +161,8 @@ impl DepService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_lb_traffic_extension(
         &self,
-        lb_traffic_extension: impl Into<crate::model::LbTrafficExtension>,
     ) -> super::builder::dep_service::UpdateLbTrafficExtension {
         super::builder::dep_service::UpdateLbTrafficExtension::new(self.inner.clone())
-            .set_lb_traffic_extension(lb_traffic_extension.into())
     }
 
     /// Deletes the specified `LbTrafficExtension` resource.
@@ -188,28 +178,18 @@ impl DepService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_lb_traffic_extension(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dep_service::DeleteLbTrafficExtension {
         super::builder::dep_service::DeleteLbTrafficExtension::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `LbRouteExtension` resources in a given project and location.
-    pub fn list_lb_route_extensions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::ListLbRouteExtensions {
+    pub fn list_lb_route_extensions(&self) -> super::builder::dep_service::ListLbRouteExtensions {
         super::builder::dep_service::ListLbRouteExtensions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of the specified `LbRouteExtension` resource.
-    pub fn get_lb_route_extension(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::GetLbRouteExtension {
+    pub fn get_lb_route_extension(&self) -> super::builder::dep_service::GetLbRouteExtension {
         super::builder::dep_service::GetLbRouteExtension::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `LbRouteExtension` resource in a given project and location.
@@ -223,12 +203,8 @@ impl DepService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_lb_route_extension(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::CreateLbRouteExtension {
+    pub fn create_lb_route_extension(&self) -> super::builder::dep_service::CreateLbRouteExtension {
         super::builder::dep_service::CreateLbRouteExtension::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of the specified `LbRouteExtension` resource.
@@ -242,12 +218,8 @@ impl DepService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_lb_route_extension(
-        &self,
-        lb_route_extension: impl Into<crate::model::LbRouteExtension>,
-    ) -> super::builder::dep_service::UpdateLbRouteExtension {
+    pub fn update_lb_route_extension(&self) -> super::builder::dep_service::UpdateLbRouteExtension {
         super::builder::dep_service::UpdateLbRouteExtension::new(self.inner.clone())
-            .set_lb_route_extension(lb_route_extension.into())
     }
 
     /// Deletes the specified `LbRouteExtension` resource.
@@ -261,28 +233,18 @@ impl DepService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_lb_route_extension(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::DeleteLbRouteExtension {
+    pub fn delete_lb_route_extension(&self) -> super::builder::dep_service::DeleteLbRouteExtension {
         super::builder::dep_service::DeleteLbRouteExtension::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::ListLocations {
-        super::builder::dep_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::dep_service::ListLocations {
+        super::builder::dep_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::GetLocation {
-        super::builder::dep_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::dep_service::GetLocation {
+        super::builder::dep_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -290,22 +252,14 @@ impl DepService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::dep_service::SetIamPolicy {
         super::builder::dep_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::dep_service::GetIamPolicy {
         super::builder::dep_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -315,52 +269,36 @@ impl DepService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::dep_service::TestIamPermissions {
         super::builder::dep_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::ListOperations {
-        super::builder::dep_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::dep_service::ListOperations {
+        super::builder::dep_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::GetOperation {
-        super::builder::dep_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::dep_service::GetOperation {
+        super::builder::dep_service::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::DeleteOperation {
-        super::builder::dep_service::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::dep_service::DeleteOperation {
+        super::builder::dep_service::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dep_service::CancelOperation {
-        super::builder::dep_service::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::dep_service::CancelOperation {
+        super::builder::dep_service::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -467,21 +405,13 @@ impl NetworkServices {
     }
 
     /// Lists EndpointPolicies in a given project and location.
-    pub fn list_endpoint_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListEndpointPolicies {
+    pub fn list_endpoint_policies(&self) -> super::builder::network_services::ListEndpointPolicies {
         super::builder::network_services::ListEndpointPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single EndpointPolicy.
-    pub fn get_endpoint_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetEndpointPolicy {
+    pub fn get_endpoint_policy(&self) -> super::builder::network_services::GetEndpointPolicy {
         super::builder::network_services::GetEndpointPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new EndpointPolicy in a given project and location.
@@ -495,12 +425,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_endpoint_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateEndpointPolicy {
+    pub fn create_endpoint_policy(&self) -> super::builder::network_services::CreateEndpointPolicy {
         super::builder::network_services::CreateEndpointPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single EndpointPolicy.
@@ -514,12 +440,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_endpoint_policy(
-        &self,
-        endpoint_policy: impl Into<crate::model::EndpointPolicy>,
-    ) -> super::builder::network_services::UpdateEndpointPolicy {
+    pub fn update_endpoint_policy(&self) -> super::builder::network_services::UpdateEndpointPolicy {
         super::builder::network_services::UpdateEndpointPolicy::new(self.inner.clone())
-            .set_endpoint_policy(endpoint_policy.into())
     }
 
     /// Deletes a single EndpointPolicy.
@@ -533,29 +455,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_endpoint_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteEndpointPolicy {
+    pub fn delete_endpoint_policy(&self) -> super::builder::network_services::DeleteEndpointPolicy {
         super::builder::network_services::DeleteEndpointPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Gateways in a given project and location.
-    pub fn list_gateways(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListGateways {
+    pub fn list_gateways(&self) -> super::builder::network_services::ListGateways {
         super::builder::network_services::ListGateways::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Gateway.
-    pub fn get_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetGateway {
-        super::builder::network_services::GetGateway::new(self.inner.clone()).set_name(name.into())
+    pub fn get_gateway(&self) -> super::builder::network_services::GetGateway {
+        super::builder::network_services::GetGateway::new(self.inner.clone())
     }
 
     /// Creates a new Gateway in a given project and location.
@@ -569,12 +480,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_gateway(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateGateway {
+    pub fn create_gateway(&self) -> super::builder::network_services::CreateGateway {
         super::builder::network_services::CreateGateway::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Gateway.
@@ -588,12 +495,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_gateway(
-        &self,
-        gateway: impl Into<crate::model::Gateway>,
-    ) -> super::builder::network_services::UpdateGateway {
+    pub fn update_gateway(&self) -> super::builder::network_services::UpdateGateway {
         super::builder::network_services::UpdateGateway::new(self.inner.clone())
-            .set_gateway(gateway.into())
     }
 
     /// Deletes a single Gateway.
@@ -607,30 +510,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_gateway(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteGateway {
+    pub fn delete_gateway(&self) -> super::builder::network_services::DeleteGateway {
         super::builder::network_services::DeleteGateway::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists GrpcRoutes in a given project and location.
-    pub fn list_grpc_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListGrpcRoutes {
+    pub fn list_grpc_routes(&self) -> super::builder::network_services::ListGrpcRoutes {
         super::builder::network_services::ListGrpcRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single GrpcRoute.
-    pub fn get_grpc_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetGrpcRoute {
+    pub fn get_grpc_route(&self) -> super::builder::network_services::GetGrpcRoute {
         super::builder::network_services::GetGrpcRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new GrpcRoute in a given project and location.
@@ -644,12 +535,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_grpc_route(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateGrpcRoute {
+    pub fn create_grpc_route(&self) -> super::builder::network_services::CreateGrpcRoute {
         super::builder::network_services::CreateGrpcRoute::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single GrpcRoute.
@@ -663,12 +550,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_grpc_route(
-        &self,
-        grpc_route: impl Into<crate::model::GrpcRoute>,
-    ) -> super::builder::network_services::UpdateGrpcRoute {
+    pub fn update_grpc_route(&self) -> super::builder::network_services::UpdateGrpcRoute {
         super::builder::network_services::UpdateGrpcRoute::new(self.inner.clone())
-            .set_grpc_route(grpc_route.into())
     }
 
     /// Deletes a single GrpcRoute.
@@ -682,30 +565,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_grpc_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteGrpcRoute {
+    pub fn delete_grpc_route(&self) -> super::builder::network_services::DeleteGrpcRoute {
         super::builder::network_services::DeleteGrpcRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists HttpRoute in a given project and location.
-    pub fn list_http_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListHttpRoutes {
+    pub fn list_http_routes(&self) -> super::builder::network_services::ListHttpRoutes {
         super::builder::network_services::ListHttpRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single HttpRoute.
-    pub fn get_http_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetHttpRoute {
+    pub fn get_http_route(&self) -> super::builder::network_services::GetHttpRoute {
         super::builder::network_services::GetHttpRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new HttpRoute in a given project and location.
@@ -719,12 +590,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_http_route(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateHttpRoute {
+    pub fn create_http_route(&self) -> super::builder::network_services::CreateHttpRoute {
         super::builder::network_services::CreateHttpRoute::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single HttpRoute.
@@ -738,12 +605,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_http_route(
-        &self,
-        http_route: impl Into<crate::model::HttpRoute>,
-    ) -> super::builder::network_services::UpdateHttpRoute {
+    pub fn update_http_route(&self) -> super::builder::network_services::UpdateHttpRoute {
         super::builder::network_services::UpdateHttpRoute::new(self.inner.clone())
-            .set_http_route(http_route.into())
     }
 
     /// Deletes a single HttpRoute.
@@ -757,29 +620,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_http_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteHttpRoute {
+    pub fn delete_http_route(&self) -> super::builder::network_services::DeleteHttpRoute {
         super::builder::network_services::DeleteHttpRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists TcpRoute in a given project and location.
-    pub fn list_tcp_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListTcpRoutes {
+    pub fn list_tcp_routes(&self) -> super::builder::network_services::ListTcpRoutes {
         super::builder::network_services::ListTcpRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single TcpRoute.
-    pub fn get_tcp_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetTcpRoute {
-        super::builder::network_services::GetTcpRoute::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tcp_route(&self) -> super::builder::network_services::GetTcpRoute {
+        super::builder::network_services::GetTcpRoute::new(self.inner.clone())
     }
 
     /// Creates a new TcpRoute in a given project and location.
@@ -793,12 +645,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_tcp_route(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateTcpRoute {
+    pub fn create_tcp_route(&self) -> super::builder::network_services::CreateTcpRoute {
         super::builder::network_services::CreateTcpRoute::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single TcpRoute.
@@ -812,12 +660,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_tcp_route(
-        &self,
-        tcp_route: impl Into<crate::model::TcpRoute>,
-    ) -> super::builder::network_services::UpdateTcpRoute {
+    pub fn update_tcp_route(&self) -> super::builder::network_services::UpdateTcpRoute {
         super::builder::network_services::UpdateTcpRoute::new(self.inner.clone())
-            .set_tcp_route(tcp_route.into())
     }
 
     /// Deletes a single TcpRoute.
@@ -831,29 +675,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tcp_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteTcpRoute {
+    pub fn delete_tcp_route(&self) -> super::builder::network_services::DeleteTcpRoute {
         super::builder::network_services::DeleteTcpRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists TlsRoute in a given project and location.
-    pub fn list_tls_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListTlsRoutes {
+    pub fn list_tls_routes(&self) -> super::builder::network_services::ListTlsRoutes {
         super::builder::network_services::ListTlsRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single TlsRoute.
-    pub fn get_tls_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetTlsRoute {
-        super::builder::network_services::GetTlsRoute::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tls_route(&self) -> super::builder::network_services::GetTlsRoute {
+        super::builder::network_services::GetTlsRoute::new(self.inner.clone())
     }
 
     /// Creates a new TlsRoute in a given project and location.
@@ -867,12 +700,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_tls_route(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateTlsRoute {
+    pub fn create_tls_route(&self) -> super::builder::network_services::CreateTlsRoute {
         super::builder::network_services::CreateTlsRoute::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single TlsRoute.
@@ -886,12 +715,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_tls_route(
-        &self,
-        tls_route: impl Into<crate::model::TlsRoute>,
-    ) -> super::builder::network_services::UpdateTlsRoute {
+    pub fn update_tls_route(&self) -> super::builder::network_services::UpdateTlsRoute {
         super::builder::network_services::UpdateTlsRoute::new(self.inner.clone())
-            .set_tls_route(tls_route.into())
     }
 
     /// Deletes a single TlsRoute.
@@ -905,30 +730,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tls_route(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteTlsRoute {
+    pub fn delete_tls_route(&self) -> super::builder::network_services::DeleteTlsRoute {
         super::builder::network_services::DeleteTlsRoute::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ServiceBinding in a given project and location.
-    pub fn list_service_bindings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListServiceBindings {
+    pub fn list_service_bindings(&self) -> super::builder::network_services::ListServiceBindings {
         super::builder::network_services::ListServiceBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ServiceBinding.
-    pub fn get_service_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetServiceBinding {
+    pub fn get_service_binding(&self) -> super::builder::network_services::GetServiceBinding {
         super::builder::network_services::GetServiceBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ServiceBinding in a given project and location.
@@ -942,12 +755,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_service_binding(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateServiceBinding {
+    pub fn create_service_binding(&self) -> super::builder::network_services::CreateServiceBinding {
         super::builder::network_services::CreateServiceBinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single ServiceBinding.
@@ -961,29 +770,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteServiceBinding {
+    pub fn delete_service_binding(&self) -> super::builder::network_services::DeleteServiceBinding {
         super::builder::network_services::DeleteServiceBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Meshes in a given project and location.
-    pub fn list_meshes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListMeshes {
+    pub fn list_meshes(&self) -> super::builder::network_services::ListMeshes {
         super::builder::network_services::ListMeshes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Mesh.
-    pub fn get_mesh(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetMesh {
-        super::builder::network_services::GetMesh::new(self.inner.clone()).set_name(name.into())
+    pub fn get_mesh(&self) -> super::builder::network_services::GetMesh {
+        super::builder::network_services::GetMesh::new(self.inner.clone())
     }
 
     /// Creates a new Mesh in a given project and location.
@@ -997,12 +795,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_mesh(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CreateMesh {
+    pub fn create_mesh(&self) -> super::builder::network_services::CreateMesh {
         super::builder::network_services::CreateMesh::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Mesh.
@@ -1016,11 +810,8 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_mesh(
-        &self,
-        mesh: impl Into<crate::model::Mesh>,
-    ) -> super::builder::network_services::UpdateMesh {
-        super::builder::network_services::UpdateMesh::new(self.inner.clone()).set_mesh(mesh.into())
+    pub fn update_mesh(&self) -> super::builder::network_services::UpdateMesh {
+        super::builder::network_services::UpdateMesh::new(self.inner.clone())
     }
 
     /// Deletes a single Mesh.
@@ -1034,28 +825,18 @@ impl NetworkServices {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_mesh(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteMesh {
-        super::builder::network_services::DeleteMesh::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_mesh(&self) -> super::builder::network_services::DeleteMesh {
+        super::builder::network_services::DeleteMesh::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListLocations {
+    pub fn list_locations(&self) -> super::builder::network_services::ListLocations {
         super::builder::network_services::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetLocation {
-        super::builder::network_services::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::network_services::GetLocation {
+        super::builder::network_services::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1063,22 +844,14 @@ impl NetworkServices {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_services::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::network_services::SetIamPolicy {
         super::builder::network_services::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::network_services::GetIamPolicy {
         super::builder::network_services::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1088,55 +861,35 @@ impl NetworkServices {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::network_services::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::network_services::TestIamPermissions {
         super::builder::network_services::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::ListOperations {
+    pub fn list_operations(&self) -> super::builder::network_services::ListOperations {
         super::builder::network_services::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::GetOperation {
+    pub fn get_operation(&self) -> super::builder::network_services::GetOperation {
         super::builder::network_services::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::network_services::DeleteOperation {
         super::builder::network_services::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::network_services::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::network_services::CancelOperation {
         super::builder::network_services::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::DepService for DepService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.lb_traffic_extension
+            let arg = &req
+                .lb_traffic_extension
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("lb_traffic_extension"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("lb_traffic_extension.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -274,10 +279,15 @@ impl super::stub::DepService for DepService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.lb_route_extension
+            let arg = &req
+                .lb_route_extension
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("lb_route_extension"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("lb_route_extension.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -704,10 +714,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.endpoint_policy
+            let arg = &req
+                .endpoint_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("endpoint_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -842,10 +857,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.gateway
+            let arg = &req
+                .gateway
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("gateway.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -980,10 +1000,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.grpc_route
+            let arg = &req
+                .grpc_route
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("grpc_route"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("grpc_route.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1118,10 +1143,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.http_route
+            let arg = &req
+                .http_route
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("http_route"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("http_route.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1256,10 +1286,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tcp_route
+            let arg = &req
+                .tcp_route
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tcp_route"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tcp_route.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1394,10 +1429,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tls_route
+            let arg = &req
+                .tls_route
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tls_route"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tls_route.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1637,10 +1677,15 @@ impl super::stub::NetworkServices for NetworkServices {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.mesh
+            let arg = &req
+                .mesh
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("mesh"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("mesh.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLbTrafficExtensionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/lbTrafficExtensions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/lbTrafficExtensions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LbTrafficExtension>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/lbTrafficExtensions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/lbTrafficExtensions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.lb_traffic_extension
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("lb_traffic_extension"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.lb_traffic_extension
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("lb_traffic_extension"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLbRouteExtensionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/lbRouteExtensions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/lbRouteExtensions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -196,9 +219,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LbRouteExtension>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -215,12 +245,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/lbRouteExtensions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/lbRouteExtensions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,18 +273,15 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.lb_route_extension
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("lb_route_extension"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.lb_route_extension
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("lb_route_extension"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,9 +305,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,9 +332,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +361,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,12 +387,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -355,12 +411,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -387,12 +447,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -407,9 +471,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,9 +500,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -448,9 +526,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +556,16 @@ impl super::stub::DepService for DepService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -530,12 +622,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEndpointPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/endpointPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/endpointPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -554,9 +650,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EndpointPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -573,12 +676,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/endpointPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/endpointPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,18 +703,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.endpoint_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("endpoint_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.endpoint_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("endpoint_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,9 +734,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -649,9 +760,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGatewaysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/gateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/gateways", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -670,9 +788,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Gateway>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -689,12 +814,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/gateways", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/gateways", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -712,18 +841,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.gateway
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.gateway
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("gateway"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -746,9 +872,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -765,12 +898,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGrpcRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/grpcRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/grpcRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -789,9 +926,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GrpcRoute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -808,12 +952,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/grpcRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/grpcRoutes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -831,18 +979,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.grpc_route
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("grpc_route"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.grpc_route
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("grpc_route"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -865,9 +1010,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -884,12 +1036,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHttpRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/httpRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/httpRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -908,9 +1064,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HttpRoute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -927,12 +1090,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/httpRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/httpRoutes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -950,18 +1117,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.http_route
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("http_route"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.http_route
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("http_route"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -984,9 +1148,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1003,12 +1174,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTcpRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tcpRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/tcpRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1027,9 +1202,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TcpRoute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1046,12 +1228,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tcpRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tcpRoutes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1069,18 +1255,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tcp_route
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tcp_route"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tcp_route
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tcp_route"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1103,9 +1286,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1122,12 +1312,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTlsRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tlsRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/tlsRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1340,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TlsRoute>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1165,12 +1366,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tlsRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/tlsRoutes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1188,18 +1393,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tls_route
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tls_route"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tls_route
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tls_route"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1222,9 +1424,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1241,12 +1450,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1265,9 +1478,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1284,12 +1504,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceBindings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1307,9 +1531,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1326,9 +1557,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMeshesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/meshes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/meshes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1347,9 +1585,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Mesh>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1366,9 +1611,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/meshes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/meshes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1384,18 +1636,15 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.mesh
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("mesh"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.mesh
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("mesh"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1416,9 +1665,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1435,9 +1691,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1457,9 +1720,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1476,12 +1746,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1496,12 +1770,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1528,12 +1806,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1548,9 +1830,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1570,9 +1859,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1589,9 +1885,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1612,9 +1915,16 @@ impl super::stub::NetworkServices for NetworkServices {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/notebooks/v2/src/client.rs
+++ b/src/generated/cloud/notebooks/v2/src/client.rs
@@ -121,20 +121,13 @@ impl NotebookService {
     }
 
     /// Lists instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListInstances {
+    pub fn list_instances(&self) -> super::builder::notebook_service::ListInstances {
         super::builder::notebook_service::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetInstance {
-        super::builder::notebook_service::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::notebook_service::GetInstance {
+        super::builder::notebook_service::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a new Instance in a given project and location.
@@ -148,12 +141,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::notebook_service::CreateInstance {
         super::builder::notebook_service::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// UpdateInstance updates an Instance.
@@ -167,12 +156,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::notebook_service::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::notebook_service::UpdateInstance {
         super::builder::notebook_service::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes a single Instance.
@@ -186,12 +171,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::notebook_service::DeleteInstance {
         super::builder::notebook_service::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts a notebook instance.
@@ -205,12 +186,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::StartInstance {
+    pub fn start_instance(&self) -> super::builder::notebook_service::StartInstance {
         super::builder::notebook_service::StartInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stops a notebook instance.
@@ -224,12 +201,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::StopInstance {
+    pub fn stop_instance(&self) -> super::builder::notebook_service::StopInstance {
         super::builder::notebook_service::StopInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resets a notebook instance.
@@ -243,21 +216,15 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reset_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ResetInstance {
+    pub fn reset_instance(&self) -> super::builder::notebook_service::ResetInstance {
         super::builder::notebook_service::ResetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Checks whether a notebook instance is upgradable.
     pub fn check_instance_upgradability(
         &self,
-        notebook_instance: impl Into<std::string::String>,
     ) -> super::builder::notebook_service::CheckInstanceUpgradability {
         super::builder::notebook_service::CheckInstanceUpgradability::new(self.inner.clone())
-            .set_notebook_instance(notebook_instance.into())
     }
 
     /// Upgrades a notebook instance to the latest version.
@@ -271,12 +238,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn upgrade_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::UpgradeInstance {
+    pub fn upgrade_instance(&self) -> super::builder::notebook_service::UpgradeInstance {
         super::builder::notebook_service::UpgradeInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rollbacks a notebook instance to the previous version.
@@ -290,12 +253,8 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn rollback_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::RollbackInstance {
+    pub fn rollback_instance(&self) -> super::builder::notebook_service::RollbackInstance {
         super::builder::notebook_service::RollbackInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Diagnostic File and runs Diagnostic Tool given an Instance.
@@ -309,29 +268,18 @@ impl NotebookService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn diagnose_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::DiagnoseInstance {
+    pub fn diagnose_instance(&self) -> super::builder::notebook_service::DiagnoseInstance {
         super::builder::notebook_service::DiagnoseInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::notebook_service::ListLocations {
         super::builder::notebook_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetLocation {
-        super::builder::notebook_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::notebook_service::GetLocation {
+        super::builder::notebook_service::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -339,22 +287,14 @@ impl NotebookService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::notebook_service::SetIamPolicy {
         super::builder::notebook_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::notebook_service::GetIamPolicy {
         super::builder::notebook_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -364,55 +304,35 @@ impl NotebookService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::notebook_service::TestIamPermissions {
         super::builder::notebook_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::notebook_service::ListOperations {
         super::builder::notebook_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::notebook_service::GetOperation {
         super::builder::notebook_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::notebook_service::DeleteOperation {
         super::builder::notebook_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::notebook_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::notebook_service::CancelOperation {
         super::builder::notebook_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +189,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -187,9 +213,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,9 +237,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:reset", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -221,12 +261,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckInstanceUpgradabilityResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:checkUpgradability", {
+            let arg = &req.notebook_instance;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("notebook_instance"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:checkUpgradability", req.notebook_instance),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -243,9 +287,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:upgrade", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:upgrade", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,9 +311,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:rollback", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:rollback", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,9 +335,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:diagnose", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:diagnose", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,9 +359,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +388,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,12 +414,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -355,12 +438,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -387,12 +474,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -407,9 +498,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,9 +527,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -448,9 +553,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +583,16 @@ impl super::stub::NotebookService for NotebookService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::NotebookService for NotebookService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/optimization/v1/src/client.rs
+++ b/src/generated/cloud/optimization/v1/src/client.rs
@@ -148,12 +148,8 @@ impl FleetRouting {
     /// The goal is to provide an assignment of `ShipmentRoute`s to `Vehicle`s that
     /// minimizes the total cost where cost has many components defined in the
     /// `ShipmentModel`.
-    pub fn optimize_tours(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::fleet_routing::OptimizeTours {
+    pub fn optimize_tours(&self) -> super::builder::fleet_routing::OptimizeTours {
         super::builder::fleet_routing::OptimizeTours::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Optimizes vehicle tours for one or more `OptimizeToursRequest`
@@ -176,21 +172,14 @@ impl FleetRouting {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_optimize_tours(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::fleet_routing::BatchOptimizeTours {
+    pub fn batch_optimize_tours(&self) -> super::builder::fleet_routing::BatchOptimizeTours {
         super::builder::fleet_routing::BatchOptimizeTours::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::fleet_routing::GetOperation {
-        super::builder::fleet_routing::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::fleet_routing::GetOperation {
+        super::builder::fleet_routing::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/optimization/v1/src/transport.rs
+++ b/src/generated/cloud/optimization/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::FleetRouting for FleetRouting {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OptimizeToursResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:optimizeTours", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:optimizeTours", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::FleetRouting for FleetRouting {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:batchOptimizeTours", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:batchOptimizeTours", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +94,16 @@ impl super::stub::FleetRouting for FleetRouting {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/oracledatabase/v1/src/client.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/client.rs
@@ -121,19 +121,15 @@ impl OracleDatabase {
     /// Lists Exadata Infrastructures in a given project and location.
     pub fn list_cloud_exadata_infrastructures(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::ListCloudExadataInfrastructures {
         super::builder::oracle_database::ListCloudExadataInfrastructures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Exadata Infrastructure.
     pub fn get_cloud_exadata_infrastructure(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::GetCloudExadataInfrastructure {
         super::builder::oracle_database::GetCloudExadataInfrastructure::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Exadata Infrastructure in a given project and location.
@@ -149,10 +145,8 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_cloud_exadata_infrastructure(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::CreateCloudExadataInfrastructure {
         super::builder::oracle_database::CreateCloudExadataInfrastructure::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Exadata Infrastructure.
@@ -168,28 +162,18 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_cloud_exadata_infrastructure(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::DeleteCloudExadataInfrastructure {
         super::builder::oracle_database::DeleteCloudExadataInfrastructure::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the VM Clusters in a given project and location.
-    pub fn list_cloud_vm_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListCloudVmClusters {
+    pub fn list_cloud_vm_clusters(&self) -> super::builder::oracle_database::ListCloudVmClusters {
         super::builder::oracle_database::ListCloudVmClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single VM Cluster.
-    pub fn get_cloud_vm_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::GetCloudVmCluster {
+    pub fn get_cloud_vm_cluster(&self) -> super::builder::oracle_database::GetCloudVmCluster {
         super::builder::oracle_database::GetCloudVmCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new VM Cluster in a given project and location.
@@ -203,12 +187,8 @@ impl OracleDatabase {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cloud_vm_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::CreateCloudVmCluster {
+    pub fn create_cloud_vm_cluster(&self) -> super::builder::oracle_database::CreateCloudVmCluster {
         super::builder::oracle_database::CreateCloudVmCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single VM Cluster.
@@ -222,76 +202,48 @@ impl OracleDatabase {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cloud_vm_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::DeleteCloudVmCluster {
+    pub fn delete_cloud_vm_cluster(&self) -> super::builder::oracle_database::DeleteCloudVmCluster {
         super::builder::oracle_database::DeleteCloudVmCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the entitlements in a given project.
-    pub fn list_entitlements(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListEntitlements {
+    pub fn list_entitlements(&self) -> super::builder::oracle_database::ListEntitlements {
         super::builder::oracle_database::ListEntitlements::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the database servers of an Exadata Infrastructure instance.
-    pub fn list_db_servers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListDbServers {
+    pub fn list_db_servers(&self) -> super::builder::oracle_database::ListDbServers {
         super::builder::oracle_database::ListDbServers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the database nodes of a VM Cluster.
-    pub fn list_db_nodes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListDbNodes {
+    pub fn list_db_nodes(&self) -> super::builder::oracle_database::ListDbNodes {
         super::builder::oracle_database::ListDbNodes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all the valid Oracle Grid Infrastructure (GI) versions for the given
     /// project and location.
-    pub fn list_gi_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListGiVersions {
+    pub fn list_gi_versions(&self) -> super::builder::oracle_database::ListGiVersions {
         super::builder::oracle_database::ListGiVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the database system shapes available for the project and location.
-    pub fn list_db_system_shapes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListDbSystemShapes {
+    pub fn list_db_system_shapes(&self) -> super::builder::oracle_database::ListDbSystemShapes {
         super::builder::oracle_database::ListDbSystemShapes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the Autonomous Databases in a given project and location.
     pub fn list_autonomous_databases(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::ListAutonomousDatabases {
         super::builder::oracle_database::ListAutonomousDatabases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a single Autonomous Database.
     pub fn get_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::GetAutonomousDatabase {
         super::builder::oracle_database::GetAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Autonomous Database in a given project and location.
@@ -307,10 +259,8 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_autonomous_database(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::CreateAutonomousDatabase {
         super::builder::oracle_database::CreateAutonomousDatabase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Autonomous Database.
@@ -326,10 +276,8 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::DeleteAutonomousDatabase {
         super::builder::oracle_database::DeleteAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restores a single Autonomous Database.
@@ -345,49 +293,39 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn restore_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::RestoreAutonomousDatabase {
         super::builder::oracle_database::RestoreAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates a wallet for an Autonomous Database.
     pub fn generate_autonomous_database_wallet(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::GenerateAutonomousDatabaseWallet {
         super::builder::oracle_database::GenerateAutonomousDatabaseWallet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all the available Autonomous Database versions for a project and
     /// location.
     pub fn list_autonomous_db_versions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::ListAutonomousDbVersions {
         super::builder::oracle_database::ListAutonomousDbVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Autonomous Database Character Sets in a given project and location.
     pub fn list_autonomous_database_character_sets(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::ListAutonomousDatabaseCharacterSets {
         super::builder::oracle_database::ListAutonomousDatabaseCharacterSets::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Lists the long-term and automatic backups of an Autonomous Database.
     pub fn list_autonomous_database_backups(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::ListAutonomousDatabaseBackups {
         super::builder::oracle_database::ListAutonomousDatabaseBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Stops an Autonomous Database.
@@ -403,10 +341,8 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn stop_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::StopAutonomousDatabase {
         super::builder::oracle_database::StopAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts an Autonomous Database.
@@ -422,10 +358,8 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn start_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::StartAutonomousDatabase {
         super::builder::oracle_database::StartAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restarts an Autonomous Database.
@@ -441,69 +375,45 @@ impl OracleDatabase {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn restart_autonomous_database(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::oracle_database::RestartAutonomousDatabase {
         super::builder::oracle_database::RestartAutonomousDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListLocations {
+    pub fn list_locations(&self) -> super::builder::oracle_database::ListLocations {
         super::builder::oracle_database::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::GetLocation {
-        super::builder::oracle_database::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::oracle_database::GetLocation {
+        super::builder::oracle_database::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::ListOperations {
+    pub fn list_operations(&self) -> super::builder::oracle_database::ListOperations {
         super::builder::oracle_database::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::GetOperation {
-        super::builder::oracle_database::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::oracle_database::GetOperation {
+        super::builder::oracle_database::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::oracle_database::DeleteOperation {
         super::builder::oracle_database::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::oracle_database::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::oracle_database::CancelOperation {
         super::builder::oracle_database::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/oracledatabase/v1/src/transport.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/transport.rs
@@ -47,12 +47,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
     ) -> Result<gax::response::Response<crate::model::ListCloudExadataInfrastructuresResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cloudExadataInfrastructures", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cloudExadataInfrastructures", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,9 +75,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CloudExadataInfrastructure>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,12 +101,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cloudExadataInfrastructures", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cloudExadataInfrastructures", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -117,9 +132,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -138,12 +160,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCloudVmClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cloudVmClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cloudVmClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -163,9 +189,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CloudVmCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -182,12 +215,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cloudVmClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cloudVmClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -206,9 +243,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -227,12 +271,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntitlementsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entitlements", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entitlements", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -251,12 +299,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDbServersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dbServers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dbServers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +327,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDbNodesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dbNodes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/dbNodes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -296,12 +355,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGiVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/giVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/giVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -320,12 +383,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDbSystemShapesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dbSystemShapes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dbSystemShapes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -344,12 +411,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutonomousDatabasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/autonomousDatabases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/autonomousDatabases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -370,9 +441,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AutonomousDatabase>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,12 +467,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/autonomousDatabases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/autonomousDatabases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -413,9 +495,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -433,9 +522,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restore", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restore", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -451,12 +547,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
     ) -> Result<gax::response::Response<crate::model::GenerateAutonomousDatabaseWalletResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateWallet", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateWallet", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,12 +571,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutonomousDbVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/autonomousDbVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/autonomousDbVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -496,12 +600,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
     ) -> Result<gax::response::Response<crate::model::ListAutonomousDatabaseCharacterSetsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/autonomousDatabaseCharacterSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/autonomousDatabaseCharacterSets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -521,12 +629,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAutonomousDatabaseBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/autonomousDatabaseBackups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/autonomousDatabaseBackups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,9 +658,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,9 +682,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -580,9 +706,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:restart", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:restart", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -597,9 +730,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -619,9 +759,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -638,9 +785,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -660,9 +814,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -679,9 +840,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -702,9 +870,16 @@ impl super::stub::OracleDatabase for OracleDatabase {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
@@ -129,29 +129,18 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_environment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::CreateEnvironment {
+    pub fn create_environment(&self) -> super::builder::environments::CreateEnvironment {
         super::builder::environments::CreateEnvironment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get an existing environment.
-    pub fn get_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetEnvironment {
-        super::builder::environments::GetEnvironment::new(self.inner.clone()).set_name(name.into())
+    pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
+        super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
 
     /// List environments.
-    pub fn list_environments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListEnvironments {
+    pub fn list_environments(&self) -> super::builder::environments::ListEnvironments {
         super::builder::environments::ListEnvironments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update an environment.
@@ -165,12 +154,8 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::UpdateEnvironment {
+    pub fn update_environment(&self) -> super::builder::environments::UpdateEnvironment {
         super::builder::environments::UpdateEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Delete an environment.
@@ -184,39 +169,23 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::DeleteEnvironment {
+    pub fn delete_environment(&self) -> super::builder::environments::DeleteEnvironment {
         super::builder::environments::DeleteEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Executes Airflow CLI command.
-    pub fn execute_airflow_command(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::ExecuteAirflowCommand {
+    pub fn execute_airflow_command(&self) -> super::builder::environments::ExecuteAirflowCommand {
         super::builder::environments::ExecuteAirflowCommand::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Stops Airflow CLI command execution.
-    pub fn stop_airflow_command(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::StopAirflowCommand {
+    pub fn stop_airflow_command(&self) -> super::builder::environments::StopAirflowCommand {
         super::builder::environments::StopAirflowCommand::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Polls Airflow CLI command execution and fetches logs.
-    pub fn poll_airflow_command(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::PollAirflowCommand {
+    pub fn poll_airflow_command(&self) -> super::builder::environments::PollAirflowCommand {
         super::builder::environments::PollAirflowCommand::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Lists workloads in a Cloud Composer environment. Workload is a unit that
@@ -224,12 +193,8 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-2.*.*-airflow-*.*.* and newer.
-    pub fn list_workloads(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListWorkloads {
+    pub fn list_workloads(&self) -> super::builder::environments::ListWorkloads {
         super::builder::environments::ListWorkloads::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Check if an upgrade operation on the environment will succeed.
@@ -245,12 +210,8 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn check_upgrade(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::CheckUpgrade {
+    pub fn check_upgrade(&self) -> super::builder::environments::CheckUpgrade {
         super::builder::environments::CheckUpgrade::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Creates a user workloads Secret.
@@ -259,10 +220,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn create_user_workloads_secret(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::environments::CreateUserWorkloadsSecret {
         super::builder::environments::CreateUserWorkloadsSecret::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an existing user workloads Secret.
@@ -272,10 +231,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn get_user_workloads_secret(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::environments::GetUserWorkloadsSecret {
         super::builder::environments::GetUserWorkloadsSecret::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists user workloads Secrets.
@@ -284,10 +241,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn list_user_workloads_secrets(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::environments::ListUserWorkloadsSecrets {
         super::builder::environments::ListUserWorkloadsSecrets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a user workloads Secret.
@@ -296,10 +251,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn update_user_workloads_secret(
         &self,
-        user_workloads_secret: impl Into<crate::model::UserWorkloadsSecret>,
     ) -> super::builder::environments::UpdateUserWorkloadsSecret {
         super::builder::environments::UpdateUserWorkloadsSecret::new(self.inner.clone())
-            .set_user_workloads_secret(user_workloads_secret.into())
     }
 
     /// Deletes a user workloads Secret.
@@ -308,10 +261,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn delete_user_workloads_secret(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::environments::DeleteUserWorkloadsSecret {
         super::builder::environments::DeleteUserWorkloadsSecret::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a user workloads ConfigMap.
@@ -320,10 +271,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn create_user_workloads_config_map(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::environments::CreateUserWorkloadsConfigMap {
         super::builder::environments::CreateUserWorkloadsConfigMap::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an existing user workloads ConfigMap.
@@ -332,10 +281,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn get_user_workloads_config_map(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::environments::GetUserWorkloadsConfigMap {
         super::builder::environments::GetUserWorkloadsConfigMap::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists user workloads ConfigMaps.
@@ -344,10 +291,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn list_user_workloads_config_maps(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::environments::ListUserWorkloadsConfigMaps {
         super::builder::environments::ListUserWorkloadsConfigMaps::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a user workloads ConfigMap.
@@ -356,10 +301,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn update_user_workloads_config_map(
         &self,
-        user_workloads_config_map: impl Into<crate::model::UserWorkloadsConfigMap>,
     ) -> super::builder::environments::UpdateUserWorkloadsConfigMap {
         super::builder::environments::UpdateUserWorkloadsConfigMap::new(self.inner.clone())
-            .set_user_workloads_config_map(user_workloads_config_map.into())
     }
 
     /// Deletes a user workloads ConfigMap.
@@ -368,10 +311,8 @@ impl Environments {
     /// composer-3-airflow-*.*.*-build.* and newer.
     pub fn delete_user_workloads_config_map(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::environments::DeleteUserWorkloadsConfigMap {
         super::builder::environments::DeleteUserWorkloadsConfigMap::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a snapshots of a Cloud Composer environment.
@@ -388,12 +329,8 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn save_snapshot(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::SaveSnapshot {
+    pub fn save_snapshot(&self) -> super::builder::environments::SaveSnapshot {
         super::builder::environments::SaveSnapshot::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Loads a snapshot of a Cloud Composer environment.
@@ -410,12 +347,8 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn load_snapshot(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::LoadSnapshot {
+    pub fn load_snapshot(&self) -> super::builder::environments::LoadSnapshot {
         super::builder::environments::LoadSnapshot::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Triggers database failover (only for highly resilient environments).
@@ -429,51 +362,36 @@ impl Environments {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn database_failover(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::environments::DatabaseFailover {
+    pub fn database_failover(&self) -> super::builder::environments::DatabaseFailover {
         super::builder::environments::DatabaseFailover::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Fetches database properties.
     pub fn fetch_database_properties(
         &self,
-        environment: impl Into<std::string::String>,
     ) -> super::builder::environments::FetchDatabaseProperties {
         super::builder::environments::FetchDatabaseProperties::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::ListOperations {
-        super::builder::environments::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::environments::ListOperations {
+        super::builder::environments::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::GetOperation {
-        super::builder::environments::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::environments::GetOperation {
+        super::builder::environments::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::environments::DeleteOperation {
-        super::builder::environments::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::environments::DeleteOperation {
+        super::builder::environments::DeleteOperation::new(self.inner.clone())
     }
 }
 
@@ -578,43 +496,28 @@ impl ImageVersions {
     }
 
     /// List ImageVersions for provided location.
-    pub fn list_image_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::image_versions::ListImageVersions {
+    pub fn list_image_versions(&self) -> super::builder::image_versions::ListImageVersions {
         super::builder::image_versions::ListImageVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::image_versions::ListOperations {
+    pub fn list_operations(&self) -> super::builder::image_versions::ListOperations {
         super::builder::image_versions::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::image_versions::GetOperation {
-        super::builder::image_versions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::image_versions::GetOperation {
+        super::builder::image_versions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::image_versions::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::image_versions::DeleteOperation {
         super::builder::image_versions::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,12 +98,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEnvironmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/environments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/environments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,9 +126,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,9 +158,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,12 +184,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExecuteAirflowCommandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:executeAirflowCommand", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:executeAirflowCommand", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,12 +208,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StopAirflowCommandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stopAirflowCommand", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:stopAirflowCommand", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -195,12 +232,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PollAirflowCommandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pollAirflowCommand", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:pollAirflowCommand", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -215,12 +256,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkloadsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workloads", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workloads", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,12 +285,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:checkUpgrade", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:checkUpgrade", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,12 +309,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsSecret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userWorkloadsSecrets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userWorkloadsSecrets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,9 +335,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsSecret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,12 +361,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUserWorkloadsSecretsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/userWorkloadsSecrets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/userWorkloadsSecrets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -325,18 +389,15 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsSecret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.user_workloads_secret
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_secret"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.user_workloads_secret
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_secret"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,9 +414,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -376,12 +444,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsConfigMap>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userWorkloadsConfigMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userWorkloadsConfigMaps", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -398,9 +470,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsConfigMap>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -417,12 +496,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUserWorkloadsConfigMapsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/userWorkloadsConfigMaps", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/userWorkloadsConfigMaps", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -441,18 +524,15 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsConfigMap>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            &req.user_workloads_config_map
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_config_map"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/{}",
-                    req.user_workloads_config_map
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_config_map"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -469,9 +549,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -492,12 +579,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:saveSnapshot", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:saveSnapshot", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -512,12 +603,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:loadSnapshot", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:loadSnapshot", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,12 +627,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:databaseFailover", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:databaseFailover", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -552,12 +651,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchDatabasePropertiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchDatabaseProperties", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchDatabaseProperties", req.environment),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -574,9 +677,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,9 +706,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -615,9 +732,16 @@ impl super::stub::Environments for Environments {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -675,12 +799,16 @@ impl super::stub::ImageVersions for ImageVersions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListImageVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/imageVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/imageVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -700,9 +828,16 @@ impl super::stub::ImageVersions for ImageVersions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -722,9 +857,16 @@ impl super::stub::ImageVersions for ImageVersions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,9 +883,16 @@ impl super::stub::ImageVersions for ImageVersions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -390,10 +390,15 @@ impl super::stub::Environments for Environments {
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsSecret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.user_workloads_secret
+            let arg = &req
+                .user_workloads_secret
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_secret"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("user_workloads_secret.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -525,10 +530,17 @@ impl super::stub::Environments for Environments {
     ) -> Result<gax::response::Response<crate::model::UserWorkloadsConfigMap>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v1/{}", {
-            &req.user_workloads_config_map
+            let arg = &req
+                .user_workloads_config_map
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("user_workloads_config_map"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "user_workloads_config_map.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/orgpolicy/v2/src/client.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/client.rs
@@ -138,20 +138,13 @@ impl OrgPolicy {
     }
 
     /// Lists constraints that could be applied on the specified resource.
-    pub fn list_constraints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::ListConstraints {
+    pub fn list_constraints(&self) -> super::builder::org_policy::ListConstraints {
         super::builder::org_policy::ListConstraints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves all of the policies that exist on a particular resource.
-    pub fn list_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::ListPolicies {
-        super::builder::org_policy::ListPolicies::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_policies(&self) -> super::builder::org_policy::ListPolicies {
+        super::builder::org_policy::ListPolicies::new(self.inner.clone())
     }
 
     /// Gets a policy on a resource.
@@ -159,11 +152,8 @@ impl OrgPolicy {
     /// If no policy is set on the resource, `NOT_FOUND` is returned. The
     /// `etag` value can be used with `UpdatePolicy()` to update a
     /// policy during read-modify-write.
-    pub fn get_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::GetPolicy {
-        super::builder::org_policy::GetPolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn get_policy(&self) -> super::builder::org_policy::GetPolicy {
+        super::builder::org_policy::GetPolicy::new(self.inner.clone())
     }
 
     /// Gets the effective policy on a resource. This is the result of merging
@@ -172,12 +162,8 @@ impl OrgPolicy {
     /// an evaluated policy across multiple resources.
     /// Subtrees of Resource Manager resource hierarchy with 'under:' prefix will
     /// not be expanded.
-    pub fn get_effective_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::GetEffectivePolicy {
+    pub fn get_effective_policy(&self) -> super::builder::org_policy::GetEffectivePolicy {
         super::builder::org_policy::GetEffectivePolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a policy.
@@ -186,11 +172,8 @@ impl OrgPolicy {
     /// constraint does not exist.
     /// Returns a `google.rpc.Status` with `google.rpc.Code.ALREADY_EXISTS` if the
     /// policy already exists on the given Google Cloud resource.
-    pub fn create_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::CreatePolicy {
-        super::builder::org_policy::CreatePolicy::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_policy(&self) -> super::builder::org_policy::CreatePolicy {
+        super::builder::org_policy::CreatePolicy::new(self.inner.clone())
     }
 
     /// Updates a policy.
@@ -202,22 +185,16 @@ impl OrgPolicy {
     ///
     /// Note: the supplied policy will perform a full overwrite of all
     /// fields.
-    pub fn update_policy(
-        &self,
-        policy: impl Into<crate::model::Policy>,
-    ) -> super::builder::org_policy::UpdatePolicy {
-        super::builder::org_policy::UpdatePolicy::new(self.inner.clone()).set_policy(policy.into())
+    pub fn update_policy(&self) -> super::builder::org_policy::UpdatePolicy {
+        super::builder::org_policy::UpdatePolicy::new(self.inner.clone())
     }
 
     /// Deletes a policy.
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// constraint or organization policy does not exist.
-    pub fn delete_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::DeletePolicy {
-        super::builder::org_policy::DeletePolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_policy(&self) -> super::builder::org_policy::DeletePolicy {
+        super::builder::org_policy::DeletePolicy::new(self.inner.clone())
     }
 
     /// Creates a custom constraint.
@@ -226,12 +203,8 @@ impl OrgPolicy {
     /// organization does not exist.
     /// Returns a `google.rpc.Status` with `google.rpc.Code.ALREADY_EXISTS` if the
     /// constraint already exists on the given organization.
-    pub fn create_custom_constraint(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::CreateCustomConstraint {
+    pub fn create_custom_constraint(&self) -> super::builder::org_policy::CreateCustomConstraint {
         super::builder::org_policy::CreateCustomConstraint::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a custom constraint.
@@ -241,45 +214,29 @@ impl OrgPolicy {
     ///
     /// Note: the supplied policy will perform a full overwrite of all
     /// fields.
-    pub fn update_custom_constraint(
-        &self,
-        custom_constraint: impl Into<crate::model::CustomConstraint>,
-    ) -> super::builder::org_policy::UpdateCustomConstraint {
+    pub fn update_custom_constraint(&self) -> super::builder::org_policy::UpdateCustomConstraint {
         super::builder::org_policy::UpdateCustomConstraint::new(self.inner.clone())
-            .set_custom_constraint(custom_constraint.into())
     }
 
     /// Gets a custom or managed constraint.
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// custom or managed constraint does not exist.
-    pub fn get_custom_constraint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::GetCustomConstraint {
+    pub fn get_custom_constraint(&self) -> super::builder::org_policy::GetCustomConstraint {
         super::builder::org_policy::GetCustomConstraint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves all of the custom constraints that exist on a particular
     /// organization resource.
-    pub fn list_custom_constraints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::ListCustomConstraints {
+    pub fn list_custom_constraints(&self) -> super::builder::org_policy::ListCustomConstraints {
         super::builder::org_policy::ListCustomConstraints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a custom constraint.
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// constraint does not exist.
-    pub fn delete_custom_constraint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::org_policy::DeleteCustomConstraint {
+    pub fn delete_custom_constraint(&self) -> super::builder::org_policy::DeleteCustomConstraint {
         super::builder::org_policy::DeleteCustomConstraint::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/orgpolicy/v2/src/transport.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConstraintsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/constraints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/constraints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/policies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/policies", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +102,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,12 +128,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getEffectivePolicy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getEffectivePolicy", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -132,12 +154,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/policies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/policies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,18 +178,15 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,9 +207,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,12 +238,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomConstraint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/customConstraints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/customConstraints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,18 +264,15 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomConstraint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.custom_constraint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("custom_constraint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.custom_constraint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("custom_constraint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -258,9 +289,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomConstraint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,12 +315,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomConstraintsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/customConstraints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/customConstraints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,9 +343,16 @@ impl super::stub::OrgPolicy for OrgPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/orgpolicy/v2/src/transport.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/transport.rs
@@ -179,10 +179,15 @@ impl super::stub::OrgPolicy for OrgPolicy {
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.policy
+            let arg = &req
+                .policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -265,10 +270,15 @@ impl super::stub::OrgPolicy for OrgPolicy {
     ) -> Result<gax::response::Response<crate::model::CustomConstraint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.custom_constraint
+            let arg = &req
+                .custom_constraint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("custom_constraint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("custom_constraint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/osconfig/v1/src/client.rs
+++ b/src/generated/cloud/osconfig/v1/src/client.rs
@@ -126,137 +126,95 @@ impl OsConfigService {
     }
 
     /// Patch VM instances by creating and running a patch job.
-    pub fn execute_patch_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::ExecutePatchJob {
+    pub fn execute_patch_job(&self) -> super::builder::os_config_service::ExecutePatchJob {
         super::builder::os_config_service::ExecutePatchJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get the patch job. This can be used to track the progress of an
     /// ongoing patch job or review the details of completed jobs.
-    pub fn get_patch_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::GetPatchJob {
+    pub fn get_patch_job(&self) -> super::builder::os_config_service::GetPatchJob {
         super::builder::os_config_service::GetPatchJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancel a patch job. The patch job must be active. Canceled patch jobs
     /// cannot be restarted.
-    pub fn cancel_patch_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::CancelPatchJob {
+    pub fn cancel_patch_job(&self) -> super::builder::os_config_service::CancelPatchJob {
         super::builder::os_config_service::CancelPatchJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a list of patch jobs.
-    pub fn list_patch_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::ListPatchJobs {
+    pub fn list_patch_jobs(&self) -> super::builder::os_config_service::ListPatchJobs {
         super::builder::os_config_service::ListPatchJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a list of instance details for a given patch job.
     pub fn list_patch_job_instance_details(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::ListPatchJobInstanceDetails {
         super::builder::os_config_service::ListPatchJobInstanceDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create an OS Config patch deployment.
     pub fn create_patch_deployment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::CreatePatchDeployment {
         super::builder::os_config_service::CreatePatchDeployment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get an OS Config patch deployment.
-    pub fn get_patch_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::GetPatchDeployment {
+    pub fn get_patch_deployment(&self) -> super::builder::os_config_service::GetPatchDeployment {
         super::builder::os_config_service::GetPatchDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get a page of OS Config patch deployments.
     pub fn list_patch_deployments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::ListPatchDeployments {
         super::builder::os_config_service::ListPatchDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete an OS Config patch deployment.
     pub fn delete_patch_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::DeletePatchDeployment {
         super::builder::os_config_service::DeletePatchDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update an OS Config patch deployment.
     pub fn update_patch_deployment(
         &self,
-        patch_deployment: impl Into<crate::model::PatchDeployment>,
     ) -> super::builder::os_config_service::UpdatePatchDeployment {
         super::builder::os_config_service::UpdatePatchDeployment::new(self.inner.clone())
-            .set_patch_deployment(patch_deployment.into())
     }
 
     /// Change state of patch deployment to "PAUSED".
     /// Patch deployment in paused state doesn't generate patch jobs.
     pub fn pause_patch_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::PausePatchDeployment {
         super::builder::os_config_service::PausePatchDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Change state of patch deployment back to "ACTIVE".
     /// Patch deployment in active state continues to generate patch jobs.
     pub fn resume_patch_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_service::ResumePatchDeployment {
         super::builder::os_config_service::ResumePatchDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::os_config_service::GetOperation {
         super::builder::os_config_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::os_config_service::CancelOperation {
         super::builder::os_config_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -386,10 +344,8 @@ impl OsConfigZonalService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_os_policy_assignment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::CreateOSPolicyAssignment {
         super::builder::os_config_zonal_service::CreateOSPolicyAssignment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update an existing OS policy assignment.
@@ -413,10 +369,8 @@ impl OsConfigZonalService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_os_policy_assignment(
         &self,
-        os_policy_assignment: impl Into<crate::model::OSPolicyAssignment>,
     ) -> super::builder::os_config_zonal_service::UpdateOSPolicyAssignment {
         super::builder::os_config_zonal_service::UpdateOSPolicyAssignment::new(self.inner.clone())
-            .set_os_policy_assignment(os_policy_assignment.into())
     }
 
     /// Retrieve an existing OS policy assignment.
@@ -426,10 +380,8 @@ impl OsConfigZonalService {
     /// `name` parameter.
     pub fn get_os_policy_assignment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::GetOSPolicyAssignment {
         super::builder::os_config_zonal_service::GetOSPolicyAssignment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List the OS policy assignments under the parent resource.
@@ -437,21 +389,17 @@ impl OsConfigZonalService {
     /// For each OS policy assignment, the latest revision is returned.
     pub fn list_os_policy_assignments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::ListOSPolicyAssignments {
         super::builder::os_config_zonal_service::ListOSPolicyAssignments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List the OS policy assignment revisions for a given OS policy assignment.
     pub fn list_os_policy_assignment_revisions(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::ListOSPolicyAssignmentRevisions {
         super::builder::os_config_zonal_service::ListOSPolicyAssignmentRevisions::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Delete the OS policy assignment.
@@ -478,93 +426,67 @@ impl OsConfigZonalService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_os_policy_assignment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::DeleteOSPolicyAssignment {
         super::builder::os_config_zonal_service::DeleteOSPolicyAssignment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get the OS policy asssignment report for the specified Compute Engine VM
     /// instance.
     pub fn get_os_policy_assignment_report(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::GetOSPolicyAssignmentReport {
         super::builder::os_config_zonal_service::GetOSPolicyAssignmentReport::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// List OS policy asssignment reports for all Compute Engine VM instances in
     /// the specified zone.
     pub fn list_os_policy_assignment_reports(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::ListOSPolicyAssignmentReports {
         super::builder::os_config_zonal_service::ListOSPolicyAssignmentReports::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get inventory data for the specified VM instance. If the VM has no
     /// associated inventory, the message `NOT_FOUND` is returned.
-    pub fn get_inventory(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_zonal_service::GetInventory {
+    pub fn get_inventory(&self) -> super::builder::os_config_zonal_service::GetInventory {
         super::builder::os_config_zonal_service::GetInventory::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List inventory data for all VM instances in the specified zone.
-    pub fn list_inventories(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::os_config_zonal_service::ListInventories {
+    pub fn list_inventories(&self) -> super::builder::os_config_zonal_service::ListInventories {
         super::builder::os_config_zonal_service::ListInventories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the vulnerability report for the specified VM instance. Only VMs with
     /// inventory data have vulnerability reports associated with them.
     pub fn get_vulnerability_report(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::GetVulnerabilityReport {
         super::builder::os_config_zonal_service::GetVulnerabilityReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List vulnerability reports for all VM instances in the specified zone.
     pub fn list_vulnerability_reports(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::os_config_zonal_service::ListVulnerabilityReports {
         super::builder::os_config_zonal_service::ListVulnerabilityReports::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_zonal_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::os_config_zonal_service::GetOperation {
         super::builder::os_config_zonal_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_config_zonal_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::os_config_zonal_service::CancelOperation {
         super::builder::os_config_zonal_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -290,10 +290,15 @@ impl super::stub::OsConfigService for OsConfigService {
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.patch_deployment
+            let arg = &req
+                .patch_deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("patch_deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("patch_deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -474,10 +479,15 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.os_policy_assignment
+            let arg = &req
+                .os_policy_assignment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("os_policy_assignment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("os_policy_assignment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/patchJobs:execute", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/patchJobs:execute", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,9 +96,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -102,12 +120,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPatchJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/patchJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/patchJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,12 +149,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPatchJobInstanceDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instanceDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instanceDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,12 +178,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/patchDeployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/patchDeployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +205,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,12 +231,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPatchDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/patchDeployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/patchDeployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -218,9 +259,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,18 +289,15 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.patch_deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("patch_deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.patch_deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("patch_deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +320,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,9 +344,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PatchDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -309,9 +368,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +394,16 @@ impl super::stub::OsConfigService for OsConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -373,12 +446,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/osPolicyAssignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/osPolicyAssignments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,18 +473,15 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.os_policy_assignment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("os_policy_assignment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.os_policy_assignment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("os_policy_assignment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -430,9 +504,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OSPolicyAssignment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -449,12 +530,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOSPolicyAssignmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/osPolicyAssignments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/osPolicyAssignments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -474,12 +559,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
     ) -> Result<gax::response::Response<crate::model::ListOSPolicyAssignmentRevisionsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -498,9 +587,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -517,9 +613,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OSPolicyAssignmentReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -536,9 +639,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOSPolicyAssignmentReportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/reports", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -558,9 +668,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Inventory>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -578,12 +695,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInventoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/inventories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/inventories", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -604,9 +725,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VulnerabilityReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -623,12 +751,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVulnerabilityReportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vulnerabilityReports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vulnerabilityReports", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -648,9 +780,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,9 +806,16 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/oslogin/v1/src/client.rs
+++ b/src/generated/cloud/oslogin/v1/src/client.rs
@@ -124,69 +124,41 @@ impl OsLoginService {
     }
 
     /// Create an SSH public key
-    pub fn create_ssh_public_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::CreateSshPublicKey {
+    pub fn create_ssh_public_key(&self) -> super::builder::os_login_service::CreateSshPublicKey {
         super::builder::os_login_service::CreateSshPublicKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a POSIX account.
-    pub fn delete_posix_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::DeletePosixAccount {
+    pub fn delete_posix_account(&self) -> super::builder::os_login_service::DeletePosixAccount {
         super::builder::os_login_service::DeletePosixAccount::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an SSH public key.
-    pub fn delete_ssh_public_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::DeleteSshPublicKey {
+    pub fn delete_ssh_public_key(&self) -> super::builder::os_login_service::DeleteSshPublicKey {
         super::builder::os_login_service::DeleteSshPublicKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves the profile information used for logging in to a virtual machine
     /// on Google Compute Engine.
-    pub fn get_login_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::GetLoginProfile {
+    pub fn get_login_profile(&self) -> super::builder::os_login_service::GetLoginProfile {
         super::builder::os_login_service::GetLoginProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves an SSH public key.
-    pub fn get_ssh_public_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::GetSshPublicKey {
+    pub fn get_ssh_public_key(&self) -> super::builder::os_login_service::GetSshPublicKey {
         super::builder::os_login_service::GetSshPublicKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds an SSH public key and returns the profile information. Default POSIX
     /// account information is set when no username and UID exist as part of the
     /// login profile.
-    pub fn import_ssh_public_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::ImportSshPublicKey {
+    pub fn import_ssh_public_key(&self) -> super::builder::os_login_service::ImportSshPublicKey {
         super::builder::os_login_service::ImportSshPublicKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an SSH public key and returns the profile information. This method
     /// supports patch semantics.
-    pub fn update_ssh_public_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::os_login_service::UpdateSshPublicKey {
+    pub fn update_ssh_public_key(&self) -> super::builder::os_login_service::UpdateSshPublicKey {
         super::builder::os_login_service::UpdateSshPublicKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/oslogin/v1/src/transport.rs
+++ b/src/generated/cloud/oslogin/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<oslogin_common::model::SshPublicKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sshPublicKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/sshPublicKeys", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +102,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,12 +132,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LoginProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/loginProfile", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/loginProfile", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -138,9 +160,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<oslogin_common::model::SshPublicKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -157,12 +186,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportSshPublicKeyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importSshPublicKey", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importSshPublicKey", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,9 +217,16 @@ impl super::stub::OsLoginService for OsLoginService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<oslogin_common::model::SshPublicKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/parallelstore/v1/src/client.rs
+++ b/src/generated/cloud/parallelstore/v1/src/client.rs
@@ -135,20 +135,13 @@ impl Parallelstore {
     }
 
     /// Lists all instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::ListInstances {
+    pub fn list_instances(&self) -> super::builder::parallelstore::ListInstances {
         super::builder::parallelstore::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::GetInstance {
-        super::builder::parallelstore::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::parallelstore::GetInstance {
+        super::builder::parallelstore::GetInstance::new(self.inner.clone())
     }
 
     /// Creates a Parallelstore instance in a given project and location.
@@ -162,12 +155,8 @@ impl Parallelstore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::parallelstore::CreateInstance {
         super::builder::parallelstore::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single instance.
@@ -181,12 +170,8 @@ impl Parallelstore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::parallelstore::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::parallelstore::UpdateInstance {
         super::builder::parallelstore::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes a single instance.
@@ -200,11 +185,8 @@ impl Parallelstore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::DeleteInstance {
-        super::builder::parallelstore::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::parallelstore::DeleteInstance {
+        super::builder::parallelstore::DeleteInstance::new(self.inner.clone())
     }
 
     /// Copies data from Cloud Storage to Parallelstore.
@@ -218,11 +200,8 @@ impl Parallelstore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::ImportData {
-        super::builder::parallelstore::ImportData::new(self.inner.clone()).set_name(name.into())
+    pub fn import_data(&self) -> super::builder::parallelstore::ImportData {
+        super::builder::parallelstore::ImportData::new(self.inner.clone())
     }
 
     /// Copies data from Parallelstore to Cloud Storage.
@@ -236,68 +215,45 @@ impl Parallelstore {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_data(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::ExportData {
-        super::builder::parallelstore::ExportData::new(self.inner.clone()).set_name(name.into())
+    pub fn export_data(&self) -> super::builder::parallelstore::ExportData {
+        super::builder::parallelstore::ExportData::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::ListLocations {
-        super::builder::parallelstore::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::parallelstore::ListLocations {
+        super::builder::parallelstore::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::GetLocation {
-        super::builder::parallelstore::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::parallelstore::GetLocation {
+        super::builder::parallelstore::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::ListOperations {
-        super::builder::parallelstore::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::parallelstore::ListOperations {
+        super::builder::parallelstore::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::GetOperation {
-        super::builder::parallelstore::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::parallelstore::GetOperation {
+        super::builder::parallelstore::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::parallelstore::DeleteOperation {
         super::builder::parallelstore::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parallelstore::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::parallelstore::CancelOperation {
         super::builder::parallelstore::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::Parallelstore for Parallelstore {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +189,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importData", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importData", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,12 +213,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportData", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportData", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -210,9 +237,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -232,9 +266,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -251,9 +292,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -273,9 +321,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,9 +347,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -315,9 +377,16 @@ impl super::stub::Parallelstore for Parallelstore {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/parametermanager/v1/src/client.rs
+++ b/src/generated/cloud/parametermanager/v1/src/client.rs
@@ -121,119 +121,77 @@ impl ParameterManager {
     }
 
     /// Lists Parameters in a given project and location.
-    pub fn list_parameters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::ListParameters {
+    pub fn list_parameters(&self) -> super::builder::parameter_manager::ListParameters {
         super::builder::parameter_manager::ListParameters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Parameter.
-    pub fn get_parameter(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::GetParameter {
+    pub fn get_parameter(&self) -> super::builder::parameter_manager::GetParameter {
         super::builder::parameter_manager::GetParameter::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Parameter in a given project and location.
-    pub fn create_parameter(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::CreateParameter {
+    pub fn create_parameter(&self) -> super::builder::parameter_manager::CreateParameter {
         super::builder::parameter_manager::CreateParameter::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a single Parameter.
-    pub fn update_parameter(
-        &self,
-        parameter: impl Into<crate::model::Parameter>,
-    ) -> super::builder::parameter_manager::UpdateParameter {
+    pub fn update_parameter(&self) -> super::builder::parameter_manager::UpdateParameter {
         super::builder::parameter_manager::UpdateParameter::new(self.inner.clone())
-            .set_parameter(parameter.into())
     }
 
     /// Deletes a single Parameter.
-    pub fn delete_parameter(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::DeleteParameter {
+    pub fn delete_parameter(&self) -> super::builder::parameter_manager::DeleteParameter {
         super::builder::parameter_manager::DeleteParameter::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ParameterVersions in a given project, location, and parameter.
     pub fn list_parameter_versions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::parameter_manager::ListParameterVersions {
         super::builder::parameter_manager::ListParameterVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ParameterVersion.
-    pub fn get_parameter_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::GetParameterVersion {
+    pub fn get_parameter_version(&self) -> super::builder::parameter_manager::GetParameterVersion {
         super::builder::parameter_manager::GetParameterVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets rendered version of a ParameterVersion.
     pub fn render_parameter_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::parameter_manager::RenderParameterVersion {
         super::builder::parameter_manager::RenderParameterVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ParameterVersion in a given project, location, and parameter.
     pub fn create_parameter_version(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::parameter_manager::CreateParameterVersion {
         super::builder::parameter_manager::CreateParameterVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a single ParameterVersion.
     pub fn update_parameter_version(
         &self,
-        parameter_version: impl Into<crate::model::ParameterVersion>,
     ) -> super::builder::parameter_manager::UpdateParameterVersion {
         super::builder::parameter_manager::UpdateParameterVersion::new(self.inner.clone())
-            .set_parameter_version(parameter_version.into())
     }
 
     /// Deletes a single ParameterVersion.
     pub fn delete_parameter_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::parameter_manager::DeleteParameterVersion {
         super::builder::parameter_manager::DeleteParameterVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::parameter_manager::ListLocations {
         super::builder::parameter_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::parameter_manager::GetLocation {
+    pub fn get_location(&self) -> super::builder::parameter_manager::GetLocation {
         super::builder::parameter_manager::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -131,10 +131,15 @@ impl super::stub::ParameterManager for ParameterManager {
     ) -> Result<gax::response::Response<crate::model::Parameter>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.parameter
+            let arg = &req
+                .parameter
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("parameter"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parameter.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -305,10 +310,15 @@ impl super::stub::ParameterManager for ParameterManager {
     ) -> Result<gax::response::Response<crate::model::ParameterVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.parameter_version
+            let arg = &req
+                .parameter_version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("parameter_version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parameter_version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListParametersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/parameters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/parameters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Parameter>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Parameter>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/parameters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/parameters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,18 +130,15 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Parameter>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.parameter
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("parameter"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.parameter
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("parameter"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +162,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,9 +193,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListParameterVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +223,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ParameterVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -217,9 +250,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RenderParameterVersionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:render", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:render", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,12 +276,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ParameterVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/versions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,18 +304,15 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ParameterVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.parameter_version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("parameter_version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.parameter_version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("parameter_version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,9 +336,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,9 +367,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -341,9 +396,16 @@ impl super::stub::ParameterManager for ParameterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/policysimulator/v1/src/client.rs
+++ b/src/generated/cloud/policysimulator/v1/src/client.rs
@@ -135,11 +135,8 @@ impl Simulator {
     /// `Replay` is available for at least 7 days.
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    pub fn get_replay(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::simulator::GetReplay {
-        super::builder::simulator::GetReplay::new(self.inner.clone()).set_name(name.into())
+    pub fn get_replay(&self) -> super::builder::simulator::GetReplay {
+        super::builder::simulator::GetReplay::new(self.inner.clone())
     }
 
     /// Creates and starts a [Replay][google.cloud.policysimulator.v1.Replay] using
@@ -157,42 +154,29 @@ impl Simulator {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_replay(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::simulator::CreateReplay {
-        super::builder::simulator::CreateReplay::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_replay(&self) -> super::builder::simulator::CreateReplay {
+        super::builder::simulator::CreateReplay::new(self.inner.clone())
     }
 
     /// Lists the results of running a
     /// [Replay][google.cloud.policysimulator.v1.Replay].
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    pub fn list_replay_results(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::simulator::ListReplayResults {
+    pub fn list_replay_results(&self) -> super::builder::simulator::ListReplayResults {
         super::builder::simulator::ListReplayResults::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::simulator::ListOperations {
-        super::builder::simulator::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::simulator::ListOperations {
+        super::builder::simulator::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::simulator::GetOperation {
-        super::builder::simulator::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::simulator::GetOperation {
+        super::builder::simulator::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/policysimulator/v1/src/transport.rs
+++ b/src/generated/cloud/policysimulator/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Simulator for Simulator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Replay>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,16 @@ impl super::stub::Simulator for Simulator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/replays", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/replays", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -82,9 +96,16 @@ impl super::stub::Simulator for Simulator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReplayResultsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/results", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/results", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,9 +124,16 @@ impl super::stub::Simulator for Simulator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -125,9 +153,16 @@ impl super::stub::Simulator for Simulator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::PolicyTroubleshooter for PolicyTroubleshooter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TroubleshootIamPolicyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/iam:troubleshoot".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/iam:troubleshoot".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::IamChecker for IamChecker {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TroubleshootIamPolicyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/iam:troubleshoot".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/iam:troubleshoot".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
@@ -144,38 +144,26 @@ impl PrivilegedAccessManager {
     /// fixed before PAM can be used on the resource.
     pub fn check_onboarding_status(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::privileged_access_manager::CheckOnboardingStatus {
         super::builder::privileged_access_manager::CheckOnboardingStatus::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists entitlements in a given project/folder/organization and location.
-    pub fn list_entitlements(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::ListEntitlements {
+    pub fn list_entitlements(&self) -> super::builder::privileged_access_manager::ListEntitlements {
         super::builder::privileged_access_manager::ListEntitlements::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// `SearchEntitlements` returns entitlements on which the caller has the
     /// specified access.
     pub fn search_entitlements(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::privileged_access_manager::SearchEntitlements {
         super::builder::privileged_access_manager::SearchEntitlements::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single entitlement.
-    pub fn get_entitlement(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::GetEntitlement {
+    pub fn get_entitlement(&self) -> super::builder::privileged_access_manager::GetEntitlement {
         super::builder::privileged_access_manager::GetEntitlement::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new entitlement in a given project/folder/organization and
@@ -192,10 +180,8 @@ impl PrivilegedAccessManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_entitlement(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::privileged_access_manager::CreateEntitlement {
         super::builder::privileged_access_manager::CreateEntitlement::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single entitlement. This method can only be called when there
@@ -213,10 +199,8 @@ impl PrivilegedAccessManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_entitlement(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::privileged_access_manager::DeleteEntitlement {
         super::builder::privileged_access_manager::DeleteEntitlement::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the entitlement specified in the request. Updated fields in the
@@ -251,70 +235,44 @@ impl PrivilegedAccessManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_entitlement(
         &self,
-        entitlement: impl Into<crate::model::Entitlement>,
     ) -> super::builder::privileged_access_manager::UpdateEntitlement {
         super::builder::privileged_access_manager::UpdateEntitlement::new(self.inner.clone())
-            .set_entitlement(entitlement.into())
     }
 
     /// Lists grants for a given entitlement.
-    pub fn list_grants(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::ListGrants {
+    pub fn list_grants(&self) -> super::builder::privileged_access_manager::ListGrants {
         super::builder::privileged_access_manager::ListGrants::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// `SearchGrants` returns grants that are related to the calling user in the
     /// specified way.
-    pub fn search_grants(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::SearchGrants {
+    pub fn search_grants(&self) -> super::builder::privileged_access_manager::SearchGrants {
         super::builder::privileged_access_manager::SearchGrants::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get details of a single grant.
-    pub fn get_grant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::GetGrant {
+    pub fn get_grant(&self) -> super::builder::privileged_access_manager::GetGrant {
         super::builder::privileged_access_manager::GetGrant::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new grant in a given project/folder/organization and
     /// location.
-    pub fn create_grant(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::CreateGrant {
+    pub fn create_grant(&self) -> super::builder::privileged_access_manager::CreateGrant {
         super::builder::privileged_access_manager::CreateGrant::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// `ApproveGrant` is used to approve a grant. This method can only be called
     /// on a grant when it's in the `APPROVAL_AWAITED` state. This operation can't
     /// be undone.
-    pub fn approve_grant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::ApproveGrant {
+    pub fn approve_grant(&self) -> super::builder::privileged_access_manager::ApproveGrant {
         super::builder::privileged_access_manager::ApproveGrant::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// `DenyGrant` is used to deny a grant. This method can only be called on a
     /// grant when it's in the `APPROVAL_AWAITED` state. This operation can't be
     /// undone.
-    pub fn deny_grant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::DenyGrant {
+    pub fn deny_grant(&self) -> super::builder::privileged_access_manager::DenyGrant {
         super::builder::privileged_access_manager::DenyGrant::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// `RevokeGrant` is used to immediately revoke access for a grant. This method
@@ -329,62 +287,38 @@ impl PrivilegedAccessManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn revoke_grant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::RevokeGrant {
+    pub fn revoke_grant(&self) -> super::builder::privileged_access_manager::RevokeGrant {
         super::builder::privileged_access_manager::RevokeGrant::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::privileged_access_manager::ListLocations {
         super::builder::privileged_access_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::GetLocation {
+    pub fn get_location(&self) -> super::builder::privileged_access_manager::GetLocation {
         super::builder::privileged_access_manager::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::privileged_access_manager::ListOperations {
         super::builder::privileged_access_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::privileged_access_manager::GetOperation {
         super::builder::privileged_access_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::privileged_access_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::privileged_access_manager::DeleteOperation {
         super::builder::privileged_access_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckOnboardingStatusResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:checkOnboardingStatus", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:checkOnboardingStatus", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,12 +72,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEntitlementsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entitlements", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entitlements", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -94,12 +102,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchEntitlementsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/entitlements:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/entitlements:search", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -120,9 +132,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Entitlement>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -139,12 +158,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/entitlements", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/entitlements", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -163,9 +186,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,18 +214,15 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.entitlement
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("entitlement"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.entitlement
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("entitlement"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -218,9 +245,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGrantsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/grants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/grants", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,12 +275,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchGrantsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/grants:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/grants:search", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -267,9 +305,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Grant>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -286,9 +331,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Grant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/grants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/grants", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,9 +356,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Grant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:approve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -321,9 +380,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Grant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:deny", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:deny", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,9 +404,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -355,9 +428,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +457,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,9 +483,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -418,9 +512,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -437,9 +538,16 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -215,10 +215,15 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.entitlement
+            let arg = &req
+                .entitlement
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("entitlement"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("entitlement.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
@@ -132,12 +132,8 @@ impl RapidMigrationAssessment {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_collector(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::CreateCollector {
+    pub fn create_collector(&self) -> super::builder::rapid_migration_assessment::CreateCollector {
         super::builder::rapid_migration_assessment::CreateCollector::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates an Annotation
@@ -153,37 +149,23 @@ impl RapidMigrationAssessment {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_annotation(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::rapid_migration_assessment::CreateAnnotation {
         super::builder::rapid_migration_assessment::CreateAnnotation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Annotation.
-    pub fn get_annotation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::GetAnnotation {
+    pub fn get_annotation(&self) -> super::builder::rapid_migration_assessment::GetAnnotation {
         super::builder::rapid_migration_assessment::GetAnnotation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Collectors in a given project and location.
-    pub fn list_collectors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::ListCollectors {
+    pub fn list_collectors(&self) -> super::builder::rapid_migration_assessment::ListCollectors {
         super::builder::rapid_migration_assessment::ListCollectors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single Collector.
-    pub fn get_collector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::GetCollector {
+    pub fn get_collector(&self) -> super::builder::rapid_migration_assessment::GetCollector {
         super::builder::rapid_migration_assessment::GetCollector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the parameters of a single Collector.
@@ -197,12 +179,8 @@ impl RapidMigrationAssessment {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_collector(
-        &self,
-        collector: impl Into<crate::model::Collector>,
-    ) -> super::builder::rapid_migration_assessment::UpdateCollector {
+    pub fn update_collector(&self) -> super::builder::rapid_migration_assessment::UpdateCollector {
         super::builder::rapid_migration_assessment::UpdateCollector::new(self.inner.clone())
-            .set_collector(collector.into())
     }
 
     /// Deletes a single Collector - changes state of collector to "Deleting".
@@ -217,12 +195,8 @@ impl RapidMigrationAssessment {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_collector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::DeleteCollector {
+    pub fn delete_collector(&self) -> super::builder::rapid_migration_assessment::DeleteCollector {
         super::builder::rapid_migration_assessment::DeleteCollector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resumes the given collector.
@@ -236,12 +210,8 @@ impl RapidMigrationAssessment {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn resume_collector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::ResumeCollector {
+    pub fn resume_collector(&self) -> super::builder::rapid_migration_assessment::ResumeCollector {
         super::builder::rapid_migration_assessment::ResumeCollector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Registers the given collector.
@@ -257,10 +227,8 @@ impl RapidMigrationAssessment {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn register_collector(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::rapid_migration_assessment::RegisterCollector {
         super::builder::rapid_migration_assessment::RegisterCollector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Pauses the given collector.
@@ -274,73 +242,45 @@ impl RapidMigrationAssessment {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn pause_collector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::PauseCollector {
+    pub fn pause_collector(&self) -> super::builder::rapid_migration_assessment::PauseCollector {
         super::builder::rapid_migration_assessment::PauseCollector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::ListLocations {
+    pub fn list_locations(&self) -> super::builder::rapid_migration_assessment::ListLocations {
         super::builder::rapid_migration_assessment::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::GetLocation {
+    pub fn get_location(&self) -> super::builder::rapid_migration_assessment::GetLocation {
         super::builder::rapid_migration_assessment::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::ListOperations {
+    pub fn list_operations(&self) -> super::builder::rapid_migration_assessment::ListOperations {
         super::builder::rapid_migration_assessment::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::GetOperation {
+    pub fn get_operation(&self) -> super::builder::rapid_migration_assessment::GetOperation {
         super::builder::rapid_migration_assessment::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::rapid_migration_assessment::DeleteOperation {
         super::builder::rapid_migration_assessment::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::rapid_migration_assessment::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::rapid_migration_assessment::CancelOperation {
         super::builder::rapid_migration_assessment::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/collectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/collectors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,12 +74,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/annotations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/annotations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,9 +101,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Annotation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,12 +127,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCollectorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/collectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/collectors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -138,9 +157,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Collector>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -157,18 +183,15 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.collector
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("collector"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.collector
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("collector"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,9 +215,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,9 +242,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -229,9 +266,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:register", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:register", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,9 +290,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -263,9 +314,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,9 +343,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,9 +369,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -326,9 +398,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -345,9 +424,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -368,9 +454,16 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -184,10 +184,15 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.collector
+            let arg = &req
+                .collector
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("collector"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("collector.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
@@ -123,38 +123,26 @@ impl RecaptchaEnterpriseService {
     /// Creates an Assessment of the likelihood an event is legitimate.
     pub fn create_assessment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::CreateAssessment {
         super::builder::recaptcha_enterprise_service::CreateAssessment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Annotates a previously created Assessment to provide additional information
     /// on whether the event turned out to be authentic or fraudulent.
     pub fn annotate_assessment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::AnnotateAssessment {
         super::builder::recaptcha_enterprise_service::AnnotateAssessment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new reCAPTCHA Enterprise key.
-    pub fn create_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::CreateKey {
+    pub fn create_key(&self) -> super::builder::recaptcha_enterprise_service::CreateKey {
         super::builder::recaptcha_enterprise_service::CreateKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the list of all keys that belong to a project.
-    pub fn list_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::ListKeys {
+    pub fn list_keys(&self) -> super::builder::recaptcha_enterprise_service::ListKeys {
         super::builder::recaptcha_enterprise_service::ListKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the secret key related to the specified public key.
@@ -162,39 +150,25 @@ impl RecaptchaEnterpriseService {
     /// legacy reCAPTCHA.
     pub fn retrieve_legacy_secret_key(
         &self,
-        key: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::RetrieveLegacySecretKey {
         super::builder::recaptcha_enterprise_service::RetrieveLegacySecretKey::new(
             self.inner.clone(),
         )
-        .set_key(key.into())
     }
 
     /// Returns the specified key.
-    pub fn get_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::GetKey {
+    pub fn get_key(&self) -> super::builder::recaptcha_enterprise_service::GetKey {
         super::builder::recaptcha_enterprise_service::GetKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified key.
-    pub fn update_key(
-        &self,
-        key: impl Into<crate::model::Key>,
-    ) -> super::builder::recaptcha_enterprise_service::UpdateKey {
+    pub fn update_key(&self) -> super::builder::recaptcha_enterprise_service::UpdateKey {
         super::builder::recaptcha_enterprise_service::UpdateKey::new(self.inner.clone())
-            .set_key(key.into())
     }
 
     /// Deletes the specified key.
-    pub fn delete_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::DeleteKey {
+    pub fn delete_key(&self) -> super::builder::recaptcha_enterprise_service::DeleteKey {
         super::builder::recaptcha_enterprise_service::DeleteKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Migrates an existing key from reCAPTCHA to reCAPTCHA Enterprise.
@@ -203,12 +177,8 @@ impl RecaptchaEnterpriseService {
     /// authenticated as one of the current owners of the reCAPTCHA Key, and
     /// your user must have the reCAPTCHA Enterprise Admin IAM role in the
     /// destination project.
-    pub fn migrate_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::MigrateKey {
+    pub fn migrate_key(&self) -> super::builder::recaptcha_enterprise_service::MigrateKey {
         super::builder::recaptcha_enterprise_service::MigrateKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds an IP override to a key. The following restrictions hold:
@@ -216,12 +186,8 @@ impl RecaptchaEnterpriseService {
     /// * The maximum number of IP overrides per key is 100.
     /// * For any conflict (such as IP already exists or IP part of an existing
     ///   IP range), an error is returned.
-    pub fn add_ip_override(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::AddIpOverride {
+    pub fn add_ip_override(&self) -> super::builder::recaptcha_enterprise_service::AddIpOverride {
         super::builder::recaptcha_enterprise_service::AddIpOverride::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Removes an IP override from a key. The following restrictions hold:
@@ -232,29 +198,21 @@ impl RecaptchaEnterpriseService {
     ///   override type does not match, a `NOT_FOUND` error is returned.
     pub fn remove_ip_override(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::RemoveIpOverride {
         super::builder::recaptcha_enterprise_service::RemoveIpOverride::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all IP overrides for a key.
     pub fn list_ip_overrides(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::ListIpOverrides {
         super::builder::recaptcha_enterprise_service::ListIpOverrides::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get some aggregated metrics for a Key. This data can be used to build
     /// dashboards.
-    pub fn get_metrics(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recaptcha_enterprise_service::GetMetrics {
+    pub fn get_metrics(&self) -> super::builder::recaptcha_enterprise_service::GetMetrics {
         super::builder::recaptcha_enterprise_service::GetMetrics::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new FirewallPolicy, specifying conditions at which reCAPTCHA
@@ -262,89 +220,71 @@ impl RecaptchaEnterpriseService {
     /// A project may have a maximum of 1000 policies.
     pub fn create_firewall_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::CreateFirewallPolicy {
         super::builder::recaptcha_enterprise_service::CreateFirewallPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the list of all firewall policies that belong to a project.
     pub fn list_firewall_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::ListFirewallPolicies {
         super::builder::recaptcha_enterprise_service::ListFirewallPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified firewall policy.
     pub fn get_firewall_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::GetFirewallPolicy {
         super::builder::recaptcha_enterprise_service::GetFirewallPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified firewall policy.
     pub fn update_firewall_policy(
         &self,
-        firewall_policy: impl Into<crate::model::FirewallPolicy>,
     ) -> super::builder::recaptcha_enterprise_service::UpdateFirewallPolicy {
         super::builder::recaptcha_enterprise_service::UpdateFirewallPolicy::new(self.inner.clone())
-            .set_firewall_policy(firewall_policy.into())
     }
 
     /// Deletes the specified firewall policy.
     pub fn delete_firewall_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::DeleteFirewallPolicy {
         super::builder::recaptcha_enterprise_service::DeleteFirewallPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reorders all firewall policies.
     pub fn reorder_firewall_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::ReorderFirewallPolicies {
         super::builder::recaptcha_enterprise_service::ReorderFirewallPolicies::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// List groups of related accounts.
     pub fn list_related_account_groups(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::ListRelatedAccountGroups {
         super::builder::recaptcha_enterprise_service::ListRelatedAccountGroups::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get memberships in a group of related accounts.
     pub fn list_related_account_group_memberships(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::ListRelatedAccountGroupMemberships {
         super::builder::recaptcha_enterprise_service::ListRelatedAccountGroupMemberships::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Search group memberships related to a given account.
     pub fn search_related_account_group_memberships(
         &self,
-        project: impl Into<std::string::String>,
     ) -> super::builder::recaptcha_enterprise_service::SearchRelatedAccountGroupMemberships {
         super::builder::recaptcha_enterprise_service::SearchRelatedAccountGroupMemberships::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
     }
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Assessment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assessments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/assessments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AnnotateAssessmentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:annotate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:annotate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,9 +96,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/keys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/keys", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -102,9 +120,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/keys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/keys", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -123,12 +148,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RetrieveLegacySecretKeyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:retrieveLegacySecretKey", {
+            let arg = &req.key;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("key"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:retrieveLegacySecretKey", req.key),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,9 +174,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -164,18 +200,15 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.key
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("key"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.key
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("key"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -196,9 +229,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,9 +259,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:migrate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:migrate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -236,12 +283,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AddIpOverrideResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addIpOverride", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addIpOverride", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,12 +307,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RemoveIpOverrideResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeIpOverride", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeIpOverride", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,12 +331,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIpOverridesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listIpOverrides", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listIpOverrides", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,9 +359,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Metrics>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,12 +385,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/firewallpolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/firewallpolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -341,12 +411,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFirewallPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/firewallpolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/firewallpolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -365,9 +439,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,18 +465,15 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FirewallPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.firewall_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("firewall_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.firewall_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("firewall_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -418,9 +496,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -441,12 +526,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReorderFirewallPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/firewallpolicies:reorder", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/firewallpolicies:reorder", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -461,12 +550,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRelatedAccountGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/relatedaccountgroups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/relatedaccountgroups", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,12 +579,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
     ) -> Result<gax::response::Response<crate::model::ListRelatedAccountGroupMembershipsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/memberships", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/memberships", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -511,12 +608,16 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
     ) -> Result<gax::response::Response<crate::model::SearchRelatedAccountGroupMembershipsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/relatedaccountgroupmemberships:search", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/relatedaccountgroupmemberships:search", req.project),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -201,10 +201,15 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
     ) -> Result<gax::response::Response<crate::model::Key>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.key
+            let arg = &req
+                .key
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("key"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("key.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -466,10 +471,15 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
     ) -> Result<gax::response::Response<crate::model::FirewallPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.firewall_policy
+            let arg = &req
+                .firewall_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("firewall_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("firewall_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/recommender/v1/src/client.rs
+++ b/src/generated/cloud/recommender/v1/src/client.rs
@@ -123,20 +123,14 @@ impl Recommender {
 
     /// Lists insights for the specified Cloud Resource. Requires the
     /// recommender.*.list IAM permission for the specified insight type.
-    pub fn list_insights(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::recommender::ListInsights {
-        super::builder::recommender::ListInsights::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_insights(&self) -> super::builder::recommender::ListInsights {
+        super::builder::recommender::ListInsights::new(self.inner.clone())
     }
 
     /// Gets the requested insight. Requires the recommender.*.get IAM permission
     /// for the specified insight type.
-    pub fn get_insight(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommender::GetInsight {
-        super::builder::recommender::GetInsight::new(self.inner.clone()).set_name(name.into())
+    pub fn get_insight(&self) -> super::builder::recommender::GetInsight {
+        super::builder::recommender::GetInsight::new(self.inner.clone())
     }
 
     /// Marks the Insight State as Accepted. Users can use this method to
@@ -145,32 +139,20 @@ impl Recommender {
     ///
     /// MarkInsightAccepted can be applied to insights in ACTIVE state. Requires
     /// the recommender.*.update IAM permission for the specified insight.
-    pub fn mark_insight_accepted(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommender::MarkInsightAccepted {
+    pub fn mark_insight_accepted(&self) -> super::builder::recommender::MarkInsightAccepted {
         super::builder::recommender::MarkInsightAccepted::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists recommendations for the specified Cloud Resource. Requires the
     /// recommender.*.list IAM permission for the specified recommender.
-    pub fn list_recommendations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::recommender::ListRecommendations {
+    pub fn list_recommendations(&self) -> super::builder::recommender::ListRecommendations {
         super::builder::recommender::ListRecommendations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the requested recommendation. Requires the recommender.*.get
     /// IAM permission for the specified recommender.
-    pub fn get_recommendation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommender::GetRecommendation {
+    pub fn get_recommendation(&self) -> super::builder::recommender::GetRecommendation {
         super::builder::recommender::GetRecommendation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Mark the Recommendation State as Dismissed. Users can use this method to
@@ -184,10 +166,8 @@ impl Recommender {
     /// recommender.
     pub fn mark_recommendation_dismissed(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recommender::MarkRecommendationDismissed {
         super::builder::recommender::MarkRecommendationDismissed::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Marks the Recommendation State as Claimed. Users can use this method to
@@ -202,10 +182,8 @@ impl Recommender {
     /// recommender.
     pub fn mark_recommendation_claimed(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recommender::MarkRecommendationClaimed {
         super::builder::recommender::MarkRecommendationClaimed::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Marks the Recommendation State as Succeeded. Users can use this method to
@@ -221,10 +199,8 @@ impl Recommender {
     /// recommender.
     pub fn mark_recommendation_succeeded(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recommender::MarkRecommendationSucceeded {
         super::builder::recommender::MarkRecommendationSucceeded::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Marks the Recommendation State as Failed. Users can use this method to
@@ -240,49 +216,35 @@ impl Recommender {
     /// recommender.
     pub fn mark_recommendation_failed(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::recommender::MarkRecommendationFailed {
         super::builder::recommender::MarkRecommendationFailed::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the requested Recommender Config. There is only one instance of the
     /// config for each Recommender.
-    pub fn get_recommender_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommender::GetRecommenderConfig {
+    pub fn get_recommender_config(&self) -> super::builder::recommender::GetRecommenderConfig {
         super::builder::recommender::GetRecommenderConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Recommender Config. This will create a new revision of the
     /// config.
     pub fn update_recommender_config(
         &self,
-        recommender_config: impl Into<crate::model::RecommenderConfig>,
     ) -> super::builder::recommender::UpdateRecommenderConfig {
         super::builder::recommender::UpdateRecommenderConfig::new(self.inner.clone())
-            .set_recommender_config(recommender_config.into())
     }
 
     /// Gets the requested InsightTypeConfig. There is only one instance of the
     /// config for each InsightType.
-    pub fn get_insight_type_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::recommender::GetInsightTypeConfig {
+    pub fn get_insight_type_config(&self) -> super::builder::recommender::GetInsightTypeConfig {
         super::builder::recommender::GetInsightTypeConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an InsightTypeConfig change. This will create a new revision of the
     /// config.
     pub fn update_insight_type_config(
         &self,
-        insight_type_config: impl Into<crate::model::InsightTypeConfig>,
     ) -> super::builder::recommender::UpdateInsightTypeConfig {
         super::builder::recommender::UpdateInsightTypeConfig::new(self.inner.clone())
-            .set_insight_type_config(insight_type_config.into())
     }
 }

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -303,10 +303,15 @@ impl super::stub::Recommender for Recommender {
     ) -> Result<gax::response::Response<crate::model::RecommenderConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.recommender_config
+            let arg = &req
+                .recommender_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("recommender_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("recommender_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -361,10 +366,15 @@ impl super::stub::Recommender for Recommender {
     ) -> Result<gax::response::Response<crate::model::InsightTypeConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.insight_type_config
+            let arg = &req
+                .insight_type_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("insight_type_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("insight_type_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInsightsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/insights", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/insights", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +75,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Insight>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,12 +101,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Insight>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:markAccepted", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:markAccepted", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,12 +125,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRecommendationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/recommendations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/recommendations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -132,9 +154,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recommendation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -151,12 +180,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recommendation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:markDismissed", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:markDismissed", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -171,12 +204,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recommendation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:markClaimed", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:markClaimed", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -191,12 +228,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recommendation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:markSucceeded", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:markSucceeded", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,12 +252,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recommendation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:markFailed", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:markFailed", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,9 +276,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RecommenderConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,18 +302,15 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RecommenderConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.recommender_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("recommender_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.recommender_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("recommender_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,9 +334,16 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InsightTypeConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,18 +360,15 @@ impl super::stub::Recommender for Recommender {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InsightTypeConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.insight_type_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("insight_type_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.insight_type_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("insight_type_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/redis/cluster/v1/src/client.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/client.rs
@@ -145,21 +145,13 @@ impl CloudRedisCluster {
     ///
     /// If `location_id` is specified as `-` (wildcard), then all regions
     /// available to the project are queried, and the results are aggregated.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::cloud_redis_cluster::ListClusters {
         super::builder::cloud_redis_cluster::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific Redis cluster.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::GetCluster {
+    pub fn get_cluster(&self) -> super::builder::cloud_redis_cluster::GetCluster {
         super::builder::cloud_redis_cluster::GetCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the metadata and configuration of a specific Redis cluster.
@@ -177,12 +169,8 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        cluster: impl Into<crate::model::Cluster>,
-    ) -> super::builder::cloud_redis_cluster::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::cloud_redis_cluster::UpdateCluster {
         super::builder::cloud_redis_cluster::UpdateCluster::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Deletes a specific Redis cluster. Cluster stops serving and data is
@@ -197,12 +185,8 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::DeleteCluster {
+    pub fn delete_cluster(&self) -> super::builder::cloud_redis_cluster::DeleteCluster {
         super::builder::cloud_redis_cluster::DeleteCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Redis cluster based on the specified properties.
@@ -223,21 +207,15 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::cloud_redis_cluster::CreateCluster {
         super::builder::cloud_redis_cluster::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of certificate authority information for Redis cluster.
     pub fn get_cluster_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_redis_cluster::GetClusterCertificateAuthority {
         super::builder::cloud_redis_cluster::GetClusterCertificateAuthority::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Reschedules upcoming maintenance event.
@@ -253,10 +231,8 @@ impl CloudRedisCluster {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reschedule_cluster_maintenance(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_redis_cluster::RescheduleClusterMaintenance {
         super::builder::cloud_redis_cluster::RescheduleClusterMaintenance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all backup collections owned by a consumer project in either the
@@ -266,37 +242,25 @@ impl CloudRedisCluster {
     /// available to the project are queried, and the results are aggregated.
     pub fn list_backup_collections(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cloud_redis_cluster::ListBackupCollections {
         super::builder::cloud_redis_cluster::ListBackupCollections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a backup collection.
     pub fn get_backup_collection(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_redis_cluster::GetBackupCollection {
         super::builder::cloud_redis_cluster::GetBackupCollection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all backups owned by a backup collection.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::ListBackups {
+    pub fn list_backups(&self) -> super::builder::cloud_redis_cluster::ListBackups {
         super::builder::cloud_redis_cluster::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::GetBackup {
+    pub fn get_backup(&self) -> super::builder::cloud_redis_cluster::GetBackup {
         super::builder::cloud_redis_cluster::GetBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a specific backup.
@@ -310,12 +274,8 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::DeleteBackup {
+    pub fn delete_backup(&self) -> super::builder::cloud_redis_cluster::DeleteBackup {
         super::builder::cloud_redis_cluster::DeleteBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Exports a specific backup to a customer target Cloud Storage URI.
@@ -329,12 +289,8 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::ExportBackup {
+    pub fn export_backup(&self) -> super::builder::cloud_redis_cluster::ExportBackup {
         super::builder::cloud_redis_cluster::ExportBackup::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Backup Redis Cluster.
@@ -359,73 +315,45 @@ impl CloudRedisCluster {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn backup_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::BackupCluster {
+    pub fn backup_cluster(&self) -> super::builder::cloud_redis_cluster::BackupCluster {
         super::builder::cloud_redis_cluster::BackupCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::ListLocations {
+    pub fn list_locations(&self) -> super::builder::cloud_redis_cluster::ListLocations {
         super::builder::cloud_redis_cluster::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::GetLocation {
+    pub fn get_location(&self) -> super::builder::cloud_redis_cluster::GetLocation {
         super::builder::cloud_redis_cluster::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::ListOperations {
+    pub fn list_operations(&self) -> super::builder::cloud_redis_cluster::ListOperations {
         super::builder::cloud_redis_cluster::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::GetOperation {
+    pub fn get_operation(&self) -> super::builder::cloud_redis_cluster::GetOperation {
         super::builder::cloud_redis_cluster::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::cloud_redis_cluster::DeleteOperation {
         super::builder::cloud_redis_cluster::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis_cluster::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::cloud_redis_cluster::CancelOperation {
         super::builder::cloud_redis_cluster::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -101,10 +101,15 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cluster
+            let arg = &req
+                .cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,9 +74,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,18 +100,15 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,9 +132,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -141,12 +159,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,9 +187,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateAuthority>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -184,12 +213,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rescheduleClusterMaintenance", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rescheduleClusterMaintenance", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,12 +237,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupCollectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupCollections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupCollections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -228,9 +265,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupCollection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,9 +291,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -268,9 +319,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -287,9 +345,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,9 +372,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,9 +396,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:backup", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:backup", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -341,9 +420,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -363,9 +449,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -382,9 +475,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -404,9 +504,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -423,9 +530,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -446,9 +560,16 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/redis/v1/src/client.rs
+++ b/src/generated/cloud/redis/v1/src/client.rs
@@ -143,31 +143,20 @@ impl CloudRedis {
     ///
     /// If `location_id` is specified as `-` (wildcard), then all regions
     /// available to the project are queried, and the results are aggregated.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::ListInstances {
+    pub fn list_instances(&self) -> super::builder::cloud_redis::ListInstances {
         super::builder::cloud_redis::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific Redis instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::GetInstance {
-        super::builder::cloud_redis::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::cloud_redis::GetInstance {
+        super::builder::cloud_redis::GetInstance::new(self.inner.clone())
     }
 
     /// Gets the AUTH string for a Redis instance. If AUTH is not enabled for the
     /// instance the response will be empty. This information is not included in
     /// the details returned to GetInstance.
-    pub fn get_instance_auth_string(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::GetInstanceAuthString {
+    pub fn get_instance_auth_string(&self) -> super::builder::cloud_redis::GetInstanceAuthString {
         super::builder::cloud_redis::GetInstanceAuthString::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Redis instance based on the specified tier and memory size.
@@ -192,12 +181,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::cloud_redis::CreateInstance {
         super::builder::cloud_redis::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the metadata and configuration of a specific Redis instance.
@@ -215,12 +200,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::cloud_redis::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::cloud_redis::UpdateInstance {
         super::builder::cloud_redis::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Upgrades Redis instance to the newer Redis version specified in the
@@ -235,11 +216,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn upgrade_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::UpgradeInstance {
-        super::builder::cloud_redis::UpgradeInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn upgrade_instance(&self) -> super::builder::cloud_redis::UpgradeInstance {
+        super::builder::cloud_redis::UpgradeInstance::new(self.inner.clone())
     }
 
     /// Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
@@ -260,11 +238,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::ImportInstance {
-        super::builder::cloud_redis::ImportInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn import_instance(&self) -> super::builder::cloud_redis::ImportInstance {
+        super::builder::cloud_redis::ImportInstance::new(self.inner.clone())
     }
 
     /// Export Redis instance data into a Redis RDB format file in Cloud Storage.
@@ -283,11 +258,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::ExportInstance {
-        super::builder::cloud_redis::ExportInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn export_instance(&self) -> super::builder::cloud_redis::ExportInstance {
+        super::builder::cloud_redis::ExportInstance::new(self.inner.clone())
     }
 
     /// Initiates a failover of the primary node to current replica node for a
@@ -302,11 +274,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn failover_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::FailoverInstance {
-        super::builder::cloud_redis::FailoverInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn failover_instance(&self) -> super::builder::cloud_redis::FailoverInstance {
+        super::builder::cloud_redis::FailoverInstance::new(self.inner.clone())
     }
 
     /// Deletes a specific Redis instance.  Instance stops serving and data is
@@ -321,11 +290,8 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::DeleteInstance {
-        super::builder::cloud_redis::DeleteInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_instance(&self) -> super::builder::cloud_redis::DeleteInstance {
+        super::builder::cloud_redis::DeleteInstance::new(self.inner.clone())
     }
 
     /// Reschedule maintenance for a given instance in a given project and
@@ -340,67 +306,45 @@ impl CloudRedis {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reschedule_maintenance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::RescheduleMaintenance {
+    pub fn reschedule_maintenance(&self) -> super::builder::cloud_redis::RescheduleMaintenance {
         super::builder::cloud_redis::RescheduleMaintenance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::ListLocations {
-        super::builder::cloud_redis::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::cloud_redis::ListLocations {
+        super::builder::cloud_redis::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::GetLocation {
-        super::builder::cloud_redis::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cloud_redis::GetLocation {
+        super::builder::cloud_redis::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::ListOperations {
-        super::builder::cloud_redis::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::cloud_redis::ListOperations {
+        super::builder::cloud_redis::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::GetOperation {
-        super::builder::cloud_redis::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cloud_redis::GetOperation {
+        super::builder::cloud_redis::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::DeleteOperation {
-        super::builder::cloud_redis::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::cloud_redis::DeleteOperation {
+        super::builder::cloud_redis::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_redis::CancelOperation {
-        super::builder::cloud_redis::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::cloud_redis::CancelOperation {
+        super::builder::cloud_redis::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -154,10 +154,15 @@ impl super::stub::CloudRedis for CloudRedis {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,9 +100,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstanceAuthString>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/authString", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/authString", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -108,12 +126,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -131,18 +153,15 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,9 +184,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:upgrade", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:upgrade", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -182,9 +208,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:import", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:import", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,9 +232,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:export", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:export", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,9 +256,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:failover", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:failover", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -233,9 +280,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,12 +306,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rescheduleMaintenance", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:rescheduleMaintenance", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -272,9 +330,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,9 +359,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -313,9 +385,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,9 +414,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -354,9 +440,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +470,16 @@ impl super::stub::CloudRedis for CloudRedis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -125,11 +125,8 @@ impl Folders {
     /// (for example, `folders/1234`).
     /// The caller must have `resourcemanager.folders.get` permission on the
     /// identified folder.
-    pub fn get_folder(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::folders::GetFolder {
-        super::builder::folders::GetFolder::new(self.inner.clone()).set_name(name.into())
+    pub fn get_folder(&self) -> super::builder::folders::GetFolder {
+        super::builder::folders::GetFolder::new(self.inner.clone())
     }
 
     /// Lists the folders that are direct descendants of supplied parent resource.
@@ -223,11 +220,8 @@ impl Folders {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_folder(
-        &self,
-        folder: impl Into<crate::model::Folder>,
-    ) -> super::builder::folders::UpdateFolder {
-        super::builder::folders::UpdateFolder::new(self.inner.clone()).set_folder(folder.into())
+    pub fn update_folder(&self) -> super::builder::folders::UpdateFolder {
+        super::builder::folders::UpdateFolder::new(self.inner.clone())
     }
 
     /// Moves a folder under a new resource parent.
@@ -259,11 +253,8 @@ impl Folders {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn move_folder(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::folders::MoveFolder {
-        super::builder::folders::MoveFolder::new(self.inner.clone()).set_name(name.into())
+    pub fn move_folder(&self) -> super::builder::folders::MoveFolder {
+        super::builder::folders::MoveFolder::new(self.inner.clone())
     }
 
     /// Requests deletion of a folder. The folder is moved into the
@@ -290,11 +281,8 @@ impl Folders {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_folder(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::folders::DeleteFolder {
-        super::builder::folders::DeleteFolder::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_folder(&self) -> super::builder::folders::DeleteFolder {
+        super::builder::folders::DeleteFolder::new(self.inner.clone())
     }
 
     /// Cancels the deletion request for a folder. This method may be called on a
@@ -321,11 +309,8 @@ impl Folders {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_folder(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::folders::UndeleteFolder {
-        super::builder::folders::UndeleteFolder::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_folder(&self) -> super::builder::folders::UndeleteFolder {
+        super::builder::folders::UndeleteFolder::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a folder. The returned policy may be
@@ -333,11 +318,8 @@ impl Folders {
     /// be the folder's resource name, for example: "folders/1234".
     /// The caller must have `resourcemanager.folders.getIamPolicy` permission
     /// on the identified folder.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::folders::GetIamPolicy {
-        super::builder::folders::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::folders::GetIamPolicy {
+        super::builder::folders::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the access control policy on a folder, replacing any existing policy.
@@ -345,11 +327,8 @@ impl Folders {
     /// "folders/1234".
     /// The caller must have `resourcemanager.folders.setIamPolicy` permission
     /// on the identified folder.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::folders::SetIamPolicy {
-        super::builder::folders::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::folders::SetIamPolicy {
+        super::builder::folders::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified folder.
@@ -357,22 +336,15 @@ impl Folders {
     /// for example: "folders/1234".
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::folders::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::folders::TestIamPermissions {
         super::builder::folders::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::folders::GetOperation {
-        super::builder::folders::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::folders::GetOperation {
+        super::builder::folders::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -477,12 +449,8 @@ impl Organizations {
     }
 
     /// Fetches an organization resource identified by the specified resource name.
-    pub fn get_organization(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::organizations::GetOrganization {
+    pub fn get_organization(&self) -> super::builder::organizations::GetOrganization {
         super::builder::organizations::GetOrganization::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Searches organization resources that are visible to the user and satisfy
@@ -502,12 +470,8 @@ impl Organizations {
     ///
     /// Authorization requires the IAM permission
     /// `resourcemanager.organizations.getIamPolicy` on the specified organization.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::organizations::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::organizations::GetIamPolicy {
         super::builder::organizations::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on an organization resource. Replaces any
@@ -516,12 +480,8 @@ impl Organizations {
     ///
     /// Authorization requires the IAM permission
     /// `resourcemanager.organizations.setIamPolicy` on the specified organization.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::organizations::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::organizations::SetIamPolicy {
         super::builder::organizations::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the permissions that a caller has on the specified organization.
@@ -529,22 +489,15 @@ impl Organizations {
     /// for example: "organizations/123".
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::organizations::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::organizations::TestIamPermissions {
         super::builder::organizations::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::organizations::GetOperation {
-        super::builder::organizations::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::organizations::GetOperation {
+        super::builder::organizations::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -653,11 +606,8 @@ impl Projects {
     ///
     /// The caller must have `resourcemanager.projects.get` permission
     /// for this project.
-    pub fn get_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::projects::GetProject {
-        super::builder::projects::GetProject::new(self.inner.clone()).set_name(name.into())
+    pub fn get_project(&self) -> super::builder::projects::GetProject {
+        super::builder::projects::GetProject::new(self.inner.clone())
     }
 
     /// Lists projects that are direct children of the specified folder or
@@ -721,11 +671,8 @@ impl Projects {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_project(
-        &self,
-        project: impl Into<crate::model::Project>,
-    ) -> super::builder::projects::UpdateProject {
-        super::builder::projects::UpdateProject::new(self.inner.clone()).set_project(project.into())
+    pub fn update_project(&self) -> super::builder::projects::UpdateProject {
+        super::builder::projects::UpdateProject::new(self.inner.clone())
     }
 
     /// Move a project to another place in your resource hierarchy, under a new
@@ -752,11 +699,8 @@ impl Projects {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn move_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::projects::MoveProject {
-        super::builder::projects::MoveProject::new(self.inner.clone()).set_name(name.into())
+    pub fn move_project(&self) -> super::builder::projects::MoveProject {
+        super::builder::projects::MoveProject::new(self.inner.clone())
     }
 
     /// Marks the project identified by the specified
@@ -806,11 +750,8 @@ impl Projects {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::projects::DeleteProject {
-        super::builder::projects::DeleteProject::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_project(&self) -> super::builder::projects::DeleteProject {
+        super::builder::projects::DeleteProject::new(self.inner.clone())
     }
 
     /// Restores the project identified by the specified
@@ -832,22 +773,15 @@ impl Projects {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::projects::UndeleteProject {
-        super::builder::projects::UndeleteProject::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_project(&self) -> super::builder::projects::UndeleteProject {
+        super::builder::projects::UndeleteProject::new(self.inner.clone())
     }
 
     /// Returns the IAM access control policy for the specified project, in the
     /// format `projects/{ProjectIdOrNumber}` e.g. projects/123.
     /// Permission is denied if the policy or the resource do not exist.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::projects::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::projects::GetIamPolicy {
         super::builder::projects::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM access control policy for the specified project, in the
@@ -892,32 +826,21 @@ impl Projects {
     ///   rectified. If the project is part of an organization, you can remove all
     ///   owners, potentially making the organization inaccessible.
     ///
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::projects::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::projects::SetIamPolicy {
         super::builder::projects::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified project, in the
     /// format `projects/{ProjectIdOrNumber}` e.g. projects/123..
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::projects::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::projects::TestIamPermissions {
         super::builder::projects::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::projects::GetOperation {
-        super::builder::projects::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::projects::GetOperation {
+        super::builder::projects::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1057,12 +980,8 @@ impl TagBindings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tag_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_bindings::DeleteTagBinding {
+    pub fn delete_tag_binding(&self) -> super::builder::tag_bindings::DeleteTagBinding {
         super::builder::tag_bindings::DeleteTagBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Return a list of effective tags for the given Google Cloud resource, as
@@ -1074,11 +993,8 @@ impl TagBindings {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_bindings::GetOperation {
-        super::builder::tag_bindings::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tag_bindings::GetOperation {
+        super::builder::tag_bindings::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1198,11 +1114,8 @@ impl TagHolds {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_tag_hold(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tag_holds::CreateTagHold {
-        super::builder::tag_holds::CreateTagHold::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_tag_hold(&self) -> super::builder::tag_holds::CreateTagHold {
+        super::builder::tag_holds::CreateTagHold::new(self.inner.clone())
     }
 
     /// Deletes a TagHold.
@@ -1216,29 +1129,20 @@ impl TagHolds {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tag_hold(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_holds::DeleteTagHold {
-        super::builder::tag_holds::DeleteTagHold::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tag_hold(&self) -> super::builder::tag_holds::DeleteTagHold {
+        super::builder::tag_holds::DeleteTagHold::new(self.inner.clone())
     }
 
     /// Lists TagHolds under a TagValue.
-    pub fn list_tag_holds(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tag_holds::ListTagHolds {
-        super::builder::tag_holds::ListTagHolds::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_tag_holds(&self) -> super::builder::tag_holds::ListTagHolds {
+        super::builder::tag_holds::ListTagHolds::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_holds::GetOperation {
-        super::builder::tag_holds::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tag_holds::GetOperation {
+        super::builder::tag_holds::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1349,11 +1253,8 @@ impl TagKeys {
 
     /// Retrieves a TagKey. This method will return `PERMISSION_DENIED` if the
     /// key does not exist or the user does not have permission to view it.
-    pub fn get_tag_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::GetTagKey {
-        super::builder::tag_keys::GetTagKey::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tag_key(&self) -> super::builder::tag_keys::GetTagKey {
+        super::builder::tag_keys::GetTagKey::new(self.inner.clone())
     }
 
     /// Retrieves a TagKey by its namespaced name.
@@ -1392,11 +1293,8 @@ impl TagKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_tag_key(
-        &self,
-        tag_key: impl Into<crate::model::TagKey>,
-    ) -> super::builder::tag_keys::UpdateTagKey {
-        super::builder::tag_keys::UpdateTagKey::new(self.inner.clone()).set_tag_key(tag_key.into())
+    pub fn update_tag_key(&self) -> super::builder::tag_keys::UpdateTagKey {
+        super::builder::tag_keys::UpdateTagKey::new(self.inner.clone())
     }
 
     /// Deletes a TagKey. The TagKey cannot be deleted if it has any child
@@ -1411,11 +1309,8 @@ impl TagKeys {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tag_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::DeleteTagKey {
-        super::builder::tag_keys::DeleteTagKey::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tag_key(&self) -> super::builder::tag_keys::DeleteTagKey {
+        super::builder::tag_keys::DeleteTagKey::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a TagKey. The returned policy may be
@@ -1424,12 +1319,8 @@ impl TagKeys {
     /// The caller must have
     /// `cloudresourcemanager.googleapis.com/tagKeys.getIamPolicy` permission on
     /// the specified TagKey.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::tag_keys::GetIamPolicy {
         super::builder::tag_keys::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on a TagKey, replacing any existing
@@ -1437,12 +1328,8 @@ impl TagKeys {
     /// For example, "tagKeys/1234".
     /// The caller must have `resourcemanager.tagKeys.setIamPolicy` permission
     /// on the identified tagValue.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::tag_keys::SetIamPolicy {
         super::builder::tag_keys::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified TagKey.
@@ -1450,22 +1337,15 @@ impl TagKeys {
     /// For example, "tagKeys/1234".
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::tag_keys::TestIamPermissions {
         super::builder::tag_keys::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_keys::GetOperation {
-        super::builder::tag_keys::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tag_keys::GetOperation {
+        super::builder::tag_keys::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1576,11 +1456,8 @@ impl TagValues {
 
     /// Retrieves a TagValue. This method will return `PERMISSION_DENIED` if the
     /// value does not exist or the user does not have permission to view it.
-    pub fn get_tag_value(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::GetTagValue {
-        super::builder::tag_values::GetTagValue::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tag_value(&self) -> super::builder::tag_values::GetTagValue {
+        super::builder::tag_values::GetTagValue::new(self.inner.clone())
     }
 
     /// Retrieves a TagValue by its namespaced name.
@@ -1619,12 +1496,8 @@ impl TagValues {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_tag_value(
-        &self,
-        tag_value: impl Into<crate::model::TagValue>,
-    ) -> super::builder::tag_values::UpdateTagValue {
+    pub fn update_tag_value(&self) -> super::builder::tag_values::UpdateTagValue {
         super::builder::tag_values::UpdateTagValue::new(self.inner.clone())
-            .set_tag_value(tag_value.into())
     }
 
     /// Deletes a TagValue. The TagValue cannot have any bindings when it is
@@ -1639,11 +1512,8 @@ impl TagValues {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_tag_value(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::DeleteTagValue {
-        super::builder::tag_values::DeleteTagValue::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tag_value(&self) -> super::builder::tag_values::DeleteTagValue {
+        super::builder::tag_values::DeleteTagValue::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a TagValue. The returned policy may be
@@ -1652,12 +1522,8 @@ impl TagValues {
     /// The caller must have the
     /// `cloudresourcemanager.googleapis.com/tagValues.getIamPolicy` permission on
     /// the identified TagValue to get the access control policy.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::tag_values::GetIamPolicy {
         super::builder::tag_values::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy on a TagValue, replacing any existing
@@ -1665,12 +1531,8 @@ impl TagValues {
     /// For example: `tagValues/1234`.
     /// The caller must have `resourcemanager.tagValues.setIamPolicy` permission
     /// on the identified tagValue.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::tag_values::SetIamPolicy {
         super::builder::tag_values::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified TagValue.
@@ -1678,21 +1540,14 @@ impl TagValues {
     /// `tagValues/1234`.
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::tag_values::TestIamPermissions {
         super::builder::tag_values::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tag_values::GetOperation {
-        super::builder::tag_values::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tag_values::GetOperation {
+        super::builder::tag_values::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Folder>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,10 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFoldersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/folders".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/folders".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +96,10 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchFoldersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/folders:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/folders:search".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,9 +119,10 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/folders".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/folders".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,18 +137,15 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.folder
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("folder"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.folder
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("folder"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +166,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:move", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:move", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,9 +190,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -195,9 +216,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,12 +240,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -232,12 +264,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,12 +288,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -272,9 +312,16 @@ impl super::stub::Folders for Folders {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +375,16 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Organization>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,9 +401,10 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchOrganizationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/organizations:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/organizations:search".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -369,12 +424,16 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -389,12 +448,16 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,12 +472,16 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -429,9 +496,16 @@ impl super::stub::Organizations for Organizations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +545,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Project>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -490,9 +571,10 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProjectsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/projects".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/projects".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -513,9 +595,10 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchProjectsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/projects:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/projects:search".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -535,9 +618,10 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/projects".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/projects".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -554,18 +638,15 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.project
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("project"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.project
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("project"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -588,9 +669,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:move", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:move", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -605,9 +693,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -624,9 +719,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -641,12 +743,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -661,12 +767,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -681,12 +791,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,9 +815,16 @@ impl super::stub::Projects for Projects {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -757,9 +878,10 @@ impl super::stub::TagBindings for TagBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/tagBindings".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/tagBindings".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -779,9 +901,10 @@ impl super::stub::TagBindings for TagBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/tagBindings".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/tagBindings".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -799,9 +922,16 @@ impl super::stub::TagBindings for TagBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -818,9 +948,10 @@ impl super::stub::TagBindings for TagBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEffectiveTagsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/effectiveTags".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/effectiveTags".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -840,9 +971,16 @@ impl super::stub::TagBindings for TagBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -896,12 +1034,16 @@ impl super::stub::TagHolds for TagHolds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/tagHolds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/tagHolds", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -919,9 +1061,16 @@ impl super::stub::TagHolds for TagHolds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -939,9 +1088,16 @@ impl super::stub::TagHolds for TagHolds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagHoldsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/tagHolds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/tagHolds", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -961,9 +1117,16 @@ impl super::stub::TagHolds for TagHolds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1017,9 +1180,10 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/tagKeys".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/tagKeys".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1039,9 +1203,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1058,9 +1229,10 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/tagKeys/namespaced".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/tagKeys/namespaced".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1078,9 +1250,10 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/tagKeys".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/tagKeys".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1098,18 +1271,15 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.tag_key
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tag_key"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.tag_key
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tag_key"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1133,9 +1303,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1154,12 +1331,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1174,12 +1355,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1194,12 +1379,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1214,9 +1403,16 @@ impl super::stub::TagKeys for TagKeys {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1270,9 +1466,10 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagValuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/tagValues".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/tagValues".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1292,9 +1489,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagValue>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1311,9 +1515,10 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TagValue>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/tagValues/namespaced".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/tagValues/namespaced".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1331,9 +1536,10 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v3/tagValues".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v3/tagValues".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1351,18 +1557,15 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.tag_value
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tag_value"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.tag_value
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tag_value"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1386,9 +1589,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1407,12 +1617,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1427,12 +1641,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1447,12 +1665,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1467,9 +1689,16 @@ impl super::stub::TagValues for TagValues {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -138,10 +138,15 @@ impl super::stub::Folders for Folders {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.folder
+            let arg = &req
+                .folder
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("folder"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("folder.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -639,10 +644,15 @@ impl super::stub::Projects for Projects {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.project
+            let arg = &req
+                .project
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("project"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1272,10 +1282,15 @@ impl super::stub::TagKeys for TagKeys {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.tag_key
+            let arg = &req
+                .tag_key
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tag_key"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tag_key.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1558,10 +1573,15 @@ impl super::stub::TagValues for TagValues {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.tag_value
+            let arg = &req
+                .tag_value
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tag_value"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tag_value.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/retail/v2/src/client.rs
+++ b/src/generated/cloud/retail/v2/src/client.rs
@@ -137,32 +137,22 @@ impl AnalyticsService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn export_analytics_metrics(
         &self,
-        catalog: impl Into<std::string::String>,
     ) -> super::builder::analytics_service::ExportAnalyticsMetrics {
         super::builder::analytics_service::ExportAnalyticsMetrics::new(self.inner.clone())
-            .set_catalog(catalog.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::analytics_service::ListOperations {
         super::builder::analytics_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::analytics_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::analytics_service::GetOperation {
         super::builder::analytics_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -270,23 +260,15 @@ impl CatalogService {
     /// the project.
     ///
     /// [google.cloud.retail.v2.Catalog]: crate::model::Catalog
-    pub fn list_catalogs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListCatalogs {
+    pub fn list_catalogs(&self) -> super::builder::catalog_service::ListCatalogs {
         super::builder::catalog_service::ListCatalogs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the [Catalog][google.cloud.retail.v2.Catalog]s.
     ///
     /// [google.cloud.retail.v2.Catalog]: crate::model::Catalog
-    pub fn update_catalog(
-        &self,
-        catalog: impl Into<crate::model::Catalog>,
-    ) -> super::builder::catalog_service::UpdateCatalog {
+    pub fn update_catalog(&self) -> super::builder::catalog_service::UpdateCatalog {
         super::builder::catalog_service::UpdateCatalog::new(self.inner.clone())
-            .set_catalog(catalog.into())
     }
 
     /// Set a specified branch id as default branch. API methods such as
@@ -328,12 +310,8 @@ impl CatalogService {
     /// [google.cloud.retail.v2.ProductService.ListProducts]: crate::client::ProductService::list_products
     /// [google.cloud.retail.v2.SearchRequest.branch]: crate::model::SearchRequest::branch
     /// [google.cloud.retail.v2.SearchService.Search]: crate::client::SearchService::search
-    pub fn set_default_branch(
-        &self,
-        catalog: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::SetDefaultBranch {
+    pub fn set_default_branch(&self) -> super::builder::catalog_service::SetDefaultBranch {
         super::builder::catalog_service::SetDefaultBranch::new(self.inner.clone())
-            .set_catalog(catalog.into())
     }
 
     /// Get which branch is currently default branch set by
@@ -341,23 +319,15 @@ impl CatalogService {
     /// method under a specified parent catalog.
     ///
     /// [google.cloud.retail.v2.CatalogService.SetDefaultBranch]: crate::client::CatalogService::set_default_branch
-    pub fn get_default_branch(
-        &self,
-        catalog: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetDefaultBranch {
+    pub fn get_default_branch(&self) -> super::builder::catalog_service::GetDefaultBranch {
         super::builder::catalog_service::GetDefaultBranch::new(self.inner.clone())
-            .set_catalog(catalog.into())
     }
 
     /// Gets a [CompletionConfig][google.cloud.retail.v2.CompletionConfig].
     ///
     /// [google.cloud.retail.v2.CompletionConfig]: crate::model::CompletionConfig
-    pub fn get_completion_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetCompletionConfig {
+    pub fn get_completion_config(&self) -> super::builder::catalog_service::GetCompletionConfig {
         super::builder::catalog_service::GetCompletionConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the [CompletionConfig][google.cloud.retail.v2.CompletionConfig]s.
@@ -365,21 +335,15 @@ impl CatalogService {
     /// [google.cloud.retail.v2.CompletionConfig]: crate::model::CompletionConfig
     pub fn update_completion_config(
         &self,
-        completion_config: impl Into<crate::model::CompletionConfig>,
     ) -> super::builder::catalog_service::UpdateCompletionConfig {
         super::builder::catalog_service::UpdateCompletionConfig::new(self.inner.clone())
-            .set_completion_config(completion_config.into())
     }
 
     /// Gets an [AttributesConfig][google.cloud.retail.v2.AttributesConfig].
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
-    pub fn get_attributes_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetAttributesConfig {
+    pub fn get_attributes_config(&self) -> super::builder::catalog_service::GetAttributesConfig {
         super::builder::catalog_service::GetAttributesConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the [AttributesConfig][google.cloud.retail.v2.AttributesConfig].
@@ -394,10 +358,8 @@ impl CatalogService {
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
     pub fn update_attributes_config(
         &self,
-        attributes_config: impl Into<crate::model::AttributesConfig>,
     ) -> super::builder::catalog_service::UpdateAttributesConfig {
         super::builder::catalog_service::UpdateAttributesConfig::new(self.inner.clone())
-            .set_attributes_config(attributes_config.into())
     }
 
     /// Adds the specified
@@ -409,12 +371,8 @@ impl CatalogService {
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
     /// [google.cloud.retail.v2.CatalogAttribute]: crate::model::CatalogAttribute
-    pub fn add_catalog_attribute(
-        &self,
-        attributes_config: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::AddCatalogAttribute {
+    pub fn add_catalog_attribute(&self) -> super::builder::catalog_service::AddCatalogAttribute {
         super::builder::catalog_service::AddCatalogAttribute::new(self.inner.clone())
-            .set_attributes_config(attributes_config.into())
     }
 
     /// Removes the specified
@@ -428,10 +386,8 @@ impl CatalogService {
     /// [google.cloud.retail.v2.CatalogAttribute]: crate::model::CatalogAttribute
     pub fn remove_catalog_attribute(
         &self,
-        attributes_config: impl Into<std::string::String>,
     ) -> super::builder::catalog_service::RemoveCatalogAttribute {
         super::builder::catalog_service::RemoveCatalogAttribute::new(self.inner.clone())
-            .set_attributes_config(attributes_config.into())
     }
 
     /// Replaces the specified
@@ -448,31 +404,22 @@ impl CatalogService {
     /// [google.cloud.retail.v2.CatalogAttribute.key]: crate::model::CatalogAttribute::key
     pub fn replace_catalog_attribute(
         &self,
-        attributes_config: impl Into<std::string::String>,
     ) -> super::builder::catalog_service::ReplaceCatalogAttribute {
         super::builder::catalog_service::ReplaceCatalogAttribute::new(self.inner.clone())
-            .set_attributes_config(attributes_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::catalog_service::ListOperations {
         super::builder::catalog_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::catalog_service::GetOperation {
-        super::builder::catalog_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::catalog_service::GetOperation {
+        super::builder::catalog_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -585,12 +532,8 @@ impl CompletionService {
     ///
     /// This feature is only available for users who have Retail Search enabled.
     /// Enable Retail Search on Cloud Console before using this feature.
-    pub fn complete_query(
-        &self,
-        catalog: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::CompleteQuery {
+    pub fn complete_query(&self) -> super::builder::completion_service::CompleteQuery {
         super::builder::completion_service::CompleteQuery::new(self.inner.clone())
-            .set_catalog(catalog.into())
     }
 
     /// Bulk import of processed completion dataset.
@@ -614,32 +557,22 @@ impl CompletionService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn import_completion_data(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::completion_service::ImportCompletionData {
         super::builder::completion_service::ImportCompletionData::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::completion_service::ListOperations {
         super::builder::completion_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::completion_service::GetOperation {
         super::builder::completion_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -749,12 +682,8 @@ impl ControlService {
     /// an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
-    pub fn create_control(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::control_service::CreateControl {
+    pub fn create_control(&self) -> super::builder::control_service::CreateControl {
         super::builder::control_service::CreateControl::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Control.
@@ -763,12 +692,8 @@ impl ControlService {
     /// a NOT_FOUND error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
-    pub fn delete_control(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::DeleteControl {
+    pub fn delete_control(&self) -> super::builder::control_service::DeleteControl {
         super::builder::control_service::DeleteControl::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a Control.
@@ -779,53 +704,35 @@ impl ControlService {
     /// NOT_FOUND error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
-    pub fn update_control(
-        &self,
-        control: impl Into<crate::model::Control>,
-    ) -> super::builder::control_service::UpdateControl {
+    pub fn update_control(&self) -> super::builder::control_service::UpdateControl {
         super::builder::control_service::UpdateControl::new(self.inner.clone())
-            .set_control(control.into())
     }
 
     /// Gets a Control.
-    pub fn get_control(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::GetControl {
-        super::builder::control_service::GetControl::new(self.inner.clone()).set_name(name.into())
+    pub fn get_control(&self) -> super::builder::control_service::GetControl {
+        super::builder::control_service::GetControl::new(self.inner.clone())
     }
 
     /// Lists all Controls by their parent
     /// [Catalog][google.cloud.retail.v2.Catalog].
     ///
     /// [google.cloud.retail.v2.Catalog]: crate::model::Catalog
-    pub fn list_controls(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::control_service::ListControls {
+    pub fn list_controls(&self) -> super::builder::control_service::ListControls {
         super::builder::control_service::ListControls::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::control_service::ListOperations {
         super::builder::control_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::control_service::GetOperation {
-        super::builder::control_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::control_service::GetOperation {
+        super::builder::control_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -935,79 +842,61 @@ impl GenerativeQuestionService {
     /// feature on and off.
     pub fn update_generative_questions_feature_config(
         &self,
-        generative_questions_feature_config: impl Into<crate::model::GenerativeQuestionsFeatureConfig>,
     ) -> super::builder::generative_question_service::UpdateGenerativeQuestionsFeatureConfig {
         super::builder::generative_question_service::UpdateGenerativeQuestionsFeatureConfig::new(
             self.inner.clone(),
         )
-        .set_generative_questions_feature_config(generative_questions_feature_config.into())
     }
 
     /// Manages overal generative question feature state -- enables toggling
     /// feature on and off.
     pub fn get_generative_questions_feature_config(
         &self,
-        catalog: impl Into<std::string::String>,
     ) -> super::builder::generative_question_service::GetGenerativeQuestionsFeatureConfig {
         super::builder::generative_question_service::GetGenerativeQuestionsFeatureConfig::new(
             self.inner.clone(),
         )
-        .set_catalog(catalog.into())
     }
 
     /// Returns all questions for a given catalog.
     pub fn list_generative_question_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::generative_question_service::ListGenerativeQuestionConfigs {
         super::builder::generative_question_service::ListGenerativeQuestionConfigs::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Allows management of individual questions.
     pub fn update_generative_question_config(
         &self,
-        generative_question_config: impl Into<crate::model::GenerativeQuestionConfig>,
     ) -> super::builder::generative_question_service::UpdateGenerativeQuestionConfig {
         super::builder::generative_question_service::UpdateGenerativeQuestionConfig::new(
             self.inner.clone(),
         )
-        .set_generative_question_config(generative_question_config.into())
     }
 
     /// Allows management of multiple questions.
     pub fn batch_update_generative_question_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::generative_question_service::BatchUpdateGenerativeQuestionConfigs {
         super::builder::generative_question_service::BatchUpdateGenerativeQuestionConfigs::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generative_question_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::generative_question_service::ListOperations {
         super::builder::generative_question_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::generative_question_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::generative_question_service::GetOperation {
         super::builder::generative_question_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1133,63 +1022,41 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::CreateModel {
+    pub fn create_model(&self) -> super::builder::model_service::CreateModel {
         super::builder::model_service::CreateModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a model.
-    pub fn get_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetModel {
-        super::builder::model_service::GetModel::new(self.inner.clone()).set_name(name.into())
+    pub fn get_model(&self) -> super::builder::model_service::GetModel {
+        super::builder::model_service::GetModel::new(self.inner.clone())
     }
 
     /// Pauses the training of an existing model.
-    pub fn pause_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::PauseModel {
-        super::builder::model_service::PauseModel::new(self.inner.clone()).set_name(name.into())
+    pub fn pause_model(&self) -> super::builder::model_service::PauseModel {
+        super::builder::model_service::PauseModel::new(self.inner.clone())
     }
 
     /// Resumes the training of an existing model.
-    pub fn resume_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ResumeModel {
-        super::builder::model_service::ResumeModel::new(self.inner.clone()).set_name(name.into())
+    pub fn resume_model(&self) -> super::builder::model_service::ResumeModel {
+        super::builder::model_service::ResumeModel::new(self.inner.clone())
     }
 
     /// Deletes an existing model.
-    pub fn delete_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::DeleteModel {
-        super::builder::model_service::DeleteModel::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_model(&self) -> super::builder::model_service::DeleteModel {
+        super::builder::model_service::DeleteModel::new(self.inner.clone())
     }
 
     /// Lists all the models linked to this event store.
-    pub fn list_models(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListModels {
-        super::builder::model_service::ListModels::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_models(&self) -> super::builder::model_service::ListModels {
+        super::builder::model_service::ListModels::new(self.inner.clone())
     }
 
     /// Update of model metadata. Only fields that
     /// currently can be updated are: `filtering_option` and
     /// `periodic_tuning_state`.
     /// If other values are provided, this API method ignores them.
-    pub fn update_model(
-        &self,
-        model: impl Into<crate::model::Model>,
-    ) -> super::builder::model_service::UpdateModel {
-        super::builder::model_service::UpdateModel::new(self.inner.clone()).set_model(model.into())
+    pub fn update_model(&self) -> super::builder::model_service::UpdateModel {
+        super::builder::model_service::UpdateModel::new(self.inner.clone())
     }
 
     /// Tunes an existing model.
@@ -1203,31 +1070,22 @@ impl ModelService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn tune_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::TuneModel {
-        super::builder::model_service::TuneModel::new(self.inner.clone()).set_name(name.into())
+    pub fn tune_model(&self) -> super::builder::model_service::TuneModel {
+        super::builder::model_service::TuneModel::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::ListOperations {
-        super::builder::model_service::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::model_service::ListOperations {
+        super::builder::model_service::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::model_service::GetOperation {
-        super::builder::model_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::model_service::GetOperation {
+        super::builder::model_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -1334,34 +1192,22 @@ impl PredictionService {
     }
 
     /// Makes a recommendation prediction.
-    pub fn predict(
-        &self,
-        placement: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::Predict {
+    pub fn predict(&self) -> super::builder::prediction_service::Predict {
         super::builder::prediction_service::Predict::new(self.inner.clone())
-            .set_placement(placement.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::prediction_service::ListOperations {
         super::builder::prediction_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::prediction_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::prediction_service::GetOperation {
         super::builder::prediction_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1471,55 +1317,36 @@ impl ProductService {
     /// Creates a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    pub fn create_product(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_service::CreateProduct {
+    pub fn create_product(&self) -> super::builder::product_service::CreateProduct {
         super::builder::product_service::CreateProduct::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    pub fn get_product(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_service::GetProduct {
-        super::builder::product_service::GetProduct::new(self.inner.clone()).set_name(name.into())
+    pub fn get_product(&self) -> super::builder::product_service::GetProduct {
+        super::builder::product_service::GetProduct::new(self.inner.clone())
     }
 
     /// Gets a list of [Product][google.cloud.retail.v2.Product]s.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    pub fn list_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_service::ListProducts {
+    pub fn list_products(&self) -> super::builder::product_service::ListProducts {
         super::builder::product_service::ListProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    pub fn update_product(
-        &self,
-        product: impl Into<crate::model::Product>,
-    ) -> super::builder::product_service::UpdateProduct {
+    pub fn update_product(&self) -> super::builder::product_service::UpdateProduct {
         super::builder::product_service::UpdateProduct::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// Deletes a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    pub fn delete_product(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_service::DeleteProduct {
+    pub fn delete_product(&self) -> super::builder::product_service::DeleteProduct {
         super::builder::product_service::DeleteProduct::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Permanently deletes all selected [Product][google.cloud.retail.v2.Product]s
@@ -1554,12 +1381,8 @@ impl ProductService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_service::PurgeProducts {
+    pub fn purge_products(&self) -> super::builder::product_service::PurgeProducts {
         super::builder::product_service::PurgeProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Bulk import of multiple [Product][google.cloud.retail.v2.Product]s.
@@ -1581,12 +1404,8 @@ impl ProductService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_service::ImportProducts {
+    pub fn import_products(&self) -> super::builder::product_service::ImportProducts {
         super::builder::product_service::ImportProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates inventory information for a
@@ -1661,12 +1480,8 @@ impl ProductService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn set_inventory(
-        &self,
-        inventory: impl Into<crate::model::Product>,
-    ) -> super::builder::product_service::SetInventory {
+    pub fn set_inventory(&self) -> super::builder::product_service::SetInventory {
         super::builder::product_service::SetInventory::new(self.inner.clone())
-            .set_inventory(inventory.into())
     }
 
     /// We recommend that you use the
@@ -1718,12 +1533,8 @@ impl ProductService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn add_fulfillment_places(
-        &self,
-        product: impl Into<std::string::String>,
-    ) -> super::builder::product_service::AddFulfillmentPlaces {
+    pub fn add_fulfillment_places(&self) -> super::builder::product_service::AddFulfillmentPlaces {
         super::builder::product_service::AddFulfillmentPlaces::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// We recommend that you use the
@@ -1777,10 +1588,8 @@ impl ProductService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn remove_fulfillment_places(
         &self,
-        product: impl Into<std::string::String>,
     ) -> super::builder::product_service::RemoveFulfillmentPlaces {
         super::builder::product_service::RemoveFulfillmentPlaces::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// Updates local inventory information for a
@@ -1829,12 +1638,8 @@ impl ProductService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn add_local_inventories(
-        &self,
-        product: impl Into<std::string::String>,
-    ) -> super::builder::product_service::AddLocalInventories {
+    pub fn add_local_inventories(&self) -> super::builder::product_service::AddLocalInventories {
         super::builder::product_service::AddLocalInventories::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// Remove local inventory information for a
@@ -1883,31 +1688,22 @@ impl ProductService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn remove_local_inventories(
         &self,
-        product: impl Into<std::string::String>,
     ) -> super::builder::product_service::RemoveLocalInventories {
         super::builder::product_service::RemoveLocalInventories::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::product_service::ListOperations {
         super::builder::product_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_service::GetOperation {
-        super::builder::product_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::product_service::GetOperation {
+        super::builder::product_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -2018,33 +1814,22 @@ impl SearchService {
     ///
     /// This feature is only available for users who have Retail Search enabled.
     /// Enable Retail Search on Cloud Console before using this feature.
-    pub fn search(
-        &self,
-        placement: impl Into<std::string::String>,
-    ) -> super::builder::search_service::Search {
+    pub fn search(&self) -> super::builder::search_service::Search {
         super::builder::search_service::Search::new(self.inner.clone())
-            .set_placement(placement.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::search_service::ListOperations {
         super::builder::search_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::search_service::GetOperation {
-        super::builder::search_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::search_service::GetOperation {
+        super::builder::search_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -2160,10 +1945,8 @@ impl ServingConfigService {
     /// [google.cloud.retail.v2.ServingConfig]: crate::model::ServingConfig
     pub fn create_serving_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::serving_config_service::CreateServingConfig {
         super::builder::serving_config_service::CreateServingConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a ServingConfig.
@@ -2171,39 +1954,29 @@ impl ServingConfigService {
     /// Returns a NotFound error if the ServingConfig does not exist.
     pub fn delete_serving_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::serving_config_service::DeleteServingConfig {
         super::builder::serving_config_service::DeleteServingConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a ServingConfig.
     pub fn update_serving_config(
         &self,
-        serving_config: impl Into<crate::model::ServingConfig>,
     ) -> super::builder::serving_config_service::UpdateServingConfig {
         super::builder::serving_config_service::UpdateServingConfig::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Gets a ServingConfig.
     ///
     /// Returns a NotFound error if the ServingConfig does not exist.
-    pub fn get_serving_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::GetServingConfig {
+    pub fn get_serving_config(&self) -> super::builder::serving_config_service::GetServingConfig {
         super::builder::serving_config_service::GetServingConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all ServingConfigs linked to this catalog.
     pub fn list_serving_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::serving_config_service::ListServingConfigs {
         super::builder::serving_config_service::ListServingConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Enables a Control on the specified ServingConfig.
@@ -2213,46 +1986,30 @@ impl ServingConfigService {
     /// Returns a ALREADY_EXISTS error if the control has already been applied.
     /// Returns a FAILED_PRECONDITION error if the addition could exceed maximum
     /// number of control allowed for that type of control.
-    pub fn add_control(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::AddControl {
+    pub fn add_control(&self) -> super::builder::serving_config_service::AddControl {
         super::builder::serving_config_service::AddControl::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Disables a Control on the specified ServingConfig.
     /// The control is removed from the ServingConfig.
     /// Returns a NOT_FOUND error if the Control is not enabled for the
     /// ServingConfig.
-    pub fn remove_control(
-        &self,
-        serving_config: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::RemoveControl {
+    pub fn remove_control(&self) -> super::builder::serving_config_service::RemoveControl {
         super::builder::serving_config_service::RemoveControl::new(self.inner.clone())
-            .set_serving_config(serving_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::serving_config_service::ListOperations {
         super::builder::serving_config_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::serving_config_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::serving_config_service::GetOperation {
         super::builder::serving_config_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -2359,12 +2116,8 @@ impl UserEventService {
     }
 
     /// Writes a single user event.
-    pub fn write_user_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::WriteUserEvent {
+    pub fn write_user_event(&self) -> super::builder::user_event_service::WriteUserEvent {
         super::builder::user_event_service::WriteUserEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Writes a single user event from the browser.
@@ -2374,12 +2127,8 @@ impl UserEventService {
     ///
     /// This method is used only by the Retail API JavaScript pixel and Google Tag
     /// Manager. Users should not call this method directly.
-    pub fn collect_user_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::CollectUserEvent {
+    pub fn collect_user_event(&self) -> super::builder::user_event_service::CollectUserEvent {
         super::builder::user_event_service::CollectUserEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes permanently all user events specified by the filter provided.
@@ -2396,12 +2145,8 @@ impl UserEventService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_user_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::PurgeUserEvents {
+    pub fn purge_user_events(&self) -> super::builder::user_event_service::PurgeUserEvents {
         super::builder::user_event_service::PurgeUserEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Bulk import of User events. Request processing might be
@@ -2421,12 +2166,8 @@ impl UserEventService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_user_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::ImportUserEvents {
+    pub fn import_user_events(&self) -> super::builder::user_event_service::ImportUserEvents {
         super::builder::user_event_service::ImportUserEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Starts a user-event rejoin operation with latest product catalog. Events
@@ -2447,33 +2188,21 @@ impl UserEventService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn rejoin_user_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::RejoinUserEvents {
+    pub fn rejoin_user_events(&self) -> super::builder::user_event_service::RejoinUserEvents {
         super::builder::user_event_service::RejoinUserEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::user_event_service::ListOperations {
         super::builder::user_event_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::user_event_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::user_event_service::GetOperation {
         super::builder::user_event_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AnalyticsService for AnalyticsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:exportAnalyticsMetrics", {
+            let arg = &req.catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:exportAnalyticsMetrics", req.catalog),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::AnalyticsService for AnalyticsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +99,16 @@ impl super::stub::AnalyticsService for AnalyticsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -144,9 +162,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCatalogsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/catalogs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/catalogs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -165,18 +190,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Catalog>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.catalog
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("catalog"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.catalog
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("catalog"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,12 +221,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setDefaultBranch", {
+            let arg = &req.catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setDefaultBranch", req.catalog),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -224,12 +250,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetDefaultBranchResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getDefaultBranch", {
+            let arg = &req.catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getDefaultBranch", req.catalog),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,9 +276,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompletionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -265,18 +302,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompletionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.completion_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("completion_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.completion_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("completion_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -299,9 +333,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,18 +359,15 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.attributes_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("attributes_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.attributes_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("attributes_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,12 +390,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:addCatalogAttribute", {
+            let arg = &req.attributes_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attributes_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:addCatalogAttribute", req.attributes_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -372,12 +414,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:removeCatalogAttribute", {
+            let arg = &req.attributes_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attributes_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:removeCatalogAttribute", req.attributes_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -392,12 +438,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:replaceCatalogAttribute", {
+            let arg = &req.attributes_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attributes_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:replaceCatalogAttribute", req.attributes_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,9 +462,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -434,9 +491,16 @@ impl super::stub::CatalogService for CatalogService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,12 +540,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompleteQueryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:completeQuery", {
+            let arg = &req.catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:completeQuery", req.catalog),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -512,12 +580,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/completionData:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/completionData:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -532,9 +604,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -554,9 +633,16 @@ impl super::stub::CompletionService for CompletionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -610,12 +696,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/controls", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/controls", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -633,9 +723,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,18 +753,15 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.control
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("control"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.control
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("control"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -690,9 +784,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -709,9 +810,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListControlsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/controls", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/controls", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -731,9 +839,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -753,9 +868,16 @@ impl super::stub::ControlService for ControlService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,20 +917,17 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerativeQuestionsFeatureConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/generativeQuestionFeature", {
+            &req.generative_questions_feature_config
+                .as_ref()
+                .ok_or_else(|| {
+                    gaxi::path_parameter::missing("generative_questions_feature_config")
+                })?
+                .catalog
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}/generativeQuestionFeature",
-                    req.generative_questions_feature_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing(
-                            "generative_questions_feature_config"
-                        ))?
-                        .catalog
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -835,12 +954,16 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerativeQuestionsFeatureConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/generativeQuestionFeature", {
+            let arg = &req.catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/generativeQuestionFeature", req.catalog),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -857,12 +980,16 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGenerativeQuestionConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/generativeQuestions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/generativeQuestions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -879,18 +1006,15 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerativeQuestionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/generativeQuestion", {
+            &req.generative_question_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("generative_question_config"))?
+                .catalog
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}/generativeQuestion",
-                    req.generative_question_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("generative_question_config"))?
-                        .catalog
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -914,12 +1038,16 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
     ) -> Result<gax::response::Response<crate::model::BatchUpdateGenerativeQuestionConfigsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/generativeQuestion:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/generativeQuestion:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -934,9 +1062,16 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -956,9 +1091,16 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -998,9 +1140,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/models", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1016,9 +1165,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1035,9 +1191,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1052,9 +1215,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1069,9 +1239,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1092,9 +1269,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/models", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1113,18 +1297,15 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.model
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("model"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.model
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1145,9 +1326,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:tune", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:tune", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1162,9 +1350,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1184,9 +1379,16 @@ impl super::stub::ModelService for ModelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1240,12 +1442,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PredictResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:predict", {
+            let arg = &req.placement;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("placement"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:predict", req.placement),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1260,9 +1466,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1282,9 +1495,16 @@ impl super::stub::PredictionService for PredictionService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1324,12 +1544,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/products", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/products", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1347,9 +1571,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1366,9 +1597,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProductsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/products", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/products", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1394,18 +1632,15 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.product
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("product"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.product
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("product"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1429,9 +1664,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1452,12 +1694,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/products:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/products:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1472,12 +1718,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/products:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/products:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1492,18 +1742,15 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setInventory", {
+            &req.inventory
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("inventory"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v2/{}:setInventory",
-                    req.inventory
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("inventory"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1518,12 +1765,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:addFulfillmentPlaces", {
+            let arg = &req.product;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:addFulfillmentPlaces", req.product),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1538,12 +1789,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:removeFulfillmentPlaces", {
+            let arg = &req.product;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:removeFulfillmentPlaces", req.product),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1558,12 +1813,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:addLocalInventories", {
+            let arg = &req.product;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:addLocalInventories", req.product),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1578,12 +1837,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:removeLocalInventories", {
+            let arg = &req.product;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:removeLocalInventories", req.product),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1598,9 +1861,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1620,9 +1890,16 @@ impl super::stub::ProductService for ProductService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1676,12 +1953,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:search", {
+            let arg = &req.placement;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("placement"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:search", req.placement),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1696,9 +1977,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1718,9 +2006,16 @@ impl super::stub::SearchService for SearchService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1760,12 +2055,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/servingConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/servingConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1783,9 +2082,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1806,18 +2112,15 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.serving_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.serving_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1840,9 +2143,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1859,12 +2169,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServingConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/servingConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/servingConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1883,12 +2197,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:addControl", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:addControl", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1903,12 +2221,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:removeControl", {
+            let arg = &req.serving_config;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:removeControl", req.serving_config),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1923,9 +2245,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1945,9 +2274,16 @@ impl super::stub::ServingConfigService for ServingConfigService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1987,12 +2323,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/userEvents:write", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/userEvents:write", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2010,12 +2350,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::HttpBody>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/userEvents:collect", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/userEvents:collect", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2040,12 +2384,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/userEvents:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/userEvents:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2060,12 +2408,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/userEvents:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/userEvents:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2080,12 +2432,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/userEvents:rejoin", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/userEvents:rejoin", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2100,9 +2456,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2122,9 +2485,16 @@ impl super::stub::UserEventService for UserEventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -191,10 +191,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<crate::model::Catalog>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.catalog
+            let arg = &req
+                .catalog
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("catalog"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("catalog.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -303,10 +308,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<crate::model::CompletionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.completion_config
+            let arg = &req
+                .completion_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("completion_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("completion_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -360,10 +370,15 @@ impl super::stub::CatalogService for CatalogService {
     ) -> Result<gax::response::Response<crate::model::AttributesConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.attributes_config
+            let arg = &req
+                .attributes_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("attributes_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("attributes_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -754,10 +769,15 @@ impl super::stub::ControlService for ControlService {
     ) -> Result<gax::response::Response<crate::model::Control>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.control
+            let arg = &req
+                .control
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("control"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("control.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -918,12 +938,19 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
     ) -> Result<gax::response::Response<crate::model::GenerativeQuestionsFeatureConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}/generativeQuestionFeature", {
-            &req.generative_questions_feature_config
+            let arg = &req
+                .generative_questions_feature_config
                 .as_ref()
                 .ok_or_else(|| {
                     gaxi::path_parameter::missing("generative_questions_feature_config")
                 })?
-                .catalog
+                .catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "generative_questions_feature_config.catalog",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1007,10 +1034,17 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
     ) -> Result<gax::response::Response<crate::model::GenerativeQuestionConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}/generativeQuestion", {
-            &req.generative_question_config
+            let arg = &req
+                .generative_question_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("generative_question_config"))?
-                .catalog
+                .catalog;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "generative_question_config.catalog",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1298,10 +1332,15 @@ impl super::stub::ModelService for ModelService {
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.model
+            let arg = &req
+                .model
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("model"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("model.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1633,10 +1672,15 @@ impl super::stub::ProductService for ProductService {
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.product
+            let arg = &req
+                .product
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("product"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1743,10 +1787,15 @@ impl super::stub::ProductService for ProductService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}:setInventory", {
-            &req.inventory
+            let arg = &req
+                .inventory
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("inventory"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("inventory.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -2113,10 +2162,15 @@ impl super::stub::ServingConfigService for ServingConfigService {
     ) -> Result<gax::response::Response<crate::model::ServingConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.serving_config
+            let arg = &req
+                .serving_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("serving_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("serving_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/run/v2/src/client.rs
+++ b/src/generated/cloud/run/v2/src/client.rs
@@ -119,51 +119,36 @@ impl Builds {
     }
 
     /// Submits a build in a given project.
-    pub fn submit_build(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::builds::SubmitBuild {
-        super::builder::builds::SubmitBuild::new(self.inner.clone()).set_parent(parent.into())
+    pub fn submit_build(&self) -> super::builder::builds::SubmitBuild {
+        super::builder::builds::SubmitBuild::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::builds::ListOperations {
-        super::builder::builds::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::builds::ListOperations {
+        super::builder::builds::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::builds::GetOperation {
-        super::builder::builds::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::builds::GetOperation {
+        super::builder::builds::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::builds::DeleteOperation {
-        super::builder::builds::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::builds::DeleteOperation {
+        super::builder::builds::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::builds::WaitOperation {
-        super::builder::builds::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::builds::WaitOperation {
+        super::builder::builds::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -268,21 +253,14 @@ impl Executions {
     }
 
     /// Gets information about an Execution.
-    pub fn get_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::GetExecution {
-        super::builder::executions::GetExecution::new(self.inner.clone()).set_name(name.into())
+    pub fn get_execution(&self) -> super::builder::executions::GetExecution {
+        super::builder::executions::GetExecution::new(self.inner.clone())
     }
 
     /// Lists Executions from a Job. Results are sorted by creation time,
     /// descending.
-    pub fn list_executions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::executions::ListExecutions {
+    pub fn list_executions(&self) -> super::builder::executions::ListExecutions {
         super::builder::executions::ListExecutions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an Execution.
@@ -296,11 +274,8 @@ impl Executions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::DeleteExecution {
-        super::builder::executions::DeleteExecution::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_execution(&self) -> super::builder::executions::DeleteExecution {
+        super::builder::executions::DeleteExecution::new(self.inner.clone())
     }
 
     /// Cancels an Execution.
@@ -314,51 +289,36 @@ impl Executions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn cancel_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::CancelExecution {
-        super::builder::executions::CancelExecution::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_execution(&self) -> super::builder::executions::CancelExecution {
+        super::builder::executions::CancelExecution::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::ListOperations {
-        super::builder::executions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::executions::ListOperations {
+        super::builder::executions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::GetOperation {
-        super::builder::executions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::executions::GetOperation {
+        super::builder::executions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::DeleteOperation {
-        super::builder::executions::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::executions::DeleteOperation {
+        super::builder::executions::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::WaitOperation {
-        super::builder::executions::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::executions::WaitOperation {
+        super::builder::executions::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -471,24 +431,18 @@ impl Jobs {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::jobs::CreateJob {
-        super::builder::jobs::CreateJob::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_job(&self) -> super::builder::jobs::CreateJob {
+        super::builder::jobs::CreateJob::new(self.inner.clone())
     }
 
     /// Gets information about a Job.
-    pub fn get_job(&self, name: impl Into<std::string::String>) -> super::builder::jobs::GetJob {
-        super::builder::jobs::GetJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job(&self) -> super::builder::jobs::GetJob {
+        super::builder::jobs::GetJob::new(self.inner.clone())
     }
 
     /// Lists Jobs. Results are sorted by creation time, descending.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::jobs::ListJobs {
-        super::builder::jobs::ListJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_jobs(&self) -> super::builder::jobs::ListJobs {
+        super::builder::jobs::ListJobs::new(self.inner.clone())
     }
 
     /// Updates a Job.
@@ -502,8 +456,8 @@ impl Jobs {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_job(&self, job: impl Into<crate::model::Job>) -> super::builder::jobs::UpdateJob {
-        super::builder::jobs::UpdateJob::new(self.inner.clone()).set_job(job.into())
+    pub fn update_job(&self) -> super::builder::jobs::UpdateJob {
+        super::builder::jobs::UpdateJob::new(self.inner.clone())
     }
 
     /// Deletes a Job.
@@ -517,11 +471,8 @@ impl Jobs {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::jobs::DeleteJob {
-        super::builder::jobs::DeleteJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_job(&self) -> super::builder::jobs::DeleteJob {
+        super::builder::jobs::DeleteJob::new(self.inner.clone())
     }
 
     /// Triggers creation of a new Execution of this Job.
@@ -535,77 +486,55 @@ impl Jobs {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_job(&self, name: impl Into<std::string::String>) -> super::builder::jobs::RunJob {
-        super::builder::jobs::RunJob::new(self.inner.clone()).set_name(name.into())
+    pub fn run_job(&self) -> super::builder::jobs::RunJob {
+        super::builder::jobs::RunJob::new(self.inner.clone())
     }
 
     /// Gets the IAM Access Control policy currently in effect for the given Job.
     /// This result does not include any inherited policies.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::jobs::GetIamPolicy {
-        super::builder::jobs::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::jobs::GetIamPolicy {
+        super::builder::jobs::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM Access control policy for the specified Job. Overwrites
     /// any existing policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::jobs::SetIamPolicy {
-        super::builder::jobs::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::jobs::SetIamPolicy {
+        super::builder::jobs::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified Project.
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::jobs::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::jobs::TestIamPermissions {
         super::builder::jobs::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::jobs::ListOperations {
-        super::builder::jobs::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::jobs::ListOperations {
+        super::builder::jobs::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::jobs::GetOperation {
-        super::builder::jobs::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::jobs::GetOperation {
+        super::builder::jobs::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::jobs::DeleteOperation {
-        super::builder::jobs::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::jobs::DeleteOperation {
+        super::builder::jobs::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::jobs::WaitOperation {
-        super::builder::jobs::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::jobs::WaitOperation {
+        super::builder::jobs::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -710,20 +639,14 @@ impl Revisions {
     }
 
     /// Gets information about a Revision.
-    pub fn get_revision(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::GetRevision {
-        super::builder::revisions::GetRevision::new(self.inner.clone()).set_name(name.into())
+    pub fn get_revision(&self) -> super::builder::revisions::GetRevision {
+        super::builder::revisions::GetRevision::new(self.inner.clone())
     }
 
     /// Lists Revisions from a given Service, or from a given location.  Results
     /// are sorted by creation time, descending.
-    pub fn list_revisions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::revisions::ListRevisions {
-        super::builder::revisions::ListRevisions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_revisions(&self) -> super::builder::revisions::ListRevisions {
+        super::builder::revisions::ListRevisions::new(self.inner.clone())
     }
 
     /// Deletes a Revision.
@@ -737,51 +660,36 @@ impl Revisions {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_revision(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::DeleteRevision {
-        super::builder::revisions::DeleteRevision::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_revision(&self) -> super::builder::revisions::DeleteRevision {
+        super::builder::revisions::DeleteRevision::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::ListOperations {
-        super::builder::revisions::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::revisions::ListOperations {
+        super::builder::revisions::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::GetOperation {
-        super::builder::revisions::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::revisions::GetOperation {
+        super::builder::revisions::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::DeleteOperation {
-        super::builder::revisions::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::revisions::DeleteOperation {
+        super::builder::revisions::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::revisions::WaitOperation {
-        super::builder::revisions::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::revisions::WaitOperation {
+        super::builder::revisions::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -896,27 +804,18 @@ impl Services {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::services::CreateService {
-        super::builder::services::CreateService::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_service(&self) -> super::builder::services::CreateService {
+        super::builder::services::CreateService::new(self.inner.clone())
     }
 
     /// Gets information about a Service.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::GetService {
-        super::builder::services::GetService::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service(&self) -> super::builder::services::GetService {
+        super::builder::services::GetService::new(self.inner.clone())
     }
 
     /// Lists Services. Results are sorted by creation time, descending.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::services::ListServices {
-        super::builder::services::ListServices::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_services(&self) -> super::builder::services::ListServices {
+        super::builder::services::ListServices::new(self.inner.clone())
     }
 
     /// Updates a Service.
@@ -930,11 +829,8 @@ impl Services {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_service(
-        &self,
-        service: impl Into<crate::model::Service>,
-    ) -> super::builder::services::UpdateService {
-        super::builder::services::UpdateService::new(self.inner.clone()).set_service(service.into())
+    pub fn update_service(&self) -> super::builder::services::UpdateService {
+        super::builder::services::UpdateService::new(self.inner.clone())
     }
 
     /// Deletes a Service.
@@ -950,82 +846,55 @@ impl Services {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::DeleteService {
-        super::builder::services::DeleteService::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_service(&self) -> super::builder::services::DeleteService {
+        super::builder::services::DeleteService::new(self.inner.clone())
     }
 
     /// Gets the IAM Access Control policy currently in effect for the given
     /// Cloud Run Service. This result does not include any inherited policies.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::services::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::services::GetIamPolicy {
         super::builder::services::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM Access control policy for the specified Service. Overwrites
     /// any existing policy.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::services::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::services::SetIamPolicy {
         super::builder::services::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified Project.
     ///
     /// There are no permissions required for making this API call.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::services::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::services::TestIamPermissions {
         super::builder::services::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::ListOperations {
-        super::builder::services::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::services::ListOperations {
+        super::builder::services::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::GetOperation {
-        super::builder::services::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::services::GetOperation {
+        super::builder::services::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::DeleteOperation {
-        super::builder::services::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::services::DeleteOperation {
+        super::builder::services::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::services::WaitOperation {
-        super::builder::services::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::services::WaitOperation {
+        super::builder::services::WaitOperation::new(self.inner.clone())
     }
 }
 
@@ -1128,55 +997,40 @@ impl Tasks {
     }
 
     /// Gets information about a Task.
-    pub fn get_task(&self, name: impl Into<std::string::String>) -> super::builder::tasks::GetTask {
-        super::builder::tasks::GetTask::new(self.inner.clone()).set_name(name.into())
+    pub fn get_task(&self) -> super::builder::tasks::GetTask {
+        super::builder::tasks::GetTask::new(self.inner.clone())
     }
 
     /// Lists Tasks from an Execution of a Job.
-    pub fn list_tasks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tasks::ListTasks {
-        super::builder::tasks::ListTasks::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_tasks(&self) -> super::builder::tasks::ListTasks {
+        super::builder::tasks::ListTasks::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tasks::ListOperations {
-        super::builder::tasks::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::tasks::ListOperations {
+        super::builder::tasks::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tasks::GetOperation {
-        super::builder::tasks::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tasks::GetOperation {
+        super::builder::tasks::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tasks::DeleteOperation {
-        super::builder::tasks::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::tasks::DeleteOperation {
+        super::builder::tasks::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tasks::WaitOperation {
-        super::builder::tasks::WaitOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn wait_operation(&self) -> super::builder::tasks::WaitOperation {
+        super::builder::tasks::WaitOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -535,10 +535,15 @@ impl super::stub::Jobs for Jobs {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.job
+            let arg = &req
+                .job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1154,10 +1159,15 @@ impl super::stub::Services for Services {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.service
+            let arg = &req
+                .service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Builds for Builds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SubmitBuildResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/builds:submit", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/builds:submit", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +70,16 @@ impl super::stub::Builds for Builds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +99,16 @@ impl super::stub::Builds for Builds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,9 +125,16 @@ impl super::stub::Builds for Builds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -130,9 +155,16 @@ impl super::stub::Builds for Builds {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +202,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,12 +228,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExecutionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/executions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/executions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -214,9 +257,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,9 +285,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,9 +309,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,9 +338,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -293,9 +364,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +394,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -368,9 +453,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/jobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -387,9 +479,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -406,9 +505,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -428,18 +534,15 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -456,9 +559,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,9 +587,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -494,12 +611,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -526,12 +647,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,12 +671,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -566,9 +695,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -588,9 +724,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -607,9 +750,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,9 +780,16 @@ impl super::stub::Jobs for Jobs {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -684,9 +841,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Revision>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -703,12 +867,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/revisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/revisions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -728,9 +896,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -749,9 +924,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -771,9 +953,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -790,9 +979,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -813,9 +1009,16 @@ impl super::stub::Revisions for Revisions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -867,12 +1070,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/services", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -891,9 +1098,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -910,9 +1124,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -932,18 +1153,15 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -968,9 +1186,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -989,12 +1214,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1021,12 +1250,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1041,12 +1274,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1061,9 +1298,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1083,9 +1327,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1102,9 +1353,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1125,9 +1383,16 @@ impl super::stub::Services for Services {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1177,9 +1442,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Task>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1196,9 +1468,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTasksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/tasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/tasks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1218,9 +1497,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1240,9 +1526,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1259,9 +1552,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1282,9 +1582,16 @@ impl super::stub::Tasks for Tasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/scheduler/v1/src/client.rs
+++ b/src/generated/cloud/scheduler/v1/src/client.rs
@@ -120,28 +120,18 @@ impl CloudScheduler {
     }
 
     /// Lists jobs.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::ListJobs {
-        super::builder::cloud_scheduler::ListJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_jobs(&self) -> super::builder::cloud_scheduler::ListJobs {
+        super::builder::cloud_scheduler::ListJobs::new(self.inner.clone())
     }
 
     /// Gets a job.
-    pub fn get_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::GetJob {
-        super::builder::cloud_scheduler::GetJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job(&self) -> super::builder::cloud_scheduler::GetJob {
+        super::builder::cloud_scheduler::GetJob::new(self.inner.clone())
     }
 
     /// Creates a job.
-    pub fn create_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::CreateJob {
+    pub fn create_job(&self) -> super::builder::cloud_scheduler::CreateJob {
         super::builder::cloud_scheduler::CreateJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a job.
@@ -157,19 +147,13 @@ impl CloudScheduler {
     ///
     /// [google.cloud.scheduler.v1.Job]: crate::model::Job
     /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: crate::model::job::State::UpdateFailed
-    pub fn update_job(
-        &self,
-        job: impl Into<crate::model::Job>,
-    ) -> super::builder::cloud_scheduler::UpdateJob {
-        super::builder::cloud_scheduler::UpdateJob::new(self.inner.clone()).set_job(job.into())
+    pub fn update_job(&self) -> super::builder::cloud_scheduler::UpdateJob {
+        super::builder::cloud_scheduler::UpdateJob::new(self.inner.clone())
     }
 
     /// Deletes a job.
-    pub fn delete_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::DeleteJob {
-        super::builder::cloud_scheduler::DeleteJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_job(&self) -> super::builder::cloud_scheduler::DeleteJob {
+        super::builder::cloud_scheduler::DeleteJob::new(self.inner.clone())
     }
 
     /// Pauses a job.
@@ -187,11 +171,8 @@ impl CloudScheduler {
     /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
     /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
-    pub fn pause_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::PauseJob {
-        super::builder::cloud_scheduler::PauseJob::new(self.inner.clone()).set_name(name.into())
+    pub fn pause_job(&self) -> super::builder::cloud_scheduler::PauseJob {
+        super::builder::cloud_scheduler::PauseJob::new(self.inner.clone())
     }
 
     /// Resume a job.
@@ -207,38 +188,25 @@ impl CloudScheduler {
     /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
     /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
-    pub fn resume_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::ResumeJob {
-        super::builder::cloud_scheduler::ResumeJob::new(self.inner.clone()).set_name(name.into())
+    pub fn resume_job(&self) -> super::builder::cloud_scheduler::ResumeJob {
+        super::builder::cloud_scheduler::ResumeJob::new(self.inner.clone())
     }
 
     /// Forces a job to run now.
     ///
     /// When this method is called, Cloud Scheduler will dispatch the job, even
     /// if the job is already running.
-    pub fn run_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::RunJob {
-        super::builder::cloud_scheduler::RunJob::new(self.inner.clone()).set_name(name.into())
+    pub fn run_job(&self) -> super::builder::cloud_scheduler::RunJob {
+        super::builder::cloud_scheduler::RunJob::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::ListLocations {
+    pub fn list_locations(&self) -> super::builder::cloud_scheduler::ListLocations {
         super::builder::cloud_scheduler::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_scheduler::GetLocation {
-        super::builder::cloud_scheduler::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cloud_scheduler::GetLocation {
+        super::builder::cloud_scheduler::GetLocation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -125,10 +125,15 @@ impl super::stub::CloudScheduler for CloudScheduler {
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.job
+            let arg = &req
+                .job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,9 +74,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +100,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,18 +124,15 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +153,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +183,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +207,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,9 +231,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -209,9 +255,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,9 +284,16 @@ impl super::stub::CloudScheduler for CloudScheduler {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -132,12 +132,8 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn list_secrets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::ListSecrets {
+    pub fn list_secrets(&self) -> super::builder::secret_manager_service::ListSecrets {
         super::builder::secret_manager_service::ListSecrets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -145,12 +141,8 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn create_secret(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::CreateSecret {
+    pub fn create_secret(&self) -> super::builder::secret_manager_service::CreateSecret {
         super::builder::secret_manager_service::CreateSecret::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -159,46 +151,30 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn add_secret_version(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::AddSecretVersion {
+    pub fn add_secret_version(&self) -> super::builder::secret_manager_service::AddSecretVersion {
         super::builder::secret_manager_service::AddSecretVersion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn get_secret(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetSecret {
+    pub fn get_secret(&self) -> super::builder::secret_manager_service::GetSecret {
         super::builder::secret_manager_service::GetSecret::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates metadata of an existing
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn update_secret(
-        &self,
-        secret: impl Into<crate::model::Secret>,
-    ) -> super::builder::secret_manager_service::UpdateSecret {
+    pub fn update_secret(&self) -> super::builder::secret_manager_service::UpdateSecret {
         super::builder::secret_manager_service::UpdateSecret::new(self.inner.clone())
-            .set_secret(secret.into())
     }
 
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
-    pub fn delete_secret(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::DeleteSecret {
+    pub fn delete_secret(&self) -> super::builder::secret_manager_service::DeleteSecret {
         super::builder::secret_manager_service::DeleteSecret::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -207,10 +183,8 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     pub fn list_secret_versions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::ListSecretVersions {
         super::builder::secret_manager_service::ListSecretVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata for a
@@ -220,12 +194,8 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn get_secret_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetSecretVersion {
+    pub fn get_secret_version(&self) -> super::builder::secret_manager_service::GetSecretVersion {
         super::builder::secret_manager_service::GetSecretVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -237,10 +207,8 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     pub fn access_secret_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::AccessSecretVersion {
         super::builder::secret_manager_service::AccessSecretVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -254,10 +222,8 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn disable_secret_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::DisableSecretVersion {
         super::builder::secret_manager_service::DisableSecretVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -271,10 +237,8 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn enable_secret_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::EnableSecretVersion {
         super::builder::secret_manager_service::EnableSecretVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -289,10 +253,8 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn destroy_secret_version(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::DestroySecretVersion {
         super::builder::secret_manager_service::DestroySecretVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -305,22 +267,14 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::secret_manager_service::SetIamPolicy {
         super::builder::secret_manager_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::secret_manager_service::GetIamPolicy {
         super::builder::secret_manager_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -332,27 +286,17 @@ impl SecretManagerService {
     /// may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::TestIamPermissions {
         super::builder::secret_manager_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::secret_manager_service::ListLocations {
         super::builder::secret_manager_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::secret_manager_service::GetLocation {
         super::builder::secret_manager_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/secrets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/secrets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +75,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/secrets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/secrets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +100,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addVersion", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addVersion", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,9 +124,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -125,18 +150,15 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.secret
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("secret"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.secret
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("secret"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -157,9 +179,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -181,9 +210,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -203,9 +239,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,9 +265,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessSecretVersionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:access", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:access", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,9 +291,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -258,9 +315,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +339,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:destroy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:destroy", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,12 +363,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,12 +387,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -344,12 +423,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -364,9 +447,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -386,9 +476,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -151,10 +151,15 @@ impl super::stub::SecretManagerService for SecretManagerService {
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.secret
+            let arg = &req
+                .secret
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("secret"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("secret.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/securesourcemanager/v1/src/client.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/client.rs
@@ -140,21 +140,13 @@ impl SecureSourceManager {
     }
 
     /// Lists Instances in a given project and location.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::ListInstances {
+    pub fn list_instances(&self) -> super::builder::secure_source_manager::ListInstances {
         super::builder::secure_source_manager::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetInstance {
+    pub fn get_instance(&self) -> super::builder::secure_source_manager::GetInstance {
         super::builder::secure_source_manager::GetInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new instance in a given project and location.
@@ -168,12 +160,8 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::secure_source_manager::CreateInstance {
         super::builder::secure_source_manager::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single instance.
@@ -187,34 +175,22 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::secure_source_manager::DeleteInstance {
         super::builder::secure_source_manager::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Repositories in a given project and location.
     ///
     /// **Host: Data Plane**
-    pub fn list_repositories(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::ListRepositories {
+    pub fn list_repositories(&self) -> super::builder::secure_source_manager::ListRepositories {
         super::builder::secure_source_manager::ListRepositories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata of a repository.
     ///
     /// **Host: Data Plane**
-    pub fn get_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetRepository {
+    pub fn get_repository(&self) -> super::builder::secure_source_manager::GetRepository {
         super::builder::secure_source_manager::GetRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new repository in a given project and location.
@@ -230,12 +206,8 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_repository(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::CreateRepository {
+    pub fn create_repository(&self) -> super::builder::secure_source_manager::CreateRepository {
         super::builder::secure_source_manager::CreateRepository::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Repository.
@@ -251,40 +223,26 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::DeleteRepository {
+    pub fn delete_repository(&self) -> super::builder::secure_source_manager::DeleteRepository {
         super::builder::secure_source_manager::DeleteRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get IAM policy for a repository.
-    pub fn get_iam_policy_repo(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetIamPolicyRepo {
+    pub fn get_iam_policy_repo(&self) -> super::builder::secure_source_manager::GetIamPolicyRepo {
         super::builder::secure_source_manager::GetIamPolicyRepo::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Set IAM policy on a repository.
-    pub fn set_iam_policy_repo(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::SetIamPolicyRepo {
+    pub fn set_iam_policy_repo(&self) -> super::builder::secure_source_manager::SetIamPolicyRepo {
         super::builder::secure_source_manager::SetIamPolicyRepo::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Test IAM permissions on a repository.
     /// IAM permission checks are not required on this method.
     pub fn test_iam_permissions_repo(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::secure_source_manager::TestIamPermissionsRepo {
         super::builder::secure_source_manager::TestIamPermissionsRepo::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// CreateBranchRule creates a branch rule in a given repository.
@@ -298,30 +256,18 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_branch_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::CreateBranchRule {
+    pub fn create_branch_rule(&self) -> super::builder::secure_source_manager::CreateBranchRule {
         super::builder::secure_source_manager::CreateBranchRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// ListBranchRules lists branch rules in a given repository.
-    pub fn list_branch_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::ListBranchRules {
+    pub fn list_branch_rules(&self) -> super::builder::secure_source_manager::ListBranchRules {
         super::builder::secure_source_manager::ListBranchRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// GetBranchRule gets a branch rule.
-    pub fn get_branch_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetBranchRule {
+    pub fn get_branch_rule(&self) -> super::builder::secure_source_manager::GetBranchRule {
         super::builder::secure_source_manager::GetBranchRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// UpdateBranchRule updates a branch rule.
@@ -335,12 +281,8 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_branch_rule(
-        &self,
-        branch_rule: impl Into<crate::model::BranchRule>,
-    ) -> super::builder::secure_source_manager::UpdateBranchRule {
+    pub fn update_branch_rule(&self) -> super::builder::secure_source_manager::UpdateBranchRule {
         super::builder::secure_source_manager::UpdateBranchRule::new(self.inner.clone())
-            .set_branch_rule(branch_rule.into())
     }
 
     /// DeleteBranchRule deletes a branch rule.
@@ -354,30 +296,18 @@ impl SecureSourceManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_branch_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::DeleteBranchRule {
+    pub fn delete_branch_rule(&self) -> super::builder::secure_source_manager::DeleteBranchRule {
         super::builder::secure_source_manager::DeleteBranchRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::ListLocations {
+    pub fn list_locations(&self) -> super::builder::secure_source_manager::ListLocations {
         super::builder::secure_source_manager::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetLocation {
+    pub fn get_location(&self) -> super::builder::secure_source_manager::GetLocation {
         super::builder::secure_source_manager::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -385,22 +315,14 @@ impl SecureSourceManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::secure_source_manager::SetIamPolicy {
         super::builder::secure_source_manager::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::secure_source_manager::GetIamPolicy {
         super::builder::secure_source_manager::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -412,53 +334,35 @@ impl SecureSourceManager {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::secure_source_manager::TestIamPermissions {
         super::builder::secure_source_manager::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::secure_source_manager::ListOperations {
         super::builder::secure_source_manager::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::secure_source_manager::GetOperation {
         super::builder::secure_source_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::secure_source_manager::DeleteOperation {
         super::builder::secure_source_manager::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::secure_source_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::secure_source_manager::CancelOperation {
         super::builder::secure_source_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -433,10 +433,15 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.branch_rule
+            let arg = &req
+                .branch_rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("branch_rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("branch_rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,9 +130,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,12 +157,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRepositoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,9 +187,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Repository>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,12 +213,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -203,9 +240,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -223,12 +267,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,12 +303,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,12 +327,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,12 +351,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/branchRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/branchRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -318,12 +378,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBranchRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/branchRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/branchRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -342,9 +406,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BranchRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,18 +432,15 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.branch_rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("branch_rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.branch_rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("branch_rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,9 +464,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,9 +491,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -438,9 +520,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -457,12 +546,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,12 +570,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -509,12 +606,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -529,9 +630,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -551,9 +659,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -570,9 +685,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -593,9 +715,16 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/security/privateca/v1/src/client.rs
+++ b/src/generated/cloud/security/privateca/v1/src/client.rs
@@ -132,21 +132,15 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     pub fn create_certificate(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::CreateCertificate {
         super::builder::certificate_authority_service::CreateCertificate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a [Certificate][google.cloud.security.privateca.v1.Certificate].
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub fn get_certificate(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::GetCertificate {
+    pub fn get_certificate(&self) -> super::builder::certificate_authority_service::GetCertificate {
         super::builder::certificate_authority_service::GetCertificate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists [Certificates][google.cloud.security.privateca.v1.Certificate].
@@ -154,10 +148,8 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     pub fn list_certificates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::ListCertificates {
         super::builder::certificate_authority_service::ListCertificates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Revoke a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -165,10 +157,8 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     pub fn revoke_certificate(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::RevokeCertificate {
         super::builder::certificate_authority_service::RevokeCertificate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Update a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -179,10 +169,8 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.Certificate.labels]: crate::model::Certificate::labels
     pub fn update_certificate(
         &self,
-        certificate: impl Into<crate::model::Certificate>,
     ) -> super::builder::certificate_authority_service::UpdateCertificate {
         super::builder::certificate_authority_service::UpdateCertificate::new(self.inner.clone())
-            .set_certificate(certificate.into())
     }
 
     /// Activate a
@@ -212,12 +200,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn activate_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::ActivateCertificateAuthority {
         super::builder::certificate_authority_service::ActivateCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Create a new
@@ -237,12 +223,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_certificate_authority(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::CreateCertificateAuthority {
         super::builder::certificate_authority_service::CreateCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Disable a
@@ -261,12 +245,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn disable_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::DisableCertificateAuthority {
         super::builder::certificate_authority_service::DisableCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Enable a
@@ -285,12 +267,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn enable_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::EnableCertificateAuthority {
         super::builder::certificate_authority_service::EnableCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Fetch a certificate signing request (CSR) from a
@@ -311,12 +291,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority]: crate::client::CertificateAuthorityService::activate_certificate_authority
     pub fn fetch_certificate_authority_csr(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::FetchCertificateAuthorityCsr {
         super::builder::certificate_authority_service::FetchCertificateAuthorityCsr::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Returns a
@@ -325,12 +303,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
     pub fn get_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::GetCertificateAuthority {
         super::builder::certificate_authority_service::GetCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists
@@ -339,12 +315,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
     pub fn list_certificate_authorities(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::ListCertificateAuthorities {
         super::builder::certificate_authority_service::ListCertificateAuthorities::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Undelete a
@@ -364,12 +338,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn undelete_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::UndeleteCertificateAuthority {
         super::builder::certificate_authority_service::UndeleteCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Delete a
@@ -388,12 +360,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_certificate_authority(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::DeleteCertificateAuthority {
         super::builder::certificate_authority_service::DeleteCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Update a
@@ -412,12 +382,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_certificate_authority(
         &self,
-        certificate_authority: impl Into<crate::model::CertificateAuthority>,
     ) -> super::builder::certificate_authority_service::UpdateCertificateAuthority {
         super::builder::certificate_authority_service::UpdateCertificateAuthority::new(
             self.inner.clone(),
         )
-        .set_certificate_authority(certificate_authority.into())
     }
 
     /// Create a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -433,12 +401,8 @@ impl CertificateAuthorityService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_ca_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::CreateCaPool {
+    pub fn create_ca_pool(&self) -> super::builder::certificate_authority_service::CreateCaPool {
         super::builder::certificate_authority_service::CreateCaPool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -454,34 +418,22 @@ impl CertificateAuthorityService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_ca_pool(
-        &self,
-        ca_pool: impl Into<crate::model::CaPool>,
-    ) -> super::builder::certificate_authority_service::UpdateCaPool {
+    pub fn update_ca_pool(&self) -> super::builder::certificate_authority_service::UpdateCaPool {
         super::builder::certificate_authority_service::UpdateCaPool::new(self.inner.clone())
-            .set_ca_pool(ca_pool.into())
     }
 
     /// Returns a [CaPool][google.cloud.security.privateca.v1.CaPool].
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-    pub fn get_ca_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::GetCaPool {
+    pub fn get_ca_pool(&self) -> super::builder::certificate_authority_service::GetCaPool {
         super::builder::certificate_authority_service::GetCaPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists [CaPools][google.cloud.security.privateca.v1.CaPool].
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-    pub fn list_ca_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::ListCaPools {
+    pub fn list_ca_pools(&self) -> super::builder::certificate_authority_service::ListCaPools {
         super::builder::certificate_authority_service::ListCaPools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -497,12 +449,8 @@ impl CertificateAuthorityService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_ca_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::DeleteCaPool {
+    pub fn delete_ca_pool(&self) -> super::builder::certificate_authority_service::DeleteCaPool {
         super::builder::certificate_authority_service::DeleteCaPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// FetchCaCerts returns the current trust anchor for the
@@ -511,12 +459,8 @@ impl CertificateAuthorityService {
     /// DISABLED, or STAGED states.
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-    pub fn fetch_ca_certs(
-        &self,
-        ca_pool: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::FetchCaCerts {
+    pub fn fetch_ca_certs(&self) -> super::builder::certificate_authority_service::FetchCaCerts {
         super::builder::certificate_authority_service::FetchCaCerts::new(self.inner.clone())
-            .set_ca_pool(ca_pool.into())
     }
 
     /// Returns a
@@ -525,12 +469,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
     pub fn get_certificate_revocation_list(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::GetCertificateRevocationList {
         super::builder::certificate_authority_service::GetCertificateRevocationList::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists
@@ -539,12 +481,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
     pub fn list_certificate_revocation_lists(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::ListCertificateRevocationLists {
         super::builder::certificate_authority_service::ListCertificateRevocationLists::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Update a
@@ -563,12 +503,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_certificate_revocation_list(
         &self,
-        certificate_revocation_list: impl Into<crate::model::CertificateRevocationList>,
     ) -> super::builder::certificate_authority_service::UpdateCertificateRevocationList {
         super::builder::certificate_authority_service::UpdateCertificateRevocationList::new(
             self.inner.clone(),
         )
-        .set_certificate_revocation_list(certificate_revocation_list.into())
     }
 
     /// Create a new
@@ -588,12 +526,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_certificate_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::CreateCertificateTemplate {
         super::builder::certificate_authority_service::CreateCertificateTemplate::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// DeleteCertificateTemplate deletes a
@@ -612,12 +548,10 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_certificate_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::DeleteCertificateTemplate {
         super::builder::certificate_authority_service::DeleteCertificateTemplate::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Returns a
@@ -626,12 +560,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateTemplate]: crate::model::CertificateTemplate
     pub fn get_certificate_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::GetCertificateTemplate {
         super::builder::certificate_authority_service::GetCertificateTemplate::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists
@@ -640,12 +572,10 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateTemplate]: crate::model::CertificateTemplate
     pub fn list_certificate_templates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::ListCertificateTemplates {
         super::builder::certificate_authority_service::ListCertificateTemplates::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Update a
@@ -664,30 +594,20 @@ impl CertificateAuthorityService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_certificate_template(
         &self,
-        certificate_template: impl Into<crate::model::CertificateTemplate>,
     ) -> super::builder::certificate_authority_service::UpdateCertificateTemplate {
         super::builder::certificate_authority_service::UpdateCertificateTemplate::new(
             self.inner.clone(),
         )
-        .set_certificate_template(certificate_template.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::certificate_authority_service::ListLocations {
         super::builder::certificate_authority_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::certificate_authority_service::GetLocation {
         super::builder::certificate_authority_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -695,22 +615,14 @@ impl CertificateAuthorityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::certificate_authority_service::SetIamPolicy {
         super::builder::certificate_authority_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::certificate_authority_service::GetIamPolicy {
         super::builder::certificate_authority_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -722,32 +634,22 @@ impl CertificateAuthorityService {
     /// checking. This operation may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::TestIamPermissions {
         super::builder::certificate_authority_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::certificate_authority_service::ListOperations {
         super::builder::certificate_authority_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::certificate_authority_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::certificate_authority_service::GetOperation {
         super::builder::certificate_authority_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -755,10 +657,8 @@ impl CertificateAuthorityService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn delete_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::DeleteOperation {
         super::builder::certificate_authority_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -766,9 +666,7 @@ impl CertificateAuthorityService {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn cancel_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::certificate_authority_service::CancelOperation {
         super::builder::certificate_authority_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -160,10 +160,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate
+            let arg = &req
+                .certificate
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -430,10 +435,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate_authority
+            let arg = &req
+                .certificate_authority
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate_authority"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate_authority.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -490,10 +500,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.ca_pool
+            let arg = &req
+                .ca_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("ca_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("ca_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -687,10 +702,17 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate_revocation_list
+            let arg = &req
+                .certificate_revocation_list
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate_revocation_list"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "certificate_revocation_list.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -830,10 +852,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.certificate_template
+            let arg = &req
+                .certificate_template
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("certificate_template"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("certificate_template.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -75,9 +79,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -94,12 +105,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -120,9 +135,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -137,18 +159,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Certificate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -172,9 +191,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:activate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:activate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,12 +215,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificateAuthorities", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificateAuthorities", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -213,9 +243,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,9 +267,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,9 +291,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchCertificateAuthorityCsrResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetch", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}:fetch", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -266,9 +317,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateAuthority>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,12 +343,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateAuthoritiesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateAuthorities", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateAuthorities", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -311,9 +373,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +397,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -353,18 +429,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate_authority
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate_authority"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate_authority
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate_authority"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -388,9 +461,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/caPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/caPools", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -409,18 +489,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.ca_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("ca_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.ca_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("ca_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -444,9 +521,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CaPool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,9 +547,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCaPoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/caPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/caPools", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,9 +577,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +606,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchCaCertsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:fetchCaCerts", {
+            let arg = &req.ca_pool;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("ca_pool"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:fetchCaCerts", req.ca_pool),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -528,9 +630,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateRevocationList>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -547,12 +656,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateRevocationListsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateRevocationLists", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateRevocationLists", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -573,20 +686,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate_revocation_list
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate_revocation_list"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate_revocation_list
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing(
-                            "certificate_revocation_list"
-                        ))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -610,12 +718,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/certificateTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/certificateTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -634,9 +746,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -654,9 +773,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CertificateTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -673,12 +799,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCertificateTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/certificateTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/certificateTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -699,18 +829,15 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.certificate_template
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("certificate_template"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.certificate_template
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("certificate_template"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -734,9 +861,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -756,9 +890,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -775,12 +916,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,12 +940,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -827,12 +976,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -847,9 +1000,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -869,9 +1029,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -888,9 +1055,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -911,9 +1085,16 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/security/publicca/v1/src/client.rs
+++ b/src/generated/cloud/security/publicca/v1/src/client.rs
@@ -129,11 +129,9 @@ impl PublicCertificateAuthorityService {
     /// [google.cloud.security.publicca.v1.ExternalAccountKey]: crate::model::ExternalAccountKey
     pub fn create_external_account_key(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::public_certificate_authority_service::CreateExternalAccountKey {
         super::builder::public_certificate_authority_service::CreateExternalAccountKey::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/security/publicca/v1/src/transport.rs
+++ b/src/generated/cloud/security/publicca/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::PublicCertificateAuthorityService for PublicCertificateAuthori
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalAccountKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/externalAccountKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/externalAccountKeys", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/securitycenter/v2/src/client.rs
+++ b/src/generated/cloud/securitycenter/v2/src/client.rs
@@ -122,10 +122,8 @@ impl SecurityCenter {
     /// difference resource values for use by the attack path simulation.
     pub fn batch_create_resource_value_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_center::BatchCreateResourceValueConfigs {
         super::builder::security_center::BatchCreateResourceValueConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Kicks off an LRO to bulk mute findings for a parent based on a filter. If
@@ -142,168 +140,107 @@ impl SecurityCenter {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn bulk_mute_findings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::BulkMuteFindings {
+    pub fn bulk_mute_findings(&self) -> super::builder::security_center::BulkMuteFindings {
         super::builder::security_center::BulkMuteFindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a BigQuery export.
-    pub fn create_big_query_export(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::CreateBigQueryExport {
+    pub fn create_big_query_export(&self) -> super::builder::security_center::CreateBigQueryExport {
         super::builder::security_center::CreateBigQueryExport::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a finding in a location. The corresponding source must exist for
     /// finding creation to succeed.
-    pub fn create_finding(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::CreateFinding {
+    pub fn create_finding(&self) -> super::builder::security_center::CreateFinding {
         super::builder::security_center::CreateFinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a mute config.
-    pub fn create_mute_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::CreateMuteConfig {
+    pub fn create_mute_config(&self) -> super::builder::security_center::CreateMuteConfig {
         super::builder::security_center::CreateMuteConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a notification config.
     pub fn create_notification_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_center::CreateNotificationConfig {
         super::builder::security_center::CreateNotificationConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a source.
-    pub fn create_source(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::CreateSource {
+    pub fn create_source(&self) -> super::builder::security_center::CreateSource {
         super::builder::security_center::CreateSource::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an existing BigQuery export.
-    pub fn delete_big_query_export(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::DeleteBigQueryExport {
+    pub fn delete_big_query_export(&self) -> super::builder::security_center::DeleteBigQueryExport {
         super::builder::security_center::DeleteBigQueryExport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an existing mute config. If no location is specified, default is
     /// global.
-    pub fn delete_mute_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::DeleteMuteConfig {
+    pub fn delete_mute_config(&self) -> super::builder::security_center::DeleteMuteConfig {
         super::builder::security_center::DeleteMuteConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a notification config.
     pub fn delete_notification_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_center::DeleteNotificationConfig {
         super::builder::security_center::DeleteNotificationConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a ResourceValueConfig.
     pub fn delete_resource_value_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_center::DeleteResourceValueConfig {
         super::builder::security_center::DeleteResourceValueConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a BigQuery export.
-    pub fn get_big_query_export(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetBigQueryExport {
+    pub fn get_big_query_export(&self) -> super::builder::security_center::GetBigQueryExport {
         super::builder::security_center::GetBigQueryExport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get the simulation by name or the latest simulation for the given
     /// organization.
-    pub fn get_simulation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetSimulation {
+    pub fn get_simulation(&self) -> super::builder::security_center::GetSimulation {
         super::builder::security_center::GetSimulation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Get the valued resource by name
-    pub fn get_valued_resource(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetValuedResource {
+    pub fn get_valued_resource(&self) -> super::builder::security_center::GetValuedResource {
         super::builder::security_center::GetValuedResource::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the access control policy on the specified Source.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::security_center::GetIamPolicy {
         super::builder::security_center::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets a mute config. If no location is specified, default is
     /// global.
-    pub fn get_mute_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetMuteConfig {
+    pub fn get_mute_config(&self) -> super::builder::security_center::GetMuteConfig {
         super::builder::security_center::GetMuteConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a notification config.
     pub fn get_notification_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_center::GetNotificationConfig {
         super::builder::security_center::GetNotificationConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a ResourceValueConfig.
     pub fn get_resource_value_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_center::GetResourceValueConfig {
         super::builder::security_center::GetResourceValueConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a source.
-    pub fn get_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetSource {
-        super::builder::security_center::GetSource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_source(&self) -> super::builder::security_center::GetSource {
+        super::builder::security_center::GetSource::new(self.inner.clone())
     }
 
     /// Filters an organization or source's findings and groups them by their
@@ -321,22 +258,14 @@ impl SecurityCenter {
     /// + `/v2/folders/{folder_id}/sources/-/locations/{location_id}/findings`
     /// + `/v2/projects/{project_id}/sources/-/findings`
     /// + `/v2/projects/{project_id}/sources/-/locations/{location_id}/findings`
-    pub fn group_findings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GroupFindings {
+    pub fn group_findings(&self) -> super::builder::security_center::GroupFindings {
         super::builder::security_center::GroupFindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the attack paths for a set of simulation results or valued resources
     /// and filter.
-    pub fn list_attack_paths(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListAttackPaths {
+    pub fn list_attack_paths(&self) -> super::builder::security_center::ListAttackPaths {
         super::builder::security_center::ListAttackPaths::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists BigQuery exports. Note that when requesting BigQuery exports at a
@@ -344,12 +273,8 @@ impl SecurityCenter {
     /// requesting BigQuery exports under a folder, then all BigQuery exports
     /// immediately under the folder plus the ones created under the projects
     /// within the folder are returned.
-    pub fn list_big_query_exports(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListBigQueryExports {
+    pub fn list_big_query_exports(&self) -> super::builder::security_center::ListBigQueryExports {
         super::builder::security_center::ListBigQueryExports::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists an organization or source's findings.
@@ -361,216 +286,138 @@ impl SecurityCenter {
     /// + `/v2/organizations/{organization_id}/sources/-/findings`
     ///
     /// `/v2/organizations/{organization_id}/sources/-/locations/{location_id}/findings`
-    pub fn list_findings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListFindings {
+    pub fn list_findings(&self) -> super::builder::security_center::ListFindings {
         super::builder::security_center::ListFindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists mute configs. If no location is specified, default is
     /// global.
-    pub fn list_mute_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListMuteConfigs {
+    pub fn list_mute_configs(&self) -> super::builder::security_center::ListMuteConfigs {
         super::builder::security_center::ListMuteConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists notification configs.
     pub fn list_notification_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_center::ListNotificationConfigs {
         super::builder::security_center::ListNotificationConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all ResourceValueConfigs.
     pub fn list_resource_value_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_center::ListResourceValueConfigs {
         super::builder::security_center::ListResourceValueConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all sources belonging to an organization.
-    pub fn list_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListSources {
+    pub fn list_sources(&self) -> super::builder::security_center::ListSources {
         super::builder::security_center::ListSources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the valued resources for a set of simulation results and filter.
-    pub fn list_valued_resources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListValuedResources {
+    pub fn list_valued_resources(&self) -> super::builder::security_center::ListValuedResources {
         super::builder::security_center::ListValuedResources::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the state of a finding. If no location is specified, finding is
     /// assumed to be in global
-    pub fn set_finding_state(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::SetFindingState {
+    pub fn set_finding_state(&self) -> super::builder::security_center::SetFindingState {
         super::builder::security_center::SetFindingState::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on the specified Source.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::security_center::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::security_center::SetIamPolicy {
         super::builder::security_center::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Updates the mute state of a finding. If no location is specified, finding
     /// is assumed to be in global
-    pub fn set_mute(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::SetMute {
-        super::builder::security_center::SetMute::new(self.inner.clone()).set_name(name.into())
+    pub fn set_mute(&self) -> super::builder::security_center::SetMute {
+        super::builder::security_center::SetMute::new(self.inner.clone())
     }
 
     /// Returns the permissions that a caller has on the specified source.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::security_center::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::security_center::TestIamPermissions {
         super::builder::security_center::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Updates a BigQuery export.
-    pub fn update_big_query_export(
-        &self,
-        big_query_export: impl Into<crate::model::BigQueryExport>,
-    ) -> super::builder::security_center::UpdateBigQueryExport {
+    pub fn update_big_query_export(&self) -> super::builder::security_center::UpdateBigQueryExport {
         super::builder::security_center::UpdateBigQueryExport::new(self.inner.clone())
-            .set_big_query_export(big_query_export.into())
     }
 
     /// Updates external system. This is for a given finding. If no location is
     /// specified, finding is assumed to be in global
-    pub fn update_external_system(
-        &self,
-        external_system: impl Into<crate::model::ExternalSystem>,
-    ) -> super::builder::security_center::UpdateExternalSystem {
+    pub fn update_external_system(&self) -> super::builder::security_center::UpdateExternalSystem {
         super::builder::security_center::UpdateExternalSystem::new(self.inner.clone())
-            .set_external_system(external_system.into())
     }
 
     /// Creates or updates a finding. If no location is specified, finding is
     /// assumed to be in global. The corresponding source must exist for a finding
     /// creation to succeed.
-    pub fn update_finding(
-        &self,
-        finding: impl Into<crate::model::Finding>,
-    ) -> super::builder::security_center::UpdateFinding {
+    pub fn update_finding(&self) -> super::builder::security_center::UpdateFinding {
         super::builder::security_center::UpdateFinding::new(self.inner.clone())
-            .set_finding(finding.into())
     }
 
     /// Updates a mute config. If no location is specified, default is
     /// global.
-    pub fn update_mute_config(
-        &self,
-        mute_config: impl Into<crate::model::MuteConfig>,
-    ) -> super::builder::security_center::UpdateMuteConfig {
+    pub fn update_mute_config(&self) -> super::builder::security_center::UpdateMuteConfig {
         super::builder::security_center::UpdateMuteConfig::new(self.inner.clone())
-            .set_mute_config(mute_config.into())
     }
 
     /// Updates a notification config. The following update
     /// fields are allowed: description, pubsub_topic, streaming_config.filter
     pub fn update_notification_config(
         &self,
-        notification_config: impl Into<crate::model::NotificationConfig>,
     ) -> super::builder::security_center::UpdateNotificationConfig {
         super::builder::security_center::UpdateNotificationConfig::new(self.inner.clone())
-            .set_notification_config(notification_config.into())
     }
 
     /// Updates an existing ResourceValueConfigs with new rules.
     pub fn update_resource_value_config(
         &self,
-        resource_value_config: impl Into<crate::model::ResourceValueConfig>,
     ) -> super::builder::security_center::UpdateResourceValueConfig {
         super::builder::security_center::UpdateResourceValueConfig::new(self.inner.clone())
-            .set_resource_value_config(resource_value_config.into())
     }
 
     /// Updates security marks. For Finding Security marks, if no location is
     /// specified, finding is assumed to be in global. Assets Security Marks can
     /// only be accessed through global endpoint.
-    pub fn update_security_marks(
-        &self,
-        security_marks: impl Into<crate::model::SecurityMarks>,
-    ) -> super::builder::security_center::UpdateSecurityMarks {
+    pub fn update_security_marks(&self) -> super::builder::security_center::UpdateSecurityMarks {
         super::builder::security_center::UpdateSecurityMarks::new(self.inner.clone())
-            .set_security_marks(security_marks.into())
     }
 
     /// Updates a source.
-    pub fn update_source(
-        &self,
-        source: impl Into<crate::model::Source>,
-    ) -> super::builder::security_center::UpdateSource {
+    pub fn update_source(&self) -> super::builder::security_center::UpdateSource {
         super::builder::security_center::UpdateSource::new(self.inner.clone())
-            .set_source(source.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::ListOperations {
+    pub fn list_operations(&self) -> super::builder::security_center::ListOperations {
         super::builder::security_center::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::GetOperation {
-        super::builder::security_center::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::security_center::GetOperation {
+        super::builder::security_center::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::security_center::DeleteOperation {
         super::builder::security_center::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_center::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::security_center::CancelOperation {
         super::builder::security_center::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -909,10 +909,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::BigQueryExport>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.big_query_export
+            let arg = &req
+                .big_query_export
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("big_query_export"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("big_query_export.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -940,10 +945,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::ExternalSystem>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.external_system
+            let arg = &req
+                .external_system
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("external_system"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("external_system.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -971,10 +981,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.finding
+            let arg = &req
+                .finding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("finding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("finding.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1002,10 +1017,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::MuteConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.mute_config
+            let arg = &req
+                .mute_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("mute_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("mute_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1033,10 +1053,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::NotificationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.notification_config
+            let arg = &req
+                .notification_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("notification_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("notification_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1064,10 +1089,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::ResourceValueConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.resource_value_config
+            let arg = &req
+                .resource_value_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("resource_value_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource_value_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1095,10 +1125,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::SecurityMarks>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.security_marks
+            let arg = &req
+                .security_marks
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("security_marks"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("security_marks.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1126,10 +1161,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.source
+            let arg = &req
+                .source
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("source.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -47,12 +47,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
     ) -> Result<gax::response::Response<crate::model::BatchCreateResourceValueConfigsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/resourceValueConfigs:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/resourceValueConfigs:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,12 +71,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/findings:bulkMute", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/findings:bulkMute", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,12 +95,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BigQueryExport>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/bigQueryExports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/bigQueryExports", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,12 +122,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/findings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/findings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,12 +149,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MuteConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/muteConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/muteConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -156,12 +176,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/notificationConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/notificationConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -179,9 +203,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/sources", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -196,9 +227,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,9 +257,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,9 +287,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -265,9 +317,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,9 +347,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BigQueryExport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,9 +373,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Simulation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -326,9 +399,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ValuedResource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -345,12 +425,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -365,9 +449,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MuteConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,9 +475,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -403,9 +501,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ResourceValueConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,9 +527,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -441,12 +553,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GroupFindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/findings:group", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/findings:group", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -461,12 +577,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttackPathsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/attackPaths", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/attackPaths", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,12 +606,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBigQueryExportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/bigQueryExports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/bigQueryExports", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -510,9 +634,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/findings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/findings", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -539,12 +670,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMuteConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/muteConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/muteConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,12 +698,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotificationConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/notificationConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/notificationConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -587,12 +726,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListResourceValueConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/resourceValueConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/resourceValueConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -611,9 +754,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/sources", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -632,12 +782,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListValuedResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/valuedResources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/valuedResources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -658,9 +812,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setState", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:setState", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -675,12 +836,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -695,9 +860,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setMute", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:setMute", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -712,12 +884,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -732,18 +908,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BigQueryExport>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.big_query_export
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("big_query_export"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.big_query_export
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("big_query_export"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -766,18 +939,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalSystem>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.external_system
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("external_system"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.external_system
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("external_system"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -800,18 +970,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.finding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("finding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.finding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("finding"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -834,18 +1001,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MuteConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.mute_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("mute_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.mute_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("mute_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -868,18 +1032,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.notification_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("notification_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.notification_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("notification_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -902,18 +1063,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ResourceValueConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.resource_value_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("resource_value_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.resource_value_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("resource_value_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -936,18 +1094,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecurityMarks>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.security_marks
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("security_marks"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.security_marks
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("security_marks"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -970,18 +1125,15 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.source
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("source"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.source
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1002,9 +1154,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1024,9 +1183,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1043,9 +1209,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1066,9 +1239,16 @@ impl super::stub::SecurityCenter for SecurityCenter {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/securityposture/v1/src/client.rs
+++ b/src/generated/cloud/securityposture/v1/src/client.rs
@@ -127,21 +127,13 @@ impl SecurityPosture {
     /// "PREVIEW,GOOGLE_INTERNAL"; Postures Lists Postures in a given organization
     /// and location. In case a posture has multiple revisions, the latest revision
     /// as per UpdateTime will be returned.
-    pub fn list_postures(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ListPostures {
+    pub fn list_postures(&self) -> super::builder::security_posture::ListPostures {
         super::builder::security_posture::ListPostures::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists revisions of a Posture in a given organization and location.
-    pub fn list_posture_revisions(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ListPostureRevisions {
+    pub fn list_posture_revisions(&self) -> super::builder::security_posture::ListPostureRevisions {
         super::builder::security_posture::ListPostureRevisions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a posture in a given organization and location.
@@ -150,11 +142,8 @@ impl SecurityPosture {
     /// NOT_FOUND error is returned if the revision_id or the Posture name does not
     /// exist. In case revision_id is not provided then the latest Posture revision
     /// by UpdateTime is returned.
-    pub fn get_posture(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::GetPosture {
-        super::builder::security_posture::GetPosture::new(self.inner.clone()).set_name(name.into())
+    pub fn get_posture(&self) -> super::builder::security_posture::GetPosture {
+        super::builder::security_posture::GetPosture::new(self.inner.clone())
     }
 
     /// Creates a new Posture resource.
@@ -171,12 +160,8 @@ impl SecurityPosture {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_posture(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::CreatePosture {
+    pub fn create_posture(&self) -> super::builder::security_posture::CreatePosture {
         super::builder::security_posture::CreatePosture::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing Posture.
@@ -201,12 +186,8 @@ impl SecurityPosture {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_posture(
-        &self,
-        posture: impl Into<crate::model::Posture>,
-    ) -> super::builder::security_posture::UpdatePosture {
+    pub fn update_posture(&self) -> super::builder::security_posture::UpdatePosture {
         super::builder::security_posture::UpdatePosture::new(self.inner.clone())
-            .set_posture(posture.into())
     }
 
     /// Deletes all the revisions of a resource.
@@ -222,12 +203,8 @@ impl SecurityPosture {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_posture(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::DeletePosture {
+    pub fn delete_posture(&self) -> super::builder::security_posture::DeletePosture {
         super::builder::security_posture::DeletePosture::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Extracts existing policies on a workload as a posture.
@@ -243,31 +220,21 @@ impl SecurityPosture {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn extract_posture(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ExtractPosture {
+    pub fn extract_posture(&self) -> super::builder::security_posture::ExtractPosture {
         super::builder::security_posture::ExtractPosture::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// PostureDeployments
     /// Lists PostureDeployments in a given project and location.
     pub fn list_posture_deployments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_posture::ListPostureDeployments {
         super::builder::security_posture::ListPostureDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single PostureDeployment.
-    pub fn get_posture_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::GetPostureDeployment {
+    pub fn get_posture_deployment(&self) -> super::builder::security_posture::GetPostureDeployment {
         super::builder::security_posture::GetPostureDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new PostureDeployment in a given project and location.
@@ -283,10 +250,8 @@ impl SecurityPosture {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_posture_deployment(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::security_posture::CreatePostureDeployment {
         super::builder::security_posture::CreatePostureDeployment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single PostureDeployment.
@@ -302,10 +267,8 @@ impl SecurityPosture {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_posture_deployment(
         &self,
-        posture_deployment: impl Into<crate::model::PostureDeployment>,
     ) -> super::builder::security_posture::UpdatePostureDeployment {
         super::builder::security_posture::UpdatePostureDeployment::new(self.inner.clone())
-            .set_posture_deployment(posture_deployment.into())
     }
 
     /// Deletes a single PostureDeployment.
@@ -321,20 +284,14 @@ impl SecurityPosture {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_posture_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::security_posture::DeletePostureDeployment {
         super::builder::security_posture::DeletePostureDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// PostureTemplates
     /// Lists all the PostureTemplates available to the user.
-    pub fn list_posture_templates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ListPostureTemplates {
+    pub fn list_posture_templates(&self) -> super::builder::security_posture::ListPostureTemplates {
         super::builder::security_posture::ListPostureTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a PostureTemplate.
@@ -343,72 +300,45 @@ impl SecurityPosture {
     /// NOT_FOUND error is returned if the revision_id or the PostureTemplate name
     /// does not exist. In case revision_id is not provided then the
     /// PostureTemplate with latest revision_id is returned.
-    pub fn get_posture_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::GetPostureTemplate {
+    pub fn get_posture_template(&self) -> super::builder::security_posture::GetPostureTemplate {
         super::builder::security_posture::GetPostureTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ListLocations {
+    pub fn list_locations(&self) -> super::builder::security_posture::ListLocations {
         super::builder::security_posture::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::GetLocation {
-        super::builder::security_posture::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::security_posture::GetLocation {
+        super::builder::security_posture::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::ListOperations {
+    pub fn list_operations(&self) -> super::builder::security_posture::ListOperations {
         super::builder::security_posture::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::GetOperation {
+    pub fn get_operation(&self) -> super::builder::security_posture::GetOperation {
         super::builder::security_posture::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::security_posture::DeleteOperation {
         super::builder::security_posture::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::security_posture::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::security_posture::CancelOperation {
         super::builder::security_posture::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPosturesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/postures", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/postures", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,12 +74,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPostureRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +102,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Posture>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -111,12 +129,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/postures", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/postures", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -134,18 +156,15 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.posture
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("posture"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.posture
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("posture"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,9 +188,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,12 +215,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/postures:extract", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/postures:extract", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -209,12 +239,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPostureDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/postureDeployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/postureDeployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -234,9 +268,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PostureDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -253,12 +294,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/postureDeployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/postureDeployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,18 +321,15 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.posture_deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("posture_deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.posture_deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("posture_deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +352,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -330,12 +379,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPostureTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/postureTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/postureTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -355,9 +408,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PostureTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -375,9 +435,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,9 +464,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,9 +490,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -438,9 +519,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -457,9 +545,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -480,9 +575,16 @@ impl super::stub::SecurityPosture for SecurityPosture {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -157,10 +157,15 @@ impl super::stub::SecurityPosture for SecurityPosture {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.posture
+            let arg = &req
+                .posture
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("posture"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("posture.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -322,10 +327,15 @@ impl super::stub::SecurityPosture for SecurityPosture {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.posture_deployment
+            let arg = &req
+                .posture_deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("posture_deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("posture_deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/servicedirectory/v1/src/client.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/client.rs
@@ -123,28 +123,18 @@ impl LookupService {
     /// Resolving a service is not considered an active developer method.
     ///
     /// [google.cloud.servicedirectory.v1.Service]: crate::model::Service
-    pub fn resolve_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lookup_service::ResolveService {
+    pub fn resolve_service(&self) -> super::builder::lookup_service::ResolveService {
         super::builder::lookup_service::ResolveService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lookup_service::ListLocations {
-        super::builder::lookup_service::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::lookup_service::ListLocations {
+        super::builder::lookup_service::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::lookup_service::GetLocation {
-        super::builder::lookup_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::lookup_service::GetLocation {
+        super::builder::lookup_service::GetLocation::new(self.inner.clone())
     }
 }
 
@@ -270,184 +260,104 @@ impl RegistrationService {
     }
 
     /// Creates a namespace, and returns the new namespace.
-    pub fn create_namespace(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::CreateNamespace {
+    pub fn create_namespace(&self) -> super::builder::registration_service::CreateNamespace {
         super::builder::registration_service::CreateNamespace::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all namespaces.
-    pub fn list_namespaces(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::ListNamespaces {
+    pub fn list_namespaces(&self) -> super::builder::registration_service::ListNamespaces {
         super::builder::registration_service::ListNamespaces::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a namespace.
-    pub fn get_namespace(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::GetNamespace {
+    pub fn get_namespace(&self) -> super::builder::registration_service::GetNamespace {
         super::builder::registration_service::GetNamespace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a namespace.
-    pub fn update_namespace(
-        &self,
-        namespace: impl Into<crate::model::Namespace>,
-    ) -> super::builder::registration_service::UpdateNamespace {
+    pub fn update_namespace(&self) -> super::builder::registration_service::UpdateNamespace {
         super::builder::registration_service::UpdateNamespace::new(self.inner.clone())
-            .set_namespace(namespace.into())
     }
 
     /// Deletes a namespace. This also deletes all services and endpoints in
     /// the namespace.
-    pub fn delete_namespace(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::DeleteNamespace {
+    pub fn delete_namespace(&self) -> super::builder::registration_service::DeleteNamespace {
         super::builder::registration_service::DeleteNamespace::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a service, and returns the new service.
-    pub fn create_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::CreateService {
+    pub fn create_service(&self) -> super::builder::registration_service::CreateService {
         super::builder::registration_service::CreateService::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all services belonging to a namespace.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::ListServices {
+    pub fn list_services(&self) -> super::builder::registration_service::ListServices {
         super::builder::registration_service::ListServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a service.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::GetService {
+    pub fn get_service(&self) -> super::builder::registration_service::GetService {
         super::builder::registration_service::GetService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a service.
-    pub fn update_service(
-        &self,
-        service: impl Into<crate::model::Service>,
-    ) -> super::builder::registration_service::UpdateService {
+    pub fn update_service(&self) -> super::builder::registration_service::UpdateService {
         super::builder::registration_service::UpdateService::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Deletes a service. This also deletes all endpoints associated with
     /// the service.
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::DeleteService {
+    pub fn delete_service(&self) -> super::builder::registration_service::DeleteService {
         super::builder::registration_service::DeleteService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an endpoint, and returns the new endpoint.
-    pub fn create_endpoint(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::CreateEndpoint {
+    pub fn create_endpoint(&self) -> super::builder::registration_service::CreateEndpoint {
         super::builder::registration_service::CreateEndpoint::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all endpoints.
-    pub fn list_endpoints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::ListEndpoints {
+    pub fn list_endpoints(&self) -> super::builder::registration_service::ListEndpoints {
         super::builder::registration_service::ListEndpoints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an endpoint.
-    pub fn get_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::GetEndpoint {
+    pub fn get_endpoint(&self) -> super::builder::registration_service::GetEndpoint {
         super::builder::registration_service::GetEndpoint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an endpoint.
-    pub fn update_endpoint(
-        &self,
-        endpoint: impl Into<crate::model::Endpoint>,
-    ) -> super::builder::registration_service::UpdateEndpoint {
+    pub fn update_endpoint(&self) -> super::builder::registration_service::UpdateEndpoint {
         super::builder::registration_service::UpdateEndpoint::new(self.inner.clone())
-            .set_endpoint(endpoint.into())
     }
 
     /// Deletes an endpoint.
-    pub fn delete_endpoint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::DeleteEndpoint {
+    pub fn delete_endpoint(&self) -> super::builder::registration_service::DeleteEndpoint {
         super::builder::registration_service::DeleteEndpoint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the IAM Policy for a resource (namespace or service only).
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::registration_service::GetIamPolicy {
         super::builder::registration_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the IAM Policy for a resource (namespace or service only).
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::registration_service::SetIamPolicy {
         super::builder::registration_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Tests IAM permissions for a resource (namespace or service only).
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::registration_service::TestIamPermissions {
         super::builder::registration_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::registration_service::ListLocations {
         super::builder::registration_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::registration_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::registration_service::GetLocation {
         super::builder::registration_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::LookupService for LookupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ResolveServiceResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resolve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resolve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +70,16 @@ impl super::stub::LookupService for LookupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,9 +99,16 @@ impl super::stub::LookupService for LookupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,12 +148,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Namespace>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/namespaces", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/namespaces", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,12 +175,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNamespacesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/namespaces", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/namespaces", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,9 +205,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Namespace>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -195,18 +231,15 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Namespace>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.namespace
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("namespace"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.namespace
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("namespace"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -229,9 +262,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -252,12 +292,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/services", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +319,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,9 +349,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -317,18 +375,15 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -351,9 +406,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -374,12 +436,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,12 +463,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEndpointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/endpoints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/endpoints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -423,9 +493,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -442,18 +519,15 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.endpoint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.endpoint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,9 +550,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -499,12 +580,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -519,12 +604,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -539,12 +628,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,9 +652,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -581,9 +681,16 @@ impl super::stub::RegistrationService for RegistrationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -232,10 +232,15 @@ impl super::stub::RegistrationService for RegistrationService {
     ) -> Result<gax::response::Response<crate::model::Namespace>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.namespace
+            let arg = &req
+                .namespace
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("namespace"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("namespace.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -376,10 +381,15 @@ impl super::stub::RegistrationService for RegistrationService {
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service
+            let arg = &req
+                .service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -520,10 +530,15 @@ impl super::stub::RegistrationService for RegistrationService {
     ) -> Result<gax::response::Response<crate::model::Endpoint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.endpoint
+            let arg = &req
+                .endpoint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("endpoint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("endpoint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/servicehealth/v1/src/client.rs
+++ b/src/generated/cloud/servicehealth/v1/src/client.rs
@@ -119,74 +119,49 @@ impl ServiceHealth {
     }
 
     /// Lists events under a given project and location.
-    pub fn list_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_health::ListEvents {
+    pub fn list_events(&self) -> super::builder::service_health::ListEvents {
         super::builder::service_health::ListEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a resource containing information about an event.
-    pub fn get_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_health::GetEvent {
-        super::builder::service_health::GetEvent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_event(&self) -> super::builder::service_health::GetEvent {
+        super::builder::service_health::GetEvent::new(self.inner.clone())
     }
 
     /// Lists organization events under a given organization and location.
     pub fn list_organization_events(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::service_health::ListOrganizationEvents {
         super::builder::service_health::ListOrganizationEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a resource containing information about an event affecting an
     /// organization .
-    pub fn get_organization_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_health::GetOrganizationEvent {
+    pub fn get_organization_event(&self) -> super::builder::service_health::GetOrganizationEvent {
         super::builder::service_health::GetOrganizationEvent::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists assets impacted by organization events under a given organization and
     /// location.
     pub fn list_organization_impacts(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::service_health::ListOrganizationImpacts {
         super::builder::service_health::ListOrganizationImpacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a resource containing information about impact to an asset under
     /// an organization affected by a service health event.
-    pub fn get_organization_impact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_health::GetOrganizationImpact {
+    pub fn get_organization_impact(&self) -> super::builder::service_health::GetOrganizationImpact {
         super::builder::service_health::GetOrganizationImpact::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_health::ListLocations {
-        super::builder::service_health::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::service_health::ListLocations {
+        super::builder::service_health::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_health::GetLocation {
-        super::builder::service_health::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::service_health::GetLocation {
+        super::builder::service_health::GetLocation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/transport.rs
+++ b/src/generated/cloud/servicehealth/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/events", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/events", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Event>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +102,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOrganizationEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/organizationEvents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/organizationEvents", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,9 +132,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OrganizationEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,12 +158,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOrganizationImpactsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/organizationImpacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/organizationImpacts", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +187,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OrganizationImpact>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -177,9 +213,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,9 +242,16 @@ impl super::stub::ServiceHealth for ServiceHealth {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/shell/v1/src/client.rs
+++ b/src/generated/cloud/shell/v1/src/client.rs
@@ -127,12 +127,8 @@ impl CloudShellService {
     }
 
     /// Gets an environment. Returns NOT_FOUND if the environment does not exist.
-    pub fn get_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_shell_service::GetEnvironment {
+    pub fn get_environment(&self) -> super::builder::cloud_shell_service::GetEnvironment {
         super::builder::cloud_shell_service::GetEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts an existing environment, allowing clients to connect to it. The
@@ -151,12 +147,8 @@ impl CloudShellService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_environment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_shell_service::StartEnvironment {
+    pub fn start_environment(&self) -> super::builder::cloud_shell_service::StartEnvironment {
         super::builder::cloud_shell_service::StartEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sends OAuth credentials to a running environment on behalf of a user. When
@@ -175,10 +167,8 @@ impl CloudShellService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn authorize_environment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cloud_shell_service::AuthorizeEnvironment {
         super::builder::cloud_shell_service::AuthorizeEnvironment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds a public SSH key to an environment, allowing clients with the
@@ -194,12 +184,8 @@ impl CloudShellService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn add_public_key(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::cloud_shell_service::AddPublicKey {
+    pub fn add_public_key(&self) -> super::builder::cloud_shell_service::AddPublicKey {
         super::builder::cloud_shell_service::AddPublicKey::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Removes a public SSH key from an environment. Clients will no longer be
@@ -216,22 +202,14 @@ impl CloudShellService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn remove_public_key(
-        &self,
-        environment: impl Into<std::string::String>,
-    ) -> super::builder::cloud_shell_service::RemovePublicKey {
+    pub fn remove_public_key(&self) -> super::builder::cloud_shell_service::RemovePublicKey {
         super::builder::cloud_shell_service::RemovePublicKey::new(self.inner.clone())
-            .set_environment(environment.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_shell_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::cloud_shell_service::GetOperation {
         super::builder::cloud_shell_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/shell/v1/src/transport.rs
+++ b/src/generated/cloud/shell/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Environment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -82,9 +96,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:authorize", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:authorize", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -99,12 +120,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addPublicKey", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addPublicKey", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -119,12 +144,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removePublicKey", {
+            let arg = &req.environment;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("environment"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removePublicKey", req.environment),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -139,9 +168,16 @@ impl super::stub::CloudShellService for CloudShellService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -131,19 +131,13 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_recognizer(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::CreateRecognizer {
-        super::builder::speech::CreateRecognizer::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_recognizer(&self) -> super::builder::speech::CreateRecognizer {
+        super::builder::speech::CreateRecognizer::new(self.inner.clone())
     }
 
     /// Lists Recognizers.
-    pub fn list_recognizers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::ListRecognizers {
-        super::builder::speech::ListRecognizers::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_recognizers(&self) -> super::builder::speech::ListRecognizers {
+        super::builder::speech::ListRecognizers::new(self.inner.clone())
     }
 
     /// Returns the requested
@@ -152,11 +146,8 @@ impl Speech {
     /// exist.
     ///
     /// [google.cloud.speech.v2.Recognizer]: crate::model::Recognizer
-    pub fn get_recognizer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetRecognizer {
-        super::builder::speech::GetRecognizer::new(self.inner.clone()).set_name(name.into())
+    pub fn get_recognizer(&self) -> super::builder::speech::GetRecognizer {
+        super::builder::speech::GetRecognizer::new(self.inner.clone())
     }
 
     /// Updates the [Recognizer][google.cloud.speech.v2.Recognizer].
@@ -172,12 +163,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_recognizer(
-        &self,
-        recognizer: impl Into<crate::model::Recognizer>,
-    ) -> super::builder::speech::UpdateRecognizer {
+    pub fn update_recognizer(&self) -> super::builder::speech::UpdateRecognizer {
         super::builder::speech::UpdateRecognizer::new(self.inner.clone())
-            .set_recognizer(recognizer.into())
     }
 
     /// Deletes the [Recognizer][google.cloud.speech.v2.Recognizer].
@@ -193,11 +180,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_recognizer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::DeleteRecognizer {
-        super::builder::speech::DeleteRecognizer::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_recognizer(&self) -> super::builder::speech::DeleteRecognizer {
+        super::builder::speech::DeleteRecognizer::new(self.inner.clone())
     }
 
     /// Undeletes the [Recognizer][google.cloud.speech.v2.Recognizer].
@@ -213,20 +197,14 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_recognizer(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::UndeleteRecognizer {
-        super::builder::speech::UndeleteRecognizer::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_recognizer(&self) -> super::builder::speech::UndeleteRecognizer {
+        super::builder::speech::UndeleteRecognizer::new(self.inner.clone())
     }
 
     /// Performs synchronous Speech recognition: receive results after all audio
     /// has been sent and processed.
-    pub fn recognize(
-        &self,
-        recognizer: impl Into<std::string::String>,
-    ) -> super::builder::speech::Recognize {
-        super::builder::speech::Recognize::new(self.inner.clone()).set_recognizer(recognizer.into())
+    pub fn recognize(&self) -> super::builder::speech::Recognize {
+        super::builder::speech::Recognize::new(self.inner.clone())
     }
 
     /// Performs batch asynchronous speech recognition: send a request with N
@@ -242,32 +220,22 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_recognize(
-        &self,
-        recognizer: impl Into<std::string::String>,
-    ) -> super::builder::speech::BatchRecognize {
+    pub fn batch_recognize(&self) -> super::builder::speech::BatchRecognize {
         super::builder::speech::BatchRecognize::new(self.inner.clone())
-            .set_recognizer(recognizer.into())
     }
 
     /// Returns the requested [Config][google.cloud.speech.v2.Config].
     ///
     /// [google.cloud.speech.v2.Config]: crate::model::Config
-    pub fn get_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetConfig {
-        super::builder::speech::GetConfig::new(self.inner.clone()).set_name(name.into())
+    pub fn get_config(&self) -> super::builder::speech::GetConfig {
+        super::builder::speech::GetConfig::new(self.inner.clone())
     }
 
     /// Updates the [Config][google.cloud.speech.v2.Config].
     ///
     /// [google.cloud.speech.v2.Config]: crate::model::Config
-    pub fn update_config(
-        &self,
-        config: impl Into<crate::model::Config>,
-    ) -> super::builder::speech::UpdateConfig {
-        super::builder::speech::UpdateConfig::new(self.inner.clone()).set_config(config.into())
+    pub fn update_config(&self) -> super::builder::speech::UpdateConfig {
+        super::builder::speech::UpdateConfig::new(self.inner.clone())
     }
 
     /// Creates a [CustomClass][google.cloud.speech.v2.CustomClass].
@@ -283,30 +251,21 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_custom_class(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::CreateCustomClass {
-        super::builder::speech::CreateCustomClass::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_custom_class(&self) -> super::builder::speech::CreateCustomClass {
+        super::builder::speech::CreateCustomClass::new(self.inner.clone())
     }
 
     /// Lists CustomClasses.
-    pub fn list_custom_classes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::ListCustomClasses {
-        super::builder::speech::ListCustomClasses::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_custom_classes(&self) -> super::builder::speech::ListCustomClasses {
+        super::builder::speech::ListCustomClasses::new(self.inner.clone())
     }
 
     /// Returns the requested
     /// [CustomClass][google.cloud.speech.v2.CustomClass].
     ///
     /// [google.cloud.speech.v2.CustomClass]: crate::model::CustomClass
-    pub fn get_custom_class(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetCustomClass {
-        super::builder::speech::GetCustomClass::new(self.inner.clone()).set_name(name.into())
+    pub fn get_custom_class(&self) -> super::builder::speech::GetCustomClass {
+        super::builder::speech::GetCustomClass::new(self.inner.clone())
     }
 
     /// Updates the [CustomClass][google.cloud.speech.v2.CustomClass].
@@ -322,12 +281,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_custom_class(
-        &self,
-        custom_class: impl Into<crate::model::CustomClass>,
-    ) -> super::builder::speech::UpdateCustomClass {
+    pub fn update_custom_class(&self) -> super::builder::speech::UpdateCustomClass {
         super::builder::speech::UpdateCustomClass::new(self.inner.clone())
-            .set_custom_class(custom_class.into())
     }
 
     /// Deletes the [CustomClass][google.cloud.speech.v2.CustomClass].
@@ -343,11 +298,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_custom_class(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::DeleteCustomClass {
-        super::builder::speech::DeleteCustomClass::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_custom_class(&self) -> super::builder::speech::DeleteCustomClass {
+        super::builder::speech::DeleteCustomClass::new(self.inner.clone())
     }
 
     /// Undeletes the [CustomClass][google.cloud.speech.v2.CustomClass].
@@ -363,11 +315,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_custom_class(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::UndeleteCustomClass {
-        super::builder::speech::UndeleteCustomClass::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_custom_class(&self) -> super::builder::speech::UndeleteCustomClass {
+        super::builder::speech::UndeleteCustomClass::new(self.inner.clone())
     }
 
     /// Creates a [PhraseSet][google.cloud.speech.v2.PhraseSet].
@@ -383,30 +332,21 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_phrase_set(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::CreatePhraseSet {
-        super::builder::speech::CreatePhraseSet::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_phrase_set(&self) -> super::builder::speech::CreatePhraseSet {
+        super::builder::speech::CreatePhraseSet::new(self.inner.clone())
     }
 
     /// Lists PhraseSets.
-    pub fn list_phrase_sets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::speech::ListPhraseSets {
-        super::builder::speech::ListPhraseSets::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_phrase_sets(&self) -> super::builder::speech::ListPhraseSets {
+        super::builder::speech::ListPhraseSets::new(self.inner.clone())
     }
 
     /// Returns the requested
     /// [PhraseSet][google.cloud.speech.v2.PhraseSet].
     ///
     /// [google.cloud.speech.v2.PhraseSet]: crate::model::PhraseSet
-    pub fn get_phrase_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetPhraseSet {
-        super::builder::speech::GetPhraseSet::new(self.inner.clone()).set_name(name.into())
+    pub fn get_phrase_set(&self) -> super::builder::speech::GetPhraseSet {
+        super::builder::speech::GetPhraseSet::new(self.inner.clone())
     }
 
     /// Updates the [PhraseSet][google.cloud.speech.v2.PhraseSet].
@@ -422,12 +362,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_phrase_set(
-        &self,
-        phrase_set: impl Into<crate::model::PhraseSet>,
-    ) -> super::builder::speech::UpdatePhraseSet {
+    pub fn update_phrase_set(&self) -> super::builder::speech::UpdatePhraseSet {
         super::builder::speech::UpdatePhraseSet::new(self.inner.clone())
-            .set_phrase_set(phrase_set.into())
     }
 
     /// Deletes the [PhraseSet][google.cloud.speech.v2.PhraseSet].
@@ -443,11 +379,8 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_phrase_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::DeletePhraseSet {
-        super::builder::speech::DeletePhraseSet::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_phrase_set(&self) -> super::builder::speech::DeletePhraseSet {
+        super::builder::speech::DeletePhraseSet::new(self.inner.clone())
     }
 
     /// Undeletes the [PhraseSet][google.cloud.speech.v2.PhraseSet].
@@ -463,66 +396,45 @@ impl Speech {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_phrase_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::UndeletePhraseSet {
-        super::builder::speech::UndeletePhraseSet::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_phrase_set(&self) -> super::builder::speech::UndeletePhraseSet {
+        super::builder::speech::UndeletePhraseSet::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::ListLocations {
-        super::builder::speech::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::speech::ListLocations {
+        super::builder::speech::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetLocation {
-        super::builder::speech::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::speech::GetLocation {
+        super::builder::speech::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::ListOperations {
-        super::builder::speech::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::speech::ListOperations {
+        super::builder::speech::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::GetOperation {
-        super::builder::speech::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::speech::GetOperation {
+        super::builder::speech::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::DeleteOperation {
-        super::builder::speech::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::speech::DeleteOperation {
+        super::builder::speech::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::speech::CancelOperation {
-        super::builder::speech::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::speech::CancelOperation {
+        super::builder::speech::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/recognizers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/recognizers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,12 +74,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRecognizersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/recognizers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/recognizers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,9 +103,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Recognizer>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.recognizer
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("recognizer"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.recognizer
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("recognizer"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,9 +161,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -171,9 +190,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -188,12 +214,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RecognizeResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:recognize", {
+            let arg = &req.recognizer;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("recognizer"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:recognize", req.recognizer),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,12 +238,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:batchRecognize", {
+            let arg = &req.recognizer;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("recognizer"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:batchRecognize", req.recognizer),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -228,9 +262,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Config>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,18 +288,15 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Config>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -279,12 +317,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/customClasses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/customClasses", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -303,12 +345,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCustomClassesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/customClasses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/customClasses", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,9 +374,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CustomClass>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -347,18 +400,15 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.custom_class
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("custom_class"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.custom_class
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("custom_class"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -382,9 +432,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -404,9 +461,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,12 +485,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/phraseSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/phraseSets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -445,12 +513,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPhraseSetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/phraseSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/phraseSets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,9 +542,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PhraseSet>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,18 +568,15 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.phrase_set
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("phrase_set"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.phrase_set
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("phrase_set"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -524,9 +600,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,9 +629,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,9 +653,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -585,9 +682,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -604,9 +708,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,9 +737,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -645,9 +763,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -668,9 +793,16 @@ impl super::stub::Speech for Speech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::Speech for Speech {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.recognizer
+            let arg = &req
+                .recognizer
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("recognizer"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("recognizer.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -289,10 +294,15 @@ impl super::stub::Speech for Speech {
     ) -> Result<gax::response::Response<crate::model::Config>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.config
+            let arg = &req
+                .config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -401,10 +411,15 @@ impl super::stub::Speech for Speech {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.custom_class
+            let arg = &req
+                .custom_class
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("custom_class"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("custom_class.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -569,10 +584,15 @@ impl super::stub::Speech for Speech {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.phrase_set
+            let arg = &req
+                .phrase_set
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("phrase_set"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("phrase_set.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/sql/v1/src/client.rs
+++ b/src/generated/cloud/sql/v1/src/client.rs
@@ -121,53 +121,25 @@ impl SqlBackupRunsService {
     }
 
     /// Deletes the backup taken by a backup run.
-    pub fn delete(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        id: impl Into<i64>,
-    ) -> super::builder::sql_backup_runs_service::Delete {
+    pub fn delete(&self) -> super::builder::sql_backup_runs_service::Delete {
         super::builder::sql_backup_runs_service::Delete::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_id(id.into())
     }
 
     /// Retrieves a resource containing information about a backup run.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        id: impl Into<i64>,
-    ) -> super::builder::sql_backup_runs_service::Get {
+    pub fn get(&self) -> super::builder::sql_backup_runs_service::Get {
         super::builder::sql_backup_runs_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_id(id.into())
     }
 
     /// Creates a new backup run on demand.
-    pub fn insert(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_backup_runs_service::Insert {
+    pub fn insert(&self) -> super::builder::sql_backup_runs_service::Insert {
         super::builder::sql_backup_runs_service::Insert::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Lists all backup runs associated with the project or a given instance
     /// and configuration in the reverse chronological order of the backup
     /// initiation time.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_backup_runs_service::List {
+    pub fn list(&self) -> super::builder::sql_backup_runs_service::List {
         super::builder::sql_backup_runs_service::List::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 }
 
@@ -274,14 +246,8 @@ impl SqlConnectService {
     }
 
     /// Retrieves connect settings about a Cloud SQL instance.
-    pub fn get_connect_settings(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_connect_service::GetConnectSettings {
+    pub fn get_connect_settings(&self) -> super::builder::sql_connect_service::GetConnectSettings {
         super::builder::sql_connect_service::GetConnectSettings::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Generates a short-lived X509 certificate containing the provided public key
@@ -290,12 +256,8 @@ impl SqlConnectService {
     /// database.
     pub fn generate_ephemeral_cert(
         &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
     ) -> super::builder::sql_connect_service::GenerateEphemeralCert {
         super::builder::sql_connect_service::GenerateEphemeralCert::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 }
 
@@ -402,83 +364,39 @@ impl SqlDatabasesService {
     }
 
     /// Deletes a database from a Cloud SQL instance.
-    pub fn delete(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::Delete {
+    pub fn delete(&self) -> super::builder::sql_databases_service::Delete {
         super::builder::sql_databases_service::Delete::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_database(database.into())
     }
 
     /// Retrieves a resource containing information about a database inside a Cloud
     /// SQL instance.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::Get {
+    pub fn get(&self) -> super::builder::sql_databases_service::Get {
         super::builder::sql_databases_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_database(database.into())
     }
 
     /// Inserts a resource containing information about a database inside a Cloud
     /// SQL instance.
     ///
     /// **Note:** You can't modify the default character set and collation.
-    pub fn insert(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::Insert {
+    pub fn insert(&self) -> super::builder::sql_databases_service::Insert {
         super::builder::sql_databases_service::Insert::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Lists databases in the specified Cloud SQL instance.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::List {
+    pub fn list(&self) -> super::builder::sql_databases_service::List {
         super::builder::sql_databases_service::List::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Partially updates a resource containing information about a database inside
     /// a Cloud SQL instance. This method supports patch semantics.
-    pub fn patch(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::Patch {
+    pub fn patch(&self) -> super::builder::sql_databases_service::Patch {
         super::builder::sql_databases_service::Patch::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_database(database.into())
     }
 
     /// Updates a resource containing information about a database inside a Cloud
     /// SQL instance.
-    pub fn update(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::sql_databases_service::Update {
+    pub fn update(&self) -> super::builder::sql_databases_service::Update {
         super::builder::sql_databases_service::Update::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_database(database.into())
     }
 }
 
@@ -699,73 +617,38 @@ impl SqlInstancesService {
     /// waiting to be rotated in. For instances that have enabled Certificate
     /// Authority Service (CAS) based server CA, please use AddServerCertificate to
     /// add a new server certificate.
-    pub fn add_server_ca(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::AddServerCa {
+    pub fn add_server_ca(&self) -> super::builder::sql_instances_service::AddServerCa {
         super::builder::sql_instances_service::AddServerCa::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Creates a Cloud SQL instance as a clone of the source instance. Using this
     /// operation might cause your instance to restart.
-    pub fn clone(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Clone {
+    #[allow(clippy::should_implement_trait)]
+    pub fn clone(&self) -> super::builder::sql_instances_service::Clone {
         super::builder::sql_instances_service::Clone::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Deletes a Cloud SQL instance.
-    pub fn delete(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Delete {
+    pub fn delete(&self) -> super::builder::sql_instances_service::Delete {
         super::builder::sql_instances_service::Delete::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Demotes the stand-alone instance to be a Cloud SQL read replica for an
     /// external database server.
-    pub fn demote_master(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::DemoteMaster {
+    pub fn demote_master(&self) -> super::builder::sql_instances_service::DemoteMaster {
         super::builder::sql_instances_service::DemoteMaster::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Demotes an existing standalone instance to be a Cloud SQL read replica
     /// for an external database server.
-    pub fn demote(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Demote {
+    pub fn demote(&self) -> super::builder::sql_instances_service::Demote {
         super::builder::sql_instances_service::Demote::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL
     /// dump or CSV file.
-    pub fn export(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Export {
+    pub fn export(&self) -> super::builder::sql_instances_service::Export {
         super::builder::sql_instances_service::Export::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Initiates a manual failover of a high availability (HA) primary instance
@@ -776,66 +659,34 @@ impl SqlInstancesService {
     /// page in the Cloud SQL documentation.
     /// If using Legacy HA (MySQL only), this causes the instance to failover to
     /// its failover replica instance.
-    pub fn failover(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Failover {
+    pub fn failover(&self) -> super::builder::sql_instances_service::Failover {
         super::builder::sql_instances_service::Failover::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Reencrypt CMEK instance with latest key version.
-    pub fn reencrypt(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Reencrypt {
+    pub fn reencrypt(&self) -> super::builder::sql_instances_service::Reencrypt {
         super::builder::sql_instances_service::Reencrypt::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Retrieves a resource containing information about a Cloud SQL instance.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Get {
+    pub fn get(&self) -> super::builder::sql_instances_service::Get {
         super::builder::sql_instances_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Imports data into a Cloud SQL instance from a SQL dump  or CSV file in
     /// Cloud Storage.
-    pub fn import(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Import {
+    pub fn import(&self) -> super::builder::sql_instances_service::Import {
         super::builder::sql_instances_service::Import::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Creates a new Cloud SQL instance.
-    pub fn insert(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Insert {
+    pub fn insert(&self) -> super::builder::sql_instances_service::Insert {
         super::builder::sql_instances_service::Insert::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Lists instances under a given project.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::List {
+    pub fn list(&self) -> super::builder::sql_instances_service::List {
         super::builder::sql_instances_service::List::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Lists all of the trusted Certificate Authorities (CAs) for the specified
@@ -843,259 +694,135 @@ impl SqlInstancesService {
     /// the certificate that is currently in use, a CA that has been added but not
     /// yet used to sign a certificate, and a CA used to sign a certificate that
     /// has previously rotated out.
-    pub fn list_server_cas(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::ListServerCas {
+    pub fn list_server_cas(&self) -> super::builder::sql_instances_service::ListServerCas {
         super::builder::sql_instances_service::ListServerCas::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Partially updates settings of a Cloud SQL instance by merging the request
     /// with the current configuration. This method supports patch semantics.
-    pub fn patch(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Patch {
+    pub fn patch(&self) -> super::builder::sql_instances_service::Patch {
         super::builder::sql_instances_service::Patch::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Promotes the read replica instance to be an independent Cloud SQL
     /// primary instance.
     /// Using this operation might cause your instance to restart.
-    pub fn promote_replica(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::PromoteReplica {
+    pub fn promote_replica(&self) -> super::builder::sql_instances_service::PromoteReplica {
         super::builder::sql_instances_service::PromoteReplica::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Switches over from the primary instance to the designated DR replica
     /// instance.
-    pub fn switchover(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Switchover {
+    pub fn switchover(&self) -> super::builder::sql_instances_service::Switchover {
         super::builder::sql_instances_service::Switchover::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Deletes all client certificates and generates a new server SSL certificate
     /// for the instance.
-    pub fn reset_ssl_config(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::ResetSslConfig {
+    pub fn reset_ssl_config(&self) -> super::builder::sql_instances_service::ResetSslConfig {
         super::builder::sql_instances_service::ResetSslConfig::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Restarts a Cloud SQL instance.
-    pub fn restart(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Restart {
+    pub fn restart(&self) -> super::builder::sql_instances_service::Restart {
         super::builder::sql_instances_service::Restart::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Restores a backup of a Cloud SQL instance. Using this operation might cause
     /// your instance to restart.
-    pub fn restore_backup(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::RestoreBackup {
+    pub fn restore_backup(&self) -> super::builder::sql_instances_service::RestoreBackup {
         super::builder::sql_instances_service::RestoreBackup::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Rotates the server certificate to one signed by the Certificate Authority
     /// (CA) version previously added with the addServerCA method. For instances
     /// that have enabled Certificate Authority Service (CAS) based server CA,
     /// please use RotateServerCertificate to rotate the server certificate.
-    pub fn rotate_server_ca(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::RotateServerCa {
+    pub fn rotate_server_ca(&self) -> super::builder::sql_instances_service::RotateServerCa {
         super::builder::sql_instances_service::RotateServerCa::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Starts the replication in the read replica instance.
-    pub fn start_replica(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::StartReplica {
+    pub fn start_replica(&self) -> super::builder::sql_instances_service::StartReplica {
         super::builder::sql_instances_service::StartReplica::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Stops the replication in the read replica instance.
-    pub fn stop_replica(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::StopReplica {
+    pub fn stop_replica(&self) -> super::builder::sql_instances_service::StopReplica {
         super::builder::sql_instances_service::StopReplica::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Truncate MySQL general and slow query log tables
     /// MySQL only.
-    pub fn truncate_log(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::TruncateLog {
+    pub fn truncate_log(&self) -> super::builder::sql_instances_service::TruncateLog {
         super::builder::sql_instances_service::TruncateLog::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Updates settings of a Cloud SQL instance. Using this operation might cause
     /// your instance to restart.
-    pub fn update(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::Update {
+    pub fn update(&self) -> super::builder::sql_instances_service::Update {
         super::builder::sql_instances_service::Update::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Generates a short-lived X509 certificate containing the provided public key
     /// and signed by a private key specific to the target instance. Users may use
     /// the certificate to authenticate as themselves when connecting to the
     /// database.
-    pub fn create_ephemeral(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::CreateEphemeral {
+    pub fn create_ephemeral(&self) -> super::builder::sql_instances_service::CreateEphemeral {
         super::builder::sql_instances_service::CreateEphemeral::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Reschedules the maintenance on the given instance.
     pub fn reschedule_maintenance(
         &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
     ) -> super::builder::sql_instances_service::RescheduleMaintenance {
         super::builder::sql_instances_service::RescheduleMaintenance::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Verify External primary instance external sync settings.
     pub fn verify_external_sync_settings(
         &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
     ) -> super::builder::sql_instances_service::VerifyExternalSyncSettings {
         super::builder::sql_instances_service::VerifyExternalSyncSettings::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Start External primary instance migration.
-    pub fn start_external_sync(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::StartExternalSync {
+    pub fn start_external_sync(&self) -> super::builder::sql_instances_service::StartExternalSync {
         super::builder::sql_instances_service::StartExternalSync::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Perform Disk Shrink on primary instance.
-    pub fn perform_disk_shrink(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::PerformDiskShrink {
+    pub fn perform_disk_shrink(&self) -> super::builder::sql_instances_service::PerformDiskShrink {
         super::builder::sql_instances_service::PerformDiskShrink::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Get Disk Shrink Config for a given instance.
     pub fn get_disk_shrink_config(
         &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
     ) -> super::builder::sql_instances_service::GetDiskShrinkConfig {
         super::builder::sql_instances_service::GetDiskShrinkConfig::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Reset Replica Size to primary instance disk size.
-    pub fn reset_replica_size(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::ResetReplicaSize {
+    pub fn reset_replica_size(&self) -> super::builder::sql_instances_service::ResetReplicaSize {
         super::builder::sql_instances_service::ResetReplicaSize::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Get Latest Recovery Time for a given instance.
     pub fn get_latest_recovery_time(
         &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
     ) -> super::builder::sql_instances_service::GetLatestRecoveryTime {
         super::builder::sql_instances_service::GetLatestRecoveryTime::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Acquire a lease for the setup of SQL Server Reporting Services (SSRS).
-    pub fn acquire_ssrs_lease(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::AcquireSsrsLease {
+    pub fn acquire_ssrs_lease(&self) -> super::builder::sql_instances_service::AcquireSsrsLease {
         super::builder::sql_instances_service::AcquireSsrsLease::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Release a lease for the setup of SQL Server Reporting Services (SSRS).
-    pub fn release_ssrs_lease(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_instances_service::ReleaseSsrsLease {
+    pub fn release_ssrs_lease(&self) -> super::builder::sql_instances_service::ReleaseSsrsLease {
         super::builder::sql_instances_service::ReleaseSsrsLease::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 }
 
@@ -1202,35 +929,19 @@ impl SqlOperationsService {
     }
 
     /// Retrieves an instance operation that has been performed on an instance.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        operation: impl Into<std::string::String>,
-    ) -> super::builder::sql_operations_service::Get {
+    pub fn get(&self) -> super::builder::sql_operations_service::Get {
         super::builder::sql_operations_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_operation(operation.into())
     }
 
     /// Lists all instance operations that have been performed on the given Cloud
     /// SQL instance in the reverse chronological order of the start time.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::sql_operations_service::List {
+    pub fn list(&self) -> super::builder::sql_operations_service::List {
         super::builder::sql_operations_service::List::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Cancels an instance operation that has been performed on an instance.
-    pub fn cancel(
-        &self,
-        project: impl Into<std::string::String>,
-        operation: impl Into<std::string::String>,
-    ) -> super::builder::sql_operations_service::Cancel {
+    pub fn cancel(&self) -> super::builder::sql_operations_service::Cancel {
         super::builder::sql_operations_service::Cancel::new(self.inner.clone())
-            .set_project(project.into())
-            .set_operation(operation.into())
     }
 }
 
@@ -1338,55 +1049,27 @@ impl SqlSslCertsService {
 
     /// Deletes the SSL certificate. For First Generation instances, the
     /// certificate remains valid until the instance is restarted.
-    pub fn delete(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        sha1_fingerprint: impl Into<std::string::String>,
-    ) -> super::builder::sql_ssl_certs_service::Delete {
+    pub fn delete(&self) -> super::builder::sql_ssl_certs_service::Delete {
         super::builder::sql_ssl_certs_service::Delete::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_sha1_fingerprint(sha1_fingerprint.into())
     }
 
     /// Retrieves a particular SSL certificate.  Does not include the private key
     /// (required for usage).  The private key must be saved from the response to
     /// initial creation.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        sha1_fingerprint: impl Into<std::string::String>,
-    ) -> super::builder::sql_ssl_certs_service::Get {
+    pub fn get(&self) -> super::builder::sql_ssl_certs_service::Get {
         super::builder::sql_ssl_certs_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_sha1_fingerprint(sha1_fingerprint.into())
     }
 
     /// Creates an SSL certificate and returns it along with the private key and
     /// server certificate authority.  The new certificate will not be usable until
     /// the instance is restarted.
-    pub fn insert(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_ssl_certs_service::Insert {
+    pub fn insert(&self) -> super::builder::sql_ssl_certs_service::Insert {
         super::builder::sql_ssl_certs_service::Insert::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Lists all of the current SSL certificates for the instance.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_ssl_certs_service::List {
+    pub fn list(&self) -> super::builder::sql_ssl_certs_service::List {
         super::builder::sql_ssl_certs_service::List::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 }
 
@@ -1495,11 +1178,8 @@ impl SqlTiersService {
     /// Lists all available machine types (tiers) for Cloud SQL, for example,
     /// `db-custom-1-3840`. For more information, see
     /// <https://cloud.google.com/sql/pricing>.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::sql_tiers_service::List {
-        super::builder::sql_tiers_service::List::new(self.inner.clone()).set_project(project.into())
+    pub fn list(&self) -> super::builder::sql_tiers_service::List {
+        super::builder::sql_tiers_service::List::new(self.inner.clone())
     }
 }
 
@@ -1606,59 +1286,27 @@ impl SqlUsersService {
     }
 
     /// Deletes a user from a Cloud SQL instance.
-    pub fn delete(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_users_service::Delete {
+    pub fn delete(&self) -> super::builder::sql_users_service::Delete {
         super::builder::sql_users_service::Delete::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Retrieves a resource containing information about a user.
-    pub fn get(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sql_users_service::Get {
+    pub fn get(&self) -> super::builder::sql_users_service::Get {
         super::builder::sql_users_service::Get::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
-            .set_name(name.into())
     }
 
     /// Creates a new user in a Cloud SQL instance.
-    pub fn insert(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_users_service::Insert {
+    pub fn insert(&self) -> super::builder::sql_users_service::Insert {
         super::builder::sql_users_service::Insert::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Lists users in the specified Cloud SQL instance.
-    pub fn list(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_users_service::List {
+    pub fn list(&self) -> super::builder::sql_users_service::List {
         super::builder::sql_users_service::List::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 
     /// Updates an existing user in a Cloud SQL instance.
-    pub fn update(
-        &self,
-        project: impl Into<std::string::String>,
-        instance: impl Into<std::string::String>,
-    ) -> super::builder::sql_users_service::Update {
+    pub fn update(&self) -> super::builder::sql_users_service::Update {
         super::builder::sql_users_service::Update::new(self.inner.clone())
-            .set_project(project.into())
-            .set_instance(instance.into())
     }
 }

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -46,15 +46,27 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/backupRuns/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            { &req.id },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/instances/{}/backupRuns/{}",
-                    req.project, req.instance, req.id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,15 +83,27 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/backupRuns/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            { &req.id },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/backupRuns/{}",
-                    req.project, req.instance, req.id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -96,15 +120,26 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/backupRuns",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/backupRuns",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -119,15 +154,26 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupRunsListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/backupRuns",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/backupRuns",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,15 +215,26 @@ impl super::stub::SqlConnectService for SqlConnectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ConnectSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/connectSettings",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/connectSettings",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,15 +261,26 @@ impl super::stub::SqlConnectService for SqlConnectService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateEphemeralCertResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}:generateEphemeralCert",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}:generateEphemeralCert",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,15 +318,33 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.database;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("database"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases/{}",
-                    req.project, req.instance, req.database
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,15 +361,33 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Database>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.database;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("database"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases/{}",
-                    req.project, req.instance, req.database
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,15 +404,26 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -323,15 +438,26 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatabasesListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,15 +474,33 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.database;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("database"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases/{}",
-                    req.project, req.instance, req.database
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -371,15 +515,33 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/databases/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.database;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("database"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/projects/{}/instances/{}/databases/{}",
-                    req.project, req.instance, req.database
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -417,9 +579,10 @@ impl super::stub::SqlFlagsService for SqlFlagsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FlagsListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/flags".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/flags".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -460,15 +623,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/addServerCa",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/addServerCa",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,15 +659,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/clone",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/clone",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +693,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v1/projects/{}/instances/{}", req.project, req.instance),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -530,15 +729,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/demoteMaster",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/demoteMaster",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -553,15 +763,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/demote",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/demote",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -576,15 +797,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/export",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/export",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -599,15 +831,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/failover",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/failover",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -622,15 +865,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/reencrypt",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/reencrypt",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -645,12 +899,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatabaseInstance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/instances/{}", req.project, req.instance),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,15 +935,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/import",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/import",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -690,12 +969,16 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/instances", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/instances", req.project),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -710,12 +993,16 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstancesListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/instances", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/instances", req.project),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -735,15 +1022,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstancesListServerCasResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/listServerCas",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/listServerCas",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -760,12 +1058,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!("/v1/projects/{}/instances/{}", req.project, req.instance),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -780,15 +1092,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/promoteReplica",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/promoteReplica",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -806,15 +1129,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/switchover",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/switchover",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -841,15 +1175,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/resetSslConfig",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/resetSslConfig",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -866,15 +1211,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/restart",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/restart",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -891,15 +1247,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/restoreBackup",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/restoreBackup",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -914,15 +1281,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/rotateServerCa",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/rotateServerCa",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -937,15 +1315,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/startReplica",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/startReplica",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -962,15 +1351,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/stopReplica",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/stopReplica",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -987,15 +1387,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/truncateLog",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/truncateLog",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1010,12 +1421,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!("/v1/projects/{}/instances/{}", req.project, req.instance),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1030,15 +1455,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SslCert>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/createEphemeral",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/createEphemeral",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1053,15 +1489,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/rescheduleMaintenance",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/rescheduleMaintenance",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1077,15 +1524,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
     ) -> Result<gax::response::Response<crate::model::SqlInstancesVerifyExternalSyncSettingsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/verifyExternalSyncSettings",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/verifyExternalSyncSettings",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1100,15 +1558,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/startExternalSync",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/startExternalSync",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1123,15 +1592,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/performDiskShrink",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/performDiskShrink",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1147,15 +1627,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
     ) -> Result<gax::response::Response<crate::model::SqlInstancesGetDiskShrinkConfigResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/getDiskShrinkConfig",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/getDiskShrinkConfig",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1172,15 +1663,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/resetReplicaSize",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/resetReplicaSize",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1196,15 +1698,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
     ) -> Result<gax::response::Response<crate::model::SqlInstancesGetLatestRecoveryTimeResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/getLatestRecoveryTime",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/getLatestRecoveryTime",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1221,15 +1734,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SqlInstancesAcquireSsrsLeaseResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/acquireSsrsLease",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/acquireSsrsLease",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1244,15 +1768,26 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SqlInstancesReleaseSsrsLeaseResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/releaseSsrsLease",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/releaseSsrsLease",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1292,12 +1827,26 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/operations/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.operation;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("operation"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/operations/{}", req.project, req.operation),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1314,12 +1863,16 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OperationsListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/operations", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/operations", req.project),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1339,15 +1892,26 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/operations/{}/cancel",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.operation;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("operation"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/operations/{}/cancel",
-                    req.project, req.operation
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1391,15 +1955,33 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/sslCerts/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.sha1_fingerprint;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("sha1_fingerprint"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/instances/{}/sslCerts/{}",
-                    req.project, req.instance, req.sha1_fingerprint
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1416,15 +1998,33 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SslCert>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/sslCerts/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.sha1_fingerprint;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("sha1_fingerprint"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/sslCerts/{}",
-                    req.project, req.instance, req.sha1_fingerprint
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1441,15 +2041,26 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SslCertsInsertResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/sslCerts",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/sslCerts",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1464,15 +2075,26 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SslCertsListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/sslCerts",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/sslCerts",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1512,12 +2134,16 @@ impl super::stub::SqlTiersService for SqlTiersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TiersListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/tiers", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/tiers", req.project),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1557,15 +2183,26 @@ impl super::stub::SqlUsersService for SqlUsersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/users",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/instances/{}/users",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1584,15 +2221,33 @@ impl super::stub::SqlUsersService for SqlUsersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/users/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+            {
+                let arg = &req.name;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("name"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/users/{}",
-                    req.project, req.instance, req.name
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1610,15 +2265,26 @@ impl super::stub::SqlUsersService for SqlUsersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/users",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/instances/{}/users",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1633,15 +2299,26 @@ impl super::stub::SqlUsersService for SqlUsersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UsersListResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/users",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/instances/{}/users",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1658,15 +2335,26 @@ impl super::stub::SqlUsersService for SqlUsersService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/instances/{}/users",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.instance;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("instance"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v1/projects/{}/instances/{}/users",
-                    req.project, req.instance
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/storagebatchoperations/v1/src/client.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/client.rs
@@ -124,21 +124,13 @@ impl StorageBatchOperations {
     }
 
     /// Lists Jobs in a given project.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::ListJobs {
+    pub fn list_jobs(&self) -> super::builder::storage_batch_operations::ListJobs {
         super::builder::storage_batch_operations::ListJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a batch job.
-    pub fn get_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::GetJob {
+    pub fn get_job(&self) -> super::builder::storage_batch_operations::GetJob {
         super::builder::storage_batch_operations::GetJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a batch job.
@@ -152,91 +144,55 @@ impl StorageBatchOperations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::CreateJob {
+    pub fn create_job(&self) -> super::builder::storage_batch_operations::CreateJob {
         super::builder::storage_batch_operations::CreateJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a batch job.
-    pub fn delete_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::DeleteJob {
+    pub fn delete_job(&self) -> super::builder::storage_batch_operations::DeleteJob {
         super::builder::storage_batch_operations::DeleteJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a batch job.
-    pub fn cancel_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::CancelJob {
+    pub fn cancel_job(&self) -> super::builder::storage_batch_operations::CancelJob {
         super::builder::storage_batch_operations::CancelJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::ListLocations {
+    pub fn list_locations(&self) -> super::builder::storage_batch_operations::ListLocations {
         super::builder::storage_batch_operations::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::GetLocation {
+    pub fn get_location(&self) -> super::builder::storage_batch_operations::GetLocation {
         super::builder::storage_batch_operations::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::ListOperations {
+    pub fn list_operations(&self) -> super::builder::storage_batch_operations::ListOperations {
         super::builder::storage_batch_operations::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::GetOperation {
+    pub fn get_operation(&self) -> super::builder::storage_batch_operations::GetOperation {
         super::builder::storage_batch_operations::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::storage_batch_operations::DeleteOperation {
         super::builder::storage_batch_operations::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_batch_operations::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::storage_batch_operations::CancelOperation {
         super::builder::storage_batch_operations::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +102,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,9 +128,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -131,9 +159,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CancelJobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +183,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +212,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,9 +238,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,9 +267,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,9 +293,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -253,9 +323,16 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/storageinsights/v1/src/client.rs
+++ b/src/generated/cloud/storageinsights/v1/src/client.rs
@@ -121,126 +121,75 @@ impl StorageInsights {
     }
 
     /// Lists ReportConfigs in a given project and location.
-    pub fn list_report_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::ListReportConfigs {
+    pub fn list_report_configs(&self) -> super::builder::storage_insights::ListReportConfigs {
         super::builder::storage_insights::ListReportConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ReportConfig.
-    pub fn get_report_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::GetReportConfig {
+    pub fn get_report_config(&self) -> super::builder::storage_insights::GetReportConfig {
         super::builder::storage_insights::GetReportConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new ReportConfig in a given project and location.
-    pub fn create_report_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::CreateReportConfig {
+    pub fn create_report_config(&self) -> super::builder::storage_insights::CreateReportConfig {
         super::builder::storage_insights::CreateReportConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single ReportConfig.
-    pub fn update_report_config(
-        &self,
-        report_config: impl Into<crate::model::ReportConfig>,
-    ) -> super::builder::storage_insights::UpdateReportConfig {
+    pub fn update_report_config(&self) -> super::builder::storage_insights::UpdateReportConfig {
         super::builder::storage_insights::UpdateReportConfig::new(self.inner.clone())
-            .set_report_config(report_config.into())
     }
 
     /// Deletes a single ReportConfig.
-    pub fn delete_report_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::DeleteReportConfig {
+    pub fn delete_report_config(&self) -> super::builder::storage_insights::DeleteReportConfig {
         super::builder::storage_insights::DeleteReportConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ReportDetails in a given project and location.
-    pub fn list_report_details(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::ListReportDetails {
+    pub fn list_report_details(&self) -> super::builder::storage_insights::ListReportDetails {
         super::builder::storage_insights::ListReportDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ReportDetail.
-    pub fn get_report_detail(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::GetReportDetail {
+    pub fn get_report_detail(&self) -> super::builder::storage_insights::GetReportDetail {
         super::builder::storage_insights::GetReportDetail::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::ListLocations {
+    pub fn list_locations(&self) -> super::builder::storage_insights::ListLocations {
         super::builder::storage_insights::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::GetLocation {
-        super::builder::storage_insights::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::storage_insights::GetLocation {
+        super::builder::storage_insights::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::ListOperations {
+    pub fn list_operations(&self) -> super::builder::storage_insights::ListOperations {
         super::builder::storage_insights::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::GetOperation {
+    pub fn get_operation(&self) -> super::builder::storage_insights::GetOperation {
         super::builder::storage_insights::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::storage_insights::DeleteOperation {
         super::builder::storage_insights::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_insights::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::storage_insights::CancelOperation {
         super::builder::storage_insights::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -130,10 +130,15 @@ impl super::stub::StorageInsights for StorageInsights {
     ) -> Result<gax::response::Response<crate::model::ReportConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.report_config
+            let arg = &req
+                .report_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("report_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("report_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReportConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reportConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/reportConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/reportConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/reportConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,18 +129,15 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.report_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("report_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.report_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("report_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,9 +161,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -174,12 +193,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReportDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/reportDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/reportDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,9 +223,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportDetail>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,9 +249,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -241,9 +278,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,9 +304,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -282,9 +333,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,9 +359,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,9 +389,16 @@ impl super::stub::StorageInsights for StorageInsights {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/support/v2/src/client.rs
+++ b/src/generated/cloud/support/v2/src/client.rs
@@ -121,12 +121,8 @@ impl CaseAttachmentService {
     }
 
     /// Retrieve all attachments associated with a support case.
-    pub fn list_attachments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::case_attachment_service::ListAttachments {
+    pub fn list_attachments(&self) -> super::builder::case_attachment_service::ListAttachments {
         super::builder::case_attachment_service::ListAttachments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }
 
@@ -231,11 +227,8 @@ impl CaseService {
     }
 
     /// Retrieve the specified case.
-    pub fn get_case(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::case_service::GetCase {
-        super::builder::case_service::GetCase::new(self.inner.clone()).set_name(name.into())
+    pub fn get_case(&self) -> super::builder::case_service::GetCase {
+        super::builder::case_service::GetCase::new(self.inner.clone())
     }
 
     /// Retrieve all cases under the specified parent.
@@ -244,37 +237,25 @@ impl CaseService {
     /// parented by that organization. To retrieve all cases under an organization,
     /// including cases parented by projects under that organization, use
     /// `cases.search`.
-    pub fn list_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::case_service::ListCases {
-        super::builder::case_service::ListCases::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_cases(&self) -> super::builder::case_service::ListCases {
+        super::builder::case_service::ListCases::new(self.inner.clone())
     }
 
     /// Search cases using the specified query.
-    pub fn search_cases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::case_service::SearchCases {
-        super::builder::case_service::SearchCases::new(self.inner.clone()).set_parent(parent.into())
+    pub fn search_cases(&self) -> super::builder::case_service::SearchCases {
+        super::builder::case_service::SearchCases::new(self.inner.clone())
     }
 
     /// Create a new case and associate it with the given Google Cloud Resource.
     /// The case object must have the following fields set: `display_name`,
     /// `description`, `classification`, and `priority`.
-    pub fn create_case(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::case_service::CreateCase {
-        super::builder::case_service::CreateCase::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_case(&self) -> super::builder::case_service::CreateCase {
+        super::builder::case_service::CreateCase::new(self.inner.clone())
     }
 
     /// Update the specified case. Only a subset of fields can be updated.
-    pub fn update_case(
-        &self,
-        case: impl Into<crate::model::Case>,
-    ) -> super::builder::case_service::UpdateCase {
-        super::builder::case_service::UpdateCase::new(self.inner.clone()).set_case(case.into())
+    pub fn update_case(&self) -> super::builder::case_service::UpdateCase {
+        super::builder::case_service::UpdateCase::new(self.inner.clone())
     }
 
     /// Escalate a case. Escalating a case will initiate the Google Cloud Support
@@ -284,19 +265,13 @@ impl CaseService {
     /// <https://cloud.google.com/support> and look for 'Technical support
     /// escalations' in the feature list to find out which tiers are able to
     /// perform escalations.
-    pub fn escalate_case(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::case_service::EscalateCase {
-        super::builder::case_service::EscalateCase::new(self.inner.clone()).set_name(name.into())
+    pub fn escalate_case(&self) -> super::builder::case_service::EscalateCase {
+        super::builder::case_service::EscalateCase::new(self.inner.clone())
     }
 
     /// Close the specified case.
-    pub fn close_case(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::case_service::CloseCase {
-        super::builder::case_service::CloseCase::new(self.inner.clone()).set_name(name.into())
+    pub fn close_case(&self) -> super::builder::case_service::CloseCase {
+        super::builder::case_service::CloseCase::new(self.inner.clone())
     }
 
     /// Retrieve valid classifications to be used when creating a support case.
@@ -411,21 +386,13 @@ impl CommentService {
     }
 
     /// Retrieve all Comments associated with the Case object.
-    pub fn list_comments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::comment_service::ListComments {
+    pub fn list_comments(&self) -> super::builder::comment_service::ListComments {
         super::builder::comment_service::ListComments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Add a new comment to the specified Case.
     /// The comment object must have the following fields set: body.
-    pub fn create_comment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::comment_service::CreateComment {
+    pub fn create_comment(&self) -> super::builder::comment_service::CreateComment {
         super::builder::comment_service::CreateComment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CaseAttachmentService for CaseAttachmentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttachmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/attachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/attachments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,9 +97,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +123,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/cases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/cases", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -134,12 +152,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchCasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/cases:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/cases:search", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +181,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/cases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/cases", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,18 +205,15 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.case
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("case"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.case
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("case"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -208,9 +234,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:escalate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:escalate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,9 +258,16 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:close", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:close", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,12 +282,10 @@ impl super::stub::CaseService for CaseService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchCaseClassificationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v2/caseClassifications:search".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                "/v2/caseClassifications:search".to_string(),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +328,16 @@ impl super::stub::CommentService for CommentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCommentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/comments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/comments", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -311,12 +356,16 @@ impl super::stub::CommentService for CommentService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Comment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/comments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/comments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -206,10 +206,15 @@ impl super::stub::CaseService for CaseService {
     ) -> Result<gax::response::Response<crate::model::Case>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.case
+            let arg = &req
+                .case
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("case"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("case.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/talent/v4/src/client.rs
+++ b/src/generated/cloud/talent/v4/src/client.rs
@@ -119,58 +119,36 @@ impl CompanyService {
     }
 
     /// Creates a new company entity.
-    pub fn create_company(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::company_service::CreateCompany {
+    pub fn create_company(&self) -> super::builder::company_service::CreateCompany {
         super::builder::company_service::CreateCompany::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves specified company.
-    pub fn get_company(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::company_service::GetCompany {
-        super::builder::company_service::GetCompany::new(self.inner.clone()).set_name(name.into())
+    pub fn get_company(&self) -> super::builder::company_service::GetCompany {
+        super::builder::company_service::GetCompany::new(self.inner.clone())
     }
 
     /// Updates specified company.
-    pub fn update_company(
-        &self,
-        company: impl Into<crate::model::Company>,
-    ) -> super::builder::company_service::UpdateCompany {
+    pub fn update_company(&self) -> super::builder::company_service::UpdateCompany {
         super::builder::company_service::UpdateCompany::new(self.inner.clone())
-            .set_company(company.into())
     }
 
     /// Deletes specified company.
     /// Prerequisite: The company has no jobs associated with it.
-    pub fn delete_company(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::company_service::DeleteCompany {
+    pub fn delete_company(&self) -> super::builder::company_service::DeleteCompany {
         super::builder::company_service::DeleteCompany::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all companies associated with the project.
-    pub fn list_companies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::company_service::ListCompanies {
+    pub fn list_companies(&self) -> super::builder::company_service::ListCompanies {
         super::builder::company_service::ListCompanies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::company_service::GetOperation {
-        super::builder::company_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::company_service::GetOperation {
+        super::builder::company_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -276,21 +254,15 @@ impl Completion {
 
     /// Completes the specified prefix with keyword suggestions.
     /// Intended for use by a job search auto-complete search box.
-    pub fn complete_query(
-        &self,
-        tenant: impl Into<std::string::String>,
-    ) -> super::builder::completion::CompleteQuery {
-        super::builder::completion::CompleteQuery::new(self.inner.clone()).set_tenant(tenant.into())
+    pub fn complete_query(&self) -> super::builder::completion::CompleteQuery {
+        super::builder::completion::CompleteQuery::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::completion::GetOperation {
-        super::builder::completion::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::completion::GetOperation {
+        super::builder::completion::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -401,22 +373,15 @@ impl EventService {
     /// [Learn
     /// more](https://cloud.google.com/talent-solution/docs/management-tools)
     /// about self service tools.
-    pub fn create_client_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::event_service::CreateClientEvent {
+    pub fn create_client_event(&self) -> super::builder::event_service::CreateClientEvent {
         super::builder::event_service::CreateClientEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::event_service::GetOperation {
-        super::builder::event_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::event_service::GetOperation {
+        super::builder::event_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -524,11 +489,8 @@ impl JobService {
     ///
     /// Typically, the job becomes searchable within 10 seconds, but it may take
     /// up to 5 minutes.
-    pub fn create_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::CreateJob {
-        super::builder::job_service::CreateJob::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_job(&self) -> super::builder::job_service::CreateJob {
+        super::builder::job_service::CreateJob::new(self.inner.clone())
     }
 
     /// Begins executing a batch create jobs operation.
@@ -542,32 +504,22 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_create_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::BatchCreateJobs {
+    pub fn batch_create_jobs(&self) -> super::builder::job_service::BatchCreateJobs {
         super::builder::job_service::BatchCreateJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the specified job, whose status is OPEN or recently EXPIRED
     /// within the last 90 days.
-    pub fn get_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetJob {
-        super::builder::job_service::GetJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job(&self) -> super::builder::job_service::GetJob {
+        super::builder::job_service::GetJob::new(self.inner.clone())
     }
 
     /// Updates specified job.
     ///
     /// Typically, updated contents become visible in search results within 10
     /// seconds, but it may take up to 5 minutes.
-    pub fn update_job(
-        &self,
-        job: impl Into<crate::model::Job>,
-    ) -> super::builder::job_service::UpdateJob {
-        super::builder::job_service::UpdateJob::new(self.inner.clone()).set_job(job.into())
+    pub fn update_job(&self) -> super::builder::job_service::UpdateJob {
+        super::builder::job_service::UpdateJob::new(self.inner.clone())
     }
 
     /// Begins executing a batch update jobs operation.
@@ -581,23 +533,16 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_update_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::BatchUpdateJobs {
+    pub fn batch_update_jobs(&self) -> super::builder::job_service::BatchUpdateJobs {
         super::builder::job_service::BatchUpdateJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified job.
     ///
     /// Typically, the job becomes unsearchable within 10 seconds, but it may take
     /// up to 5 minutes.
-    pub fn delete_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::DeleteJob {
-        super::builder::job_service::DeleteJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_job(&self) -> super::builder::job_service::DeleteJob {
+        super::builder::job_service::DeleteJob::new(self.inner.clone())
     }
 
     /// Begins executing a batch delete jobs operation.
@@ -611,20 +556,13 @@ impl JobService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_delete_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::BatchDeleteJobs {
+    pub fn batch_delete_jobs(&self) -> super::builder::job_service::BatchDeleteJobs {
         super::builder::job_service::BatchDeleteJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists jobs by filter.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::ListJobs {
-        super::builder::job_service::ListJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_jobs(&self) -> super::builder::job_service::ListJobs {
+        super::builder::job_service::ListJobs::new(self.inner.clone())
     }
 
     /// Searches for jobs using the provided
@@ -637,11 +575,8 @@ impl JobService {
     ///
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
     /// [google.cloud.talent.v4.SearchJobsRequest]: crate::model::SearchJobsRequest
-    pub fn search_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::SearchJobs {
-        super::builder::job_service::SearchJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn search_jobs(&self) -> super::builder::job_service::SearchJobs {
+        super::builder::job_service::SearchJobs::new(self.inner.clone())
     }
 
     /// Searches for jobs using the provided
@@ -659,22 +594,15 @@ impl JobService {
     ///
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
     /// [google.cloud.talent.v4.SearchJobsRequest]: crate::model::SearchJobsRequest
-    pub fn search_jobs_for_alert(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::job_service::SearchJobsForAlert {
+    pub fn search_jobs_for_alert(&self) -> super::builder::job_service::SearchJobsForAlert {
         super::builder::job_service::SearchJobsForAlert::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::job_service::GetOperation {
-        super::builder::job_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::job_service::GetOperation {
+        super::builder::job_service::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -779,55 +707,34 @@ impl TenantService {
     }
 
     /// Creates a new tenant entity.
-    pub fn create_tenant(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tenant_service::CreateTenant {
+    pub fn create_tenant(&self) -> super::builder::tenant_service::CreateTenant {
         super::builder::tenant_service::CreateTenant::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves specified tenant.
-    pub fn get_tenant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tenant_service::GetTenant {
-        super::builder::tenant_service::GetTenant::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tenant(&self) -> super::builder::tenant_service::GetTenant {
+        super::builder::tenant_service::GetTenant::new(self.inner.clone())
     }
 
     /// Updates specified tenant.
-    pub fn update_tenant(
-        &self,
-        tenant: impl Into<crate::model::Tenant>,
-    ) -> super::builder::tenant_service::UpdateTenant {
+    pub fn update_tenant(&self) -> super::builder::tenant_service::UpdateTenant {
         super::builder::tenant_service::UpdateTenant::new(self.inner.clone())
-            .set_tenant(tenant.into())
     }
 
     /// Deletes specified tenant.
-    pub fn delete_tenant(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tenant_service::DeleteTenant {
-        super::builder::tenant_service::DeleteTenant::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tenant(&self) -> super::builder::tenant_service::DeleteTenant {
+        super::builder::tenant_service::DeleteTenant::new(self.inner.clone())
     }
 
     /// Lists all tenants associated with the project.
-    pub fn list_tenants(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tenant_service::ListTenants {
+    pub fn list_tenants(&self) -> super::builder::tenant_service::ListTenants {
         super::builder::tenant_service::ListTenants::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tenant_service::GetOperation {
-        super::builder::tenant_service::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tenant_service::GetOperation {
+        super::builder::tenant_service::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -99,10 +99,15 @@ impl super::stub::CompanyService for CompanyService {
     ) -> Result<gax::response::Response<crate::model::Company>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v4/{}", {
-            &req.company
+            let arg = &req
+                .company
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("company"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("company.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -471,10 +476,15 @@ impl super::stub::JobService for JobService {
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v4/{}", {
-            &req.job
+            let arg = &req
+                .job
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -769,10 +779,15 @@ impl super::stub::TenantService for TenantService {
     ) -> Result<gax::response::Response<crate::model::Tenant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v4/{}", {
-            &req.tenant
+            let arg = &req
+                .tenant
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tenant"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tenant.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Company>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/companies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/companies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Company>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,18 +98,15 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Company>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}", {
+            &req.company
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("company"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v4/{}",
-                    req.company
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("company"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,9 +129,16 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -144,12 +159,16 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCompaniesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}/companies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v4/{}/companies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,9 +188,16 @@ impl super::stub::CompanyService for CompanyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,12 +237,16 @@ impl super::stub::Completion for Completion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CompleteQueryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}:completeQuery", {
+            let arg = &req.tenant;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tenant"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v4/{}:completeQuery", req.tenant),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,9 +272,16 @@ impl super::stub::Completion for Completion {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -284,12 +321,16 @@ impl super::stub::EventService for EventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ClientEvent>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/clientEvents", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/clientEvents", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -306,9 +347,16 @@ impl super::stub::EventService for EventService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,9 +396,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v4/{}/jobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -365,12 +420,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/jobs:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -385,9 +444,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -404,18 +470,15 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}", {
+            &req.job
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("job"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v4/{}",
-                    req.job
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("job"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -436,12 +499,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs:batchUpdate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/jobs:batchUpdate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -456,9 +523,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -479,12 +553,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/jobs:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -499,9 +577,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -522,12 +607,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/jobs:search", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -542,12 +631,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/jobs:searchForAlert", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v4/{}/jobs:searchForAlert", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -562,9 +655,16 @@ impl super::stub::JobService for JobService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -618,9 +718,16 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tenant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}/tenants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v4/{}/tenants", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -635,9 +742,16 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tenant>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -654,18 +768,15 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tenant>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v4/{}", {
+            &req.tenant
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tenant"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v4/{}",
-                    req.tenant
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tenant"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -686,9 +797,16 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -709,9 +827,16 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTenantsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}/tenants", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}/tenants", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -730,9 +855,16 @@ impl super::stub::TenantService for TenantService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v4/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v4/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/tasks/v2/src/client.rs
+++ b/src/generated/cloud/tasks/v2/src/client.rs
@@ -122,19 +122,13 @@ impl CloudTasks {
     /// Lists queues.
     ///
     /// Queues are returned in lexicographical order.
-    pub fn list_queues(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::ListQueues {
-        super::builder::cloud_tasks::ListQueues::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_queues(&self) -> super::builder::cloud_tasks::ListQueues {
+        super::builder::cloud_tasks::ListQueues::new(self.inner.clone())
     }
 
     /// Gets a queue.
-    pub fn get_queue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::GetQueue {
-        super::builder::cloud_tasks::GetQueue::new(self.inner.clone()).set_name(name.into())
+    pub fn get_queue(&self) -> super::builder::cloud_tasks::GetQueue {
+        super::builder::cloud_tasks::GetQueue::new(self.inner.clone())
     }
 
     /// Creates a queue.
@@ -149,11 +143,8 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
-    pub fn create_queue(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::CreateQueue {
-        super::builder::cloud_tasks::CreateQueue::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_queue(&self) -> super::builder::cloud_tasks::CreateQueue {
+        super::builder::cloud_tasks::CreateQueue::new(self.inner.clone())
     }
 
     /// Updates a queue.
@@ -171,11 +162,8 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
-    pub fn update_queue(
-        &self,
-        queue: impl Into<crate::model::Queue>,
-    ) -> super::builder::cloud_tasks::UpdateQueue {
-        super::builder::cloud_tasks::UpdateQueue::new(self.inner.clone()).set_queue(queue.into())
+    pub fn update_queue(&self) -> super::builder::cloud_tasks::UpdateQueue {
+        super::builder::cloud_tasks::UpdateQueue::new(self.inner.clone())
     }
 
     /// Deletes a queue.
@@ -191,11 +179,8 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
-    pub fn delete_queue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::DeleteQueue {
-        super::builder::cloud_tasks::DeleteQueue::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_queue(&self) -> super::builder::cloud_tasks::DeleteQueue {
+        super::builder::cloud_tasks::DeleteQueue::new(self.inner.clone())
     }
 
     /// Purges a queue by deleting all of its tasks.
@@ -204,11 +189,8 @@ impl CloudTasks {
     ///
     /// Purge operations can take up to one minute to take effect. Tasks
     /// might be dispatched before the purge takes effect. A purge is irreversible.
-    pub fn purge_queue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::PurgeQueue {
-        super::builder::cloud_tasks::PurgeQueue::new(self.inner.clone()).set_name(name.into())
+    pub fn purge_queue(&self) -> super::builder::cloud_tasks::PurgeQueue {
+        super::builder::cloud_tasks::PurgeQueue::new(self.inner.clone())
     }
 
     /// Pauses the queue.
@@ -223,11 +205,8 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.CloudTasks.ResumeQueue]: crate::client::CloudTasks::resume_queue
     /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
-    pub fn pause_queue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::PauseQueue {
-        super::builder::cloud_tasks::PauseQueue::new(self.inner.clone()).set_name(name.into())
+    pub fn pause_queue(&self) -> super::builder::cloud_tasks::PauseQueue {
+        super::builder::cloud_tasks::PauseQueue::new(self.inner.clone())
     }
 
     /// Resume a queue.
@@ -249,11 +228,8 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.Queue.State.RUNNING]: crate::model::queue::State::Running
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
-    pub fn resume_queue(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::ResumeQueue {
-        super::builder::cloud_tasks::ResumeQueue::new(self.inner.clone()).set_name(name.into())
+    pub fn resume_queue(&self) -> super::builder::cloud_tasks::ResumeQueue {
+        super::builder::cloud_tasks::ResumeQueue::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -267,12 +243,8 @@ impl CloudTasks {
     /// * `cloudtasks.queues.getIamPolicy`
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::cloud_tasks::GetIamPolicy {
         super::builder::cloud_tasks::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -288,12 +260,8 @@ impl CloudTasks {
     /// * `cloudtasks.queues.setIamPolicy`
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::cloud_tasks::SetIamPolicy {
         super::builder::cloud_tasks::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on a
@@ -306,12 +274,8 @@ impl CloudTasks {
     /// may "fail open" without warning.
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::cloud_tasks::TestIamPermissions {
         super::builder::cloud_tasks::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists the tasks in a queue.
@@ -326,19 +290,13 @@ impl CloudTasks {
     ///
     /// [google.cloud.tasks.v2.ListTasksRequest.response_view]: crate::model::ListTasksRequest::response_view
     /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
-    pub fn list_tasks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::ListTasks {
-        super::builder::cloud_tasks::ListTasks::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_tasks(&self) -> super::builder::cloud_tasks::ListTasks {
+        super::builder::cloud_tasks::ListTasks::new(self.inner.clone())
     }
 
     /// Gets a task.
-    pub fn get_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::GetTask {
-        super::builder::cloud_tasks::GetTask::new(self.inner.clone()).set_name(name.into())
+    pub fn get_task(&self) -> super::builder::cloud_tasks::GetTask {
+        super::builder::cloud_tasks::GetTask::new(self.inner.clone())
     }
 
     /// Creates a task and adds it to a queue.
@@ -346,11 +304,8 @@ impl CloudTasks {
     /// Tasks cannot be updated after creation; there is no UpdateTask command.
     ///
     /// * The maximum task size is 100KB.
-    pub fn create_task(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::CreateTask {
-        super::builder::cloud_tasks::CreateTask::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_task(&self) -> super::builder::cloud_tasks::CreateTask {
+        super::builder::cloud_tasks::CreateTask::new(self.inner.clone())
     }
 
     /// Deletes a task.
@@ -358,11 +313,8 @@ impl CloudTasks {
     /// A task can be deleted if it is scheduled or dispatched. A task
     /// cannot be deleted if it has executed successfully or permanently
     /// failed.
-    pub fn delete_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::DeleteTask {
-        super::builder::cloud_tasks::DeleteTask::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_task(&self) -> super::builder::cloud_tasks::DeleteTask {
+        super::builder::cloud_tasks::DeleteTask::new(self.inner.clone())
     }
 
     /// Forces a task to run now.
@@ -397,26 +349,17 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.RateLimits]: crate::model::RateLimits
     /// [google.cloud.tasks.v2.RetryConfig]: crate::model::RetryConfig
     /// [google.cloud.tasks.v2.Task.schedule_time]: crate::model::Task::schedule_time
-    pub fn run_task(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::RunTask {
-        super::builder::cloud_tasks::RunTask::new(self.inner.clone()).set_name(name.into())
+    pub fn run_task(&self) -> super::builder::cloud_tasks::RunTask {
+        super::builder::cloud_tasks::RunTask::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::ListLocations {
-        super::builder::cloud_tasks::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::cloud_tasks::ListLocations {
+        super::builder::cloud_tasks::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_tasks::GetLocation {
-        super::builder::cloud_tasks::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::cloud_tasks::GetLocation {
+        super::builder::cloud_tasks::GetLocation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -126,10 +126,15 @@ impl super::stub::CloudTasks for CloudTasks {
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.queue
+            let arg = &req
+                .queue
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("queue"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("queue.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQueuesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/queues", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/queues", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +75,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,9 +101,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/queues", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/queues", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,18 +125,15 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.queue
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("queue"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.queue
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("queue"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,9 +154,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -159,9 +184,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:purge", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:purge", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,9 +208,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +232,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Queue>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -210,12 +256,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +280,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -250,12 +304,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -270,9 +328,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTasksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/tasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/tasks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,9 +357,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Task>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,9 +384,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Task>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/tasks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/tasks", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,9 +408,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,9 +438,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Task>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:run", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:run", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -369,9 +462,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -391,9 +491,16 @@ impl super::stub::CloudTasks for CloudTasks {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/telcoautomation/v1/src/client.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/client.rs
@@ -127,19 +127,15 @@ impl TelcoAutomation {
     /// Lists OrchestrationClusters in a given project and location.
     pub fn list_orchestration_clusters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ListOrchestrationClusters {
         super::builder::telco_automation::ListOrchestrationClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single OrchestrationCluster.
     pub fn get_orchestration_cluster(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::GetOrchestrationCluster {
         super::builder::telco_automation::GetOrchestrationCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new OrchestrationCluster in a given project and location.
@@ -155,10 +151,8 @@ impl TelcoAutomation {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_orchestration_cluster(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::CreateOrchestrationCluster {
         super::builder::telco_automation::CreateOrchestrationCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single OrchestrationCluster.
@@ -174,27 +168,18 @@ impl TelcoAutomation {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_orchestration_cluster(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::DeleteOrchestrationCluster {
         super::builder::telco_automation::DeleteOrchestrationCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists EdgeSlms in a given project and location.
-    pub fn list_edge_slms(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListEdgeSlms {
+    pub fn list_edge_slms(&self) -> super::builder::telco_automation::ListEdgeSlms {
         super::builder::telco_automation::ListEdgeSlms::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single EdgeSlm.
-    pub fn get_edge_slm(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetEdgeSlm {
-        super::builder::telco_automation::GetEdgeSlm::new(self.inner.clone()).set_name(name.into())
+    pub fn get_edge_slm(&self) -> super::builder::telco_automation::GetEdgeSlm {
+        super::builder::telco_automation::GetEdgeSlm::new(self.inner.clone())
     }
 
     /// Creates a new EdgeSlm in a given project and location.
@@ -208,12 +193,8 @@ impl TelcoAutomation {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_edge_slm(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::CreateEdgeSlm {
+    pub fn create_edge_slm(&self) -> super::builder::telco_automation::CreateEdgeSlm {
         super::builder::telco_automation::CreateEdgeSlm::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single EdgeSlm.
@@ -227,111 +208,69 @@ impl TelcoAutomation {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_edge_slm(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::DeleteEdgeSlm {
+    pub fn delete_edge_slm(&self) -> super::builder::telco_automation::DeleteEdgeSlm {
         super::builder::telco_automation::DeleteEdgeSlm::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a blueprint.
-    pub fn create_blueprint(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::CreateBlueprint {
+    pub fn create_blueprint(&self) -> super::builder::telco_automation::CreateBlueprint {
         super::builder::telco_automation::CreateBlueprint::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a blueprint.
-    pub fn update_blueprint(
-        &self,
-        blueprint: impl Into<crate::model::Blueprint>,
-    ) -> super::builder::telco_automation::UpdateBlueprint {
+    pub fn update_blueprint(&self) -> super::builder::telco_automation::UpdateBlueprint {
         super::builder::telco_automation::UpdateBlueprint::new(self.inner.clone())
-            .set_blueprint(blueprint.into())
     }
 
     /// Returns the requested blueprint.
-    pub fn get_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetBlueprint {
+    pub fn get_blueprint(&self) -> super::builder::telco_automation::GetBlueprint {
         super::builder::telco_automation::GetBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a blueprint and all its revisions.
-    pub fn delete_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::DeleteBlueprint {
+    pub fn delete_blueprint(&self) -> super::builder::telco_automation::DeleteBlueprint {
         super::builder::telco_automation::DeleteBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List all blueprints.
-    pub fn list_blueprints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListBlueprints {
+    pub fn list_blueprints(&self) -> super::builder::telco_automation::ListBlueprints {
         super::builder::telco_automation::ListBlueprints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Approves a blueprint and commits a new revision.
-    pub fn approve_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ApproveBlueprint {
+    pub fn approve_blueprint(&self) -> super::builder::telco_automation::ApproveBlueprint {
         super::builder::telco_automation::ApproveBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Proposes a blueprint for approval of changes.
-    pub fn propose_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ProposeBlueprint {
+    pub fn propose_blueprint(&self) -> super::builder::telco_automation::ProposeBlueprint {
         super::builder::telco_automation::ProposeBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rejects a blueprint revision proposal and flips it back to Draft state.
-    pub fn reject_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::RejectBlueprint {
+    pub fn reject_blueprint(&self) -> super::builder::telco_automation::RejectBlueprint {
         super::builder::telco_automation::RejectBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List blueprint revisions of a given blueprint.
     pub fn list_blueprint_revisions(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ListBlueprintRevisions {
         super::builder::telco_automation::ListBlueprintRevisions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Searches across blueprint revisions.
     pub fn search_blueprint_revisions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::SearchBlueprintRevisions {
         super::builder::telco_automation::SearchBlueprintRevisions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Searches across deployment revisions.
     pub fn search_deployment_revisions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::SearchDeploymentRevisions {
         super::builder::telco_automation::SearchDeploymentRevisions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Discards the changes in a blueprint and reverts the blueprint to the last
@@ -339,84 +278,52 @@ impl TelcoAutomation {
     /// have revisions.
     pub fn discard_blueprint_changes(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::DiscardBlueprintChanges {
         super::builder::telco_automation::DiscardBlueprintChanges::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the blueprints in TNA's public catalog. Default page size = 20,
     /// Max Page Size = 100.
-    pub fn list_public_blueprints(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListPublicBlueprints {
+    pub fn list_public_blueprints(&self) -> super::builder::telco_automation::ListPublicBlueprints {
         super::builder::telco_automation::ListPublicBlueprints::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the requested public blueprint.
-    pub fn get_public_blueprint(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetPublicBlueprint {
+    pub fn get_public_blueprint(&self) -> super::builder::telco_automation::GetPublicBlueprint {
         super::builder::telco_automation::GetPublicBlueprint::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a deployment.
-    pub fn create_deployment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::CreateDeployment {
+    pub fn create_deployment(&self) -> super::builder::telco_automation::CreateDeployment {
         super::builder::telco_automation::CreateDeployment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a deployment.
-    pub fn update_deployment(
-        &self,
-        deployment: impl Into<crate::model::Deployment>,
-    ) -> super::builder::telco_automation::UpdateDeployment {
+    pub fn update_deployment(&self) -> super::builder::telco_automation::UpdateDeployment {
         super::builder::telco_automation::UpdateDeployment::new(self.inner.clone())
-            .set_deployment(deployment.into())
     }
 
     /// Returns the requested deployment.
-    pub fn get_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetDeployment {
+    pub fn get_deployment(&self) -> super::builder::telco_automation::GetDeployment {
         super::builder::telco_automation::GetDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Removes the deployment by marking it as DELETING. Post which deployment and
     /// it's revisions gets deleted.
-    pub fn remove_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::RemoveDeployment {
+    pub fn remove_deployment(&self) -> super::builder::telco_automation::RemoveDeployment {
         super::builder::telco_automation::RemoveDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List all deployments.
-    pub fn list_deployments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListDeployments {
+    pub fn list_deployments(&self) -> super::builder::telco_automation::ListDeployments {
         super::builder::telco_automation::ListDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List deployment revisions of a given deployment.
     pub fn list_deployment_revisions(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ListDeploymentRevisions {
         super::builder::telco_automation::ListDeploymentRevisions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Discards the changes in a deployment and reverts the deployment to the last
@@ -424,134 +331,91 @@ impl TelcoAutomation {
     /// not have revisions.
     pub fn discard_deployment_changes(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::DiscardDeploymentChanges {
         super::builder::telco_automation::DiscardDeploymentChanges::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Applies the deployment's YAML files to the parent orchestration cluster.
-    pub fn apply_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ApplyDeployment {
+    pub fn apply_deployment(&self) -> super::builder::telco_automation::ApplyDeployment {
         super::builder::telco_automation::ApplyDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the requested deployment status.
     pub fn compute_deployment_status(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ComputeDeploymentStatus {
         super::builder::telco_automation::ComputeDeploymentStatus::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rollback the active deployment to the given past approved deployment
     /// revision.
-    pub fn rollback_deployment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::RollbackDeployment {
+    pub fn rollback_deployment(&self) -> super::builder::telco_automation::RollbackDeployment {
         super::builder::telco_automation::RollbackDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the requested hydrated deployment.
     pub fn get_hydrated_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::GetHydratedDeployment {
         super::builder::telco_automation::GetHydratedDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List all hydrated deployments present under a deployment.
     pub fn list_hydrated_deployments(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ListHydratedDeployments {
         super::builder::telco_automation::ListHydratedDeployments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a hydrated deployment.
     pub fn update_hydrated_deployment(
         &self,
-        hydrated_deployment: impl Into<crate::model::HydratedDeployment>,
     ) -> super::builder::telco_automation::UpdateHydratedDeployment {
         super::builder::telco_automation::UpdateHydratedDeployment::new(self.inner.clone())
-            .set_hydrated_deployment(hydrated_deployment.into())
     }
 
     /// Applies a hydrated deployment to a workload cluster.
     pub fn apply_hydrated_deployment(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::telco_automation::ApplyHydratedDeployment {
         super::builder::telco_automation::ApplyHydratedDeployment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListLocations {
+    pub fn list_locations(&self) -> super::builder::telco_automation::ListLocations {
         super::builder::telco_automation::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetLocation {
-        super::builder::telco_automation::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::telco_automation::GetLocation {
+        super::builder::telco_automation::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::ListOperations {
+    pub fn list_operations(&self) -> super::builder::telco_automation::ListOperations {
         super::builder::telco_automation::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::GetOperation {
+    pub fn get_operation(&self) -> super::builder::telco_automation::GetOperation {
         super::builder::telco_automation::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::telco_automation::DeleteOperation {
         super::builder::telco_automation::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::telco_automation::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::telco_automation::CancelOperation {
         super::builder::telco_automation::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -296,10 +296,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.blueprint
+            let arg = &req
+                .blueprint
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("blueprint"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("blueprint.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -676,10 +681,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.deployment
+            let arg = &req
+                .deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -972,10 +982,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
     ) -> Result<gax::response::Response<crate::model::HydratedDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.hydrated_deployment
+            let arg = &req
+                .hydrated_deployment
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("hydrated_deployment"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("hydrated_deployment.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOrchestrationClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/orchestrationClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/orchestrationClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::OrchestrationCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/orchestrationClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/orchestrationClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,9 +130,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +157,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEdgeSlmsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/edgeSlms", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/edgeSlms", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -158,9 +187,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EdgeSlm>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -177,12 +213,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/edgeSlms", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/edgeSlms", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -201,9 +241,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -221,12 +268,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/blueprints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/blueprints", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -244,18 +295,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.blueprint
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("blueprint"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.blueprint
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("blueprint"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -278,9 +326,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,9 +353,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -321,12 +383,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBlueprintsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/blueprints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/blueprints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -346,9 +412,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:approve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -363,9 +436,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:propose", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:propose", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -380,9 +460,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:reject", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:reject", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,12 +484,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBlueprintRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,12 +512,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchBlueprintRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/blueprints:searchRevisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/blueprints:searchRevisions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -446,12 +541,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchDeploymentRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments:searchRevisions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments:searchRevisions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,9 +570,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscardBlueprintChangesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:discard", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:discard", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -488,12 +594,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPublicBlueprintsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/publicBlueprints", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/publicBlueprints", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -512,9 +622,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PublicBlueprint>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -531,12 +648,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -554,18 +675,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -588,9 +706,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -608,9 +733,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:remove", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:remove", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,12 +762,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/deployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/deployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -655,12 +791,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeploymentRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -679,9 +819,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscardDeploymentChangesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:discard", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:discard", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -696,9 +843,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:apply", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -713,12 +867,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ComputeDeploymentStatusResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:computeDeploymentStatus", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:computeDeploymentStatus", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -735,9 +893,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Deployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rollback", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -752,9 +917,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HydratedDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -771,12 +943,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHydratedDeploymentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/hydratedDeployments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/hydratedDeployments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,18 +971,15 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HydratedDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.hydrated_deployment
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("hydrated_deployment"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.hydrated_deployment
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("hydrated_deployment"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -829,9 +1002,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HydratedDeployment>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:apply", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:apply", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -846,9 +1026,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -868,9 +1055,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -887,9 +1081,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -909,9 +1110,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -928,9 +1136,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -951,9 +1166,16 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/texttospeech/v1/src/client.rs
+++ b/src/generated/cloud/texttospeech/v1/src/client.rs
@@ -132,22 +132,15 @@ impl TextToSpeech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::text_to_speech::ListOperations {
+    pub fn list_operations(&self) -> super::builder::text_to_speech::ListOperations {
         super::builder::text_to_speech::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::text_to_speech::GetOperation {
-        super::builder::text_to_speech::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::text_to_speech::GetOperation {
+        super::builder::text_to_speech::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -266,12 +259,10 @@ impl TextToSpeechLongAudioSynthesize {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn synthesize_long_audio(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::text_to_speech_long_audio_synthesize::SynthesizeLongAudio {
         super::builder::text_to_speech_long_audio_synthesize::SynthesizeLongAudio::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -279,12 +270,10 @@ impl TextToSpeechLongAudioSynthesize {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn list_operations(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::text_to_speech_long_audio_synthesize::ListOperations {
         super::builder::text_to_speech_long_audio_synthesize::ListOperations::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -292,9 +281,7 @@ impl TextToSpeechLongAudioSynthesize {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::text_to_speech_long_audio_synthesize::GetOperation {
         super::builder::text_to_speech_long_audio_synthesize::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/texttospeech/v1/src/transport.rs
+++ b/src/generated/cloud/texttospeech/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::TextToSpeech for TextToSpeech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVoicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/voices".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/voices".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +67,10 @@ impl super::stub::TextToSpeech for TextToSpeech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SynthesizeSpeechResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/text:synthesize".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/text:synthesize".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -83,9 +85,16 @@ impl super::stub::TextToSpeech for TextToSpeech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,9 +114,16 @@ impl super::stub::TextToSpeech for TextToSpeech {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -147,12 +163,16 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:synthesizeLongAudio", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:synthesizeLongAudio", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -167,9 +187,16 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -189,9 +216,16 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/timeseriesinsights/v1/src/client.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/client.rs
@@ -126,12 +126,8 @@ impl TimeseriesInsightsController {
     /// of this list.
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn list_data_sets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::ListDataSets {
+    pub fn list_data_sets(&self) -> super::builder::timeseries_insights_controller::ListDataSets {
         super::builder::timeseries_insights_controller::ListDataSets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a [DataSet][google.cloud.timeseriesinsights.v1.DataSet] from data stored on Cloud
@@ -142,12 +138,8 @@ impl TimeseriesInsightsController {
     /// might result.  For more information, see [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn create_data_set(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::CreateDataSet {
+    pub fn create_data_set(&self) -> super::builder::timeseries_insights_controller::CreateDataSet {
         super::builder::timeseries_insights_controller::CreateDataSet::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete a [DataSet][google.cloud.timeseriesinsights.v1.DataSet] from the system.
@@ -156,54 +148,36 @@ impl TimeseriesInsightsController {
     /// processed, it will be aborted and deleted.
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn delete_data_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::DeleteDataSet {
+    pub fn delete_data_set(&self) -> super::builder::timeseries_insights_controller::DeleteDataSet {
         super::builder::timeseries_insights_controller::DeleteDataSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Append events to a `LOADED` [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn append_events(
-        &self,
-        dataset: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::AppendEvents {
+    pub fn append_events(&self) -> super::builder::timeseries_insights_controller::AppendEvents {
         super::builder::timeseries_insights_controller::AppendEvents::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Execute a Timeseries Insights query over a loaded
     /// [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn query_data_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::QueryDataSet {
+    pub fn query_data_set(&self) -> super::builder::timeseries_insights_controller::QueryDataSet {
         super::builder::timeseries_insights_controller::QueryDataSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Evaluate an explicit slice from a loaded [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
-    pub fn evaluate_slice(
-        &self,
-        dataset: impl Into<std::string::String>,
-    ) -> super::builder::timeseries_insights_controller::EvaluateSlice {
+    pub fn evaluate_slice(&self) -> super::builder::timeseries_insights_controller::EvaluateSlice {
         super::builder::timeseries_insights_controller::EvaluateSlice::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Evaluate an explicit timeseries.
     pub fn evaluate_timeseries(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::timeseries_insights_controller::EvaluateTimeseries {
         super::builder::timeseries_insights_controller::EvaluateTimeseries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDataSetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/datasets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,12 +74,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DataSet>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,9 +100,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,12 +130,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AppendEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:appendEvents", {
+            let arg = &req.dataset;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:appendEvents", req.dataset),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -132,9 +154,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryDataSetResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:query", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:query", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,12 +178,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EvaluatedSlice>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:evaluateSlice", {
+            let arg = &req.dataset;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:evaluateSlice", req.dataset),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +202,16 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EvaluatedSlice>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datasets:evaluateTimeseries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datasets:evaluateTimeseries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/tpu/v2/src/client.rs
+++ b/src/generated/cloud/tpu/v2/src/client.rs
@@ -119,16 +119,13 @@ impl Tpu {
     }
 
     /// Lists nodes.
-    pub fn list_nodes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListNodes {
-        super::builder::tpu::ListNodes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_nodes(&self) -> super::builder::tpu::ListNodes {
+        super::builder::tpu::ListNodes::new(self.inner.clone())
     }
 
     /// Gets the details of a node.
-    pub fn get_node(&self, name: impl Into<std::string::String>) -> super::builder::tpu::GetNode {
-        super::builder::tpu::GetNode::new(self.inner.clone()).set_name(name.into())
+    pub fn get_node(&self) -> super::builder::tpu::GetNode {
+        super::builder::tpu::GetNode::new(self.inner.clone())
     }
 
     /// Creates a node.
@@ -142,11 +139,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_node(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::CreateNode {
-        super::builder::tpu::CreateNode::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_node(&self) -> super::builder::tpu::CreateNode {
+        super::builder::tpu::CreateNode::new(self.inner.clone())
     }
 
     /// Deletes a node.
@@ -160,11 +154,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_node(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::DeleteNode {
-        super::builder::tpu::DeleteNode::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_node(&self) -> super::builder::tpu::DeleteNode {
+        super::builder::tpu::DeleteNode::new(self.inner.clone())
     }
 
     /// Stops a node. This operation is only available with single TPU nodes.
@@ -178,8 +169,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_node(&self, name: impl Into<std::string::String>) -> super::builder::tpu::StopNode {
-        super::builder::tpu::StopNode::new(self.inner.clone()).set_name(name.into())
+    pub fn stop_node(&self) -> super::builder::tpu::StopNode {
+        super::builder::tpu::StopNode::new(self.inner.clone())
     }
 
     /// Starts a node.
@@ -193,11 +184,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_node(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::StartNode {
-        super::builder::tpu::StartNode::new(self.inner.clone()).set_name(name.into())
+    pub fn start_node(&self) -> super::builder::tpu::StartNode {
+        super::builder::tpu::StartNode::new(self.inner.clone())
     }
 
     /// Updates the configurations of a node.
@@ -211,27 +199,18 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_node(
-        &self,
-        node: impl Into<crate::model::Node>,
-    ) -> super::builder::tpu::UpdateNode {
-        super::builder::tpu::UpdateNode::new(self.inner.clone()).set_node(node.into())
+    pub fn update_node(&self) -> super::builder::tpu::UpdateNode {
+        super::builder::tpu::UpdateNode::new(self.inner.clone())
     }
 
     /// Lists queued resources.
-    pub fn list_queued_resources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListQueuedResources {
-        super::builder::tpu::ListQueuedResources::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_queued_resources(&self) -> super::builder::tpu::ListQueuedResources {
+        super::builder::tpu::ListQueuedResources::new(self.inner.clone())
     }
 
     /// Gets details of a queued resource.
-    pub fn get_queued_resource(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetQueuedResource {
-        super::builder::tpu::GetQueuedResource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_queued_resource(&self) -> super::builder::tpu::GetQueuedResource {
+        super::builder::tpu::GetQueuedResource::new(self.inner.clone())
     }
 
     /// Creates a QueuedResource TPU instance.
@@ -245,11 +224,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_queued_resource(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::CreateQueuedResource {
-        super::builder::tpu::CreateQueuedResource::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_queued_resource(&self) -> super::builder::tpu::CreateQueuedResource {
+        super::builder::tpu::CreateQueuedResource::new(self.inner.clone())
     }
 
     /// Deletes a QueuedResource TPU instance.
@@ -263,11 +239,8 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_queued_resource(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::DeleteQueuedResource {
-        super::builder::tpu::DeleteQueuedResource::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_queued_resource(&self) -> super::builder::tpu::DeleteQueuedResource {
+        super::builder::tpu::DeleteQueuedResource::new(self.inner.clone())
     }
 
     /// Resets a QueuedResource TPU instance
@@ -281,115 +254,75 @@ impl Tpu {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reset_queued_resource(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ResetQueuedResource {
-        super::builder::tpu::ResetQueuedResource::new(self.inner.clone()).set_name(name.into())
+    pub fn reset_queued_resource(&self) -> super::builder::tpu::ResetQueuedResource {
+        super::builder::tpu::ResetQueuedResource::new(self.inner.clone())
     }
 
     /// Generates the Cloud TPU service identity for the project.
-    pub fn generate_service_identity(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GenerateServiceIdentity {
+    pub fn generate_service_identity(&self) -> super::builder::tpu::GenerateServiceIdentity {
         super::builder::tpu::GenerateServiceIdentity::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists accelerator types supported by this API.
-    pub fn list_accelerator_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListAcceleratorTypes {
-        super::builder::tpu::ListAcceleratorTypes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_accelerator_types(&self) -> super::builder::tpu::ListAcceleratorTypes {
+        super::builder::tpu::ListAcceleratorTypes::new(self.inner.clone())
     }
 
     /// Gets AcceleratorType.
-    pub fn get_accelerator_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetAcceleratorType {
-        super::builder::tpu::GetAcceleratorType::new(self.inner.clone()).set_name(name.into())
+    pub fn get_accelerator_type(&self) -> super::builder::tpu::GetAcceleratorType {
+        super::builder::tpu::GetAcceleratorType::new(self.inner.clone())
     }
 
     /// Lists runtime versions supported by this API.
-    pub fn list_runtime_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListRuntimeVersions {
-        super::builder::tpu::ListRuntimeVersions::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_runtime_versions(&self) -> super::builder::tpu::ListRuntimeVersions {
+        super::builder::tpu::ListRuntimeVersions::new(self.inner.clone())
     }
 
     /// Gets a runtime version.
-    pub fn get_runtime_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetRuntimeVersion {
-        super::builder::tpu::GetRuntimeVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_runtime_version(&self) -> super::builder::tpu::GetRuntimeVersion {
+        super::builder::tpu::GetRuntimeVersion::new(self.inner.clone())
     }
 
     /// Retrieves the guest attributes for the node.
-    pub fn get_guest_attributes(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetGuestAttributes {
-        super::builder::tpu::GetGuestAttributes::new(self.inner.clone()).set_name(name.into())
+    pub fn get_guest_attributes(&self) -> super::builder::tpu::GetGuestAttributes {
+        super::builder::tpu::GetGuestAttributes::new(self.inner.clone())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListLocations {
-        super::builder::tpu::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::tpu::ListLocations {
+        super::builder::tpu::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetLocation {
-        super::builder::tpu::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::tpu::GetLocation {
+        super::builder::tpu::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::ListOperations {
-        super::builder::tpu::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::tpu::ListOperations {
+        super::builder::tpu::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::GetOperation {
-        super::builder::tpu::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::tpu::GetOperation {
+        super::builder::tpu::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::DeleteOperation {
-        super::builder::tpu::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::tpu::DeleteOperation {
+        super::builder::tpu::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::tpu::CancelOperation {
-        super::builder::tpu::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::tpu::CancelOperation {
+        super::builder::tpu::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -44,9 +44,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNodesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/nodes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/nodes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,9 +72,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Node>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -84,9 +98,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/nodes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/nodes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -102,9 +123,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -121,9 +149,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -138,9 +173,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,18 +197,15 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.node
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("node"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.node
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("node"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -187,12 +226,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListQueuedResourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/queuedResources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/queuedResources", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,9 +254,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueuedResource>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +280,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/queuedResources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/queuedResources", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,9 +308,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,9 +336,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:reset", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:reset", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -292,12 +360,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateServiceIdentityResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:generateServiceIdentity", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:generateServiceIdentity", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,12 +384,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAcceleratorTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/acceleratorTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/acceleratorTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,9 +414,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AcceleratorType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,12 +440,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRuntimeVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/runtimeVersions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/runtimeVersions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -383,9 +470,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RuntimeVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,12 +496,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetGuestAttributesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:getGuestAttributes", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:getGuestAttributes", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,9 +520,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -444,9 +549,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,9 +575,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,9 +604,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,9 +630,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -527,9 +660,16 @@ impl super::stub::Tpu for Tpu {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -198,10 +198,15 @@ impl super::stub::Tpu for Tpu {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.node
+            let arg = &req
+                .node
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("node"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("node.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/translate/v3/src/client.rs
+++ b/src/generated/cloud/translate/v3/src/client.rs
@@ -121,48 +121,30 @@ impl TranslationService {
     }
 
     /// Translates input text and returns translated text.
-    pub fn translate_text(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::TranslateText {
+    pub fn translate_text(&self) -> super::builder::translation_service::TranslateText {
         super::builder::translation_service::TranslateText::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Romanize input text written in non-Latin scripts to Latin text.
-    pub fn romanize_text(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::RomanizeText {
+    pub fn romanize_text(&self) -> super::builder::translation_service::RomanizeText {
         super::builder::translation_service::RomanizeText::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Detects the language of text within a request.
-    pub fn detect_language(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::DetectLanguage {
+    pub fn detect_language(&self) -> super::builder::translation_service::DetectLanguage {
         super::builder::translation_service::DetectLanguage::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a list of supported languages for translation.
     pub fn get_supported_languages(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::GetSupportedLanguages {
         super::builder::translation_service::GetSupportedLanguages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Translates documents in synchronous mode.
-    pub fn translate_document(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::TranslateDocument {
+    pub fn translate_document(&self) -> super::builder::translation_service::TranslateDocument {
         super::builder::translation_service::TranslateDocument::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Translates a large volume of text in asynchronous batch mode.
@@ -182,12 +164,8 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_translate_text(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::BatchTranslateText {
+    pub fn batch_translate_text(&self) -> super::builder::translation_service::BatchTranslateText {
         super::builder::translation_service::BatchTranslateText::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Translates a large volume of document in asynchronous batch mode.
@@ -209,10 +187,8 @@ impl TranslationService {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_translate_document(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::BatchTranslateDocument {
         super::builder::translation_service::BatchTranslateDocument::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a glossary and returns the long-running operation. Returns
@@ -227,12 +203,8 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_glossary(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::CreateGlossary {
+    pub fn create_glossary(&self) -> super::builder::translation_service::CreateGlossary {
         super::builder::translation_service::CreateGlossary::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a glossary. A LRO is used since the update can be async if the
@@ -247,32 +219,20 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_glossary(
-        &self,
-        glossary: impl Into<crate::model::Glossary>,
-    ) -> super::builder::translation_service::UpdateGlossary {
+    pub fn update_glossary(&self) -> super::builder::translation_service::UpdateGlossary {
         super::builder::translation_service::UpdateGlossary::new(self.inner.clone())
-            .set_glossary(glossary.into())
     }
 
     /// Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
     /// exist.
-    pub fn list_glossaries(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListGlossaries {
+    pub fn list_glossaries(&self) -> super::builder::translation_service::ListGlossaries {
         super::builder::translation_service::ListGlossaries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
     /// exist.
-    pub fn get_glossary(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetGlossary {
+    pub fn get_glossary(&self) -> super::builder::translation_service::GetGlossary {
         super::builder::translation_service::GetGlossary::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a glossary, or cancels glossary construction
@@ -288,57 +248,41 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_glossary(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::DeleteGlossary {
+    pub fn delete_glossary(&self) -> super::builder::translation_service::DeleteGlossary {
         super::builder::translation_service::DeleteGlossary::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a single glossary entry by the given id.
-    pub fn get_glossary_entry(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetGlossaryEntry {
+    pub fn get_glossary_entry(&self) -> super::builder::translation_service::GetGlossaryEntry {
         super::builder::translation_service::GetGlossaryEntry::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List the entries for the glossary.
     pub fn list_glossary_entries(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::ListGlossaryEntries {
         super::builder::translation_service::ListGlossaryEntries::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a glossary entry.
     pub fn create_glossary_entry(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::CreateGlossaryEntry {
         super::builder::translation_service::CreateGlossaryEntry::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a glossary entry.
     pub fn update_glossary_entry(
         &self,
-        glossary_entry: impl Into<crate::model::GlossaryEntry>,
     ) -> super::builder::translation_service::UpdateGlossaryEntry {
         super::builder::translation_service::UpdateGlossaryEntry::new(self.inner.clone())
-            .set_glossary_entry(glossary_entry.into())
     }
 
     /// Deletes a single entry from the glossary
     pub fn delete_glossary_entry(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::translation_service::DeleteGlossaryEntry {
         super::builder::translation_service::DeleteGlossaryEntry::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Dataset.
@@ -352,30 +296,18 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_dataset(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::CreateDataset {
+    pub fn create_dataset(&self) -> super::builder::translation_service::CreateDataset {
         super::builder::translation_service::CreateDataset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Dataset.
-    pub fn get_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetDataset {
+    pub fn get_dataset(&self) -> super::builder::translation_service::GetDataset {
         super::builder::translation_service::GetDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists datasets.
-    pub fn list_datasets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListDatasets {
+    pub fn list_datasets(&self) -> super::builder::translation_service::ListDatasets {
         super::builder::translation_service::ListDatasets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a dataset and all of its contents.
@@ -389,104 +321,78 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_dataset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::DeleteDataset {
+    pub fn delete_dataset(&self) -> super::builder::translation_service::DeleteDataset {
         super::builder::translation_service::DeleteDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an Adaptive MT dataset.
     pub fn create_adaptive_mt_dataset(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::CreateAdaptiveMtDataset {
         super::builder::translation_service::CreateAdaptiveMtDataset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an Adaptive MT dataset, including all its entries and associated
     /// metadata.
     pub fn delete_adaptive_mt_dataset(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::translation_service::DeleteAdaptiveMtDataset {
         super::builder::translation_service::DeleteAdaptiveMtDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the Adaptive MT dataset.
     pub fn get_adaptive_mt_dataset(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::translation_service::GetAdaptiveMtDataset {
         super::builder::translation_service::GetAdaptiveMtDataset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all Adaptive MT datasets for which the caller has read permission.
     pub fn list_adaptive_mt_datasets(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::ListAdaptiveMtDatasets {
         super::builder::translation_service::ListAdaptiveMtDatasets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Translate text using Adaptive MT.
     pub fn adaptive_mt_translate(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::AdaptiveMtTranslate {
         super::builder::translation_service::AdaptiveMtTranslate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets and AdaptiveMtFile
-    pub fn get_adaptive_mt_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetAdaptiveMtFile {
+    pub fn get_adaptive_mt_file(&self) -> super::builder::translation_service::GetAdaptiveMtFile {
         super::builder::translation_service::GetAdaptiveMtFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an AdaptiveMtFile along with its sentences.
     pub fn delete_adaptive_mt_file(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::translation_service::DeleteAdaptiveMtFile {
         super::builder::translation_service::DeleteAdaptiveMtFile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports an AdaptiveMtFile and adds all of its sentences into the
     /// AdaptiveMtDataset.
     pub fn import_adaptive_mt_file(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::ImportAdaptiveMtFile {
         super::builder::translation_service::ImportAdaptiveMtFile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all AdaptiveMtFiles associated to an AdaptiveMtDataset.
     pub fn list_adaptive_mt_files(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::ListAdaptiveMtFiles {
         super::builder::translation_service::ListAdaptiveMtFiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all AdaptiveMtSentences under a given file/dataset.
     pub fn list_adaptive_mt_sentences(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::translation_service::ListAdaptiveMtSentences {
         super::builder::translation_service::ListAdaptiveMtSentences::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Import sentence pairs into translation Dataset.
@@ -500,12 +406,8 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_data(
-        &self,
-        dataset: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ImportData {
+    pub fn import_data(&self) -> super::builder::translation_service::ImportData {
         super::builder::translation_service::ImportData::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Exports dataset's data to the provided output location.
@@ -519,21 +421,13 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_data(
-        &self,
-        dataset: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ExportData {
+    pub fn export_data(&self) -> super::builder::translation_service::ExportData {
         super::builder::translation_service::ExportData::new(self.inner.clone())
-            .set_dataset(dataset.into())
     }
 
     /// Lists sentence pairs in the dataset.
-    pub fn list_examples(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListExamples {
+    pub fn list_examples(&self) -> super::builder::translation_service::ListExamples {
         super::builder::translation_service::ListExamples::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a Model.
@@ -547,29 +441,18 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_model(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::CreateModel {
+    pub fn create_model(&self) -> super::builder::translation_service::CreateModel {
         super::builder::translation_service::CreateModel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists models.
-    pub fn list_models(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListModels {
+    pub fn list_models(&self) -> super::builder::translation_service::ListModels {
         super::builder::translation_service::ListModels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a model.
-    pub fn get_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetModel {
-        super::builder::translation_service::GetModel::new(self.inner.clone()).set_name(name.into())
+    pub fn get_model(&self) -> super::builder::translation_service::GetModel {
+        super::builder::translation_service::GetModel::new(self.inner.clone())
     }
 
     /// Deletes a model.
@@ -583,84 +466,52 @@ impl TranslationService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_model(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::DeleteModel {
+    pub fn delete_model(&self) -> super::builder::translation_service::DeleteModel {
         super::builder::translation_service::DeleteModel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::translation_service::ListLocations {
         super::builder::translation_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::translation_service::GetLocation {
         super::builder::translation_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::translation_service::ListOperations {
         super::builder::translation_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::translation_service::GetOperation {
         super::builder::translation_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::translation_service::DeleteOperation {
         super::builder::translation_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::translation_service::CancelOperation {
         super::builder::translation_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn wait_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::translation_service::WaitOperation {
+    pub fn wait_operation(&self) -> super::builder::translation_service::WaitOperation {
         super::builder::translation_service::WaitOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -245,10 +245,15 @@ impl super::stub::TranslationService for TranslationService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.glossary
+            let arg = &req
+                .glossary
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("glossary"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("glossary.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -437,10 +442,15 @@ impl super::stub::TranslationService for TranslationService {
     ) -> Result<gax::response::Response<crate::model::GlossaryEntry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.glossary_entry
+            let arg = &req
+                .glossary_entry
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("glossary_entry"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("glossary_entry.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TranslateTextResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:translateText", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:translateText", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RomanizeTextResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:romanizeText", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:romanizeText", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DetectLanguageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:detectLanguage", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:detectLanguage", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +118,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SupportedLanguages>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/supportedLanguages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/supportedLanguages", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -130,12 +146,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TranslateDocumentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:translateDocument", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:translateDocument", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,12 +170,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:batchTranslateText", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:batchTranslateText", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,12 +194,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:batchTranslateDocument", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:batchTranslateDocument", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,12 +218,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/glossaries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/glossaries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,18 +244,15 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.glossary
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("glossary"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.glossary
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("glossary"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -246,12 +275,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGlossariesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/glossaries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/glossaries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -271,9 +304,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Glossary>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +330,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -309,9 +356,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GlossaryEntry>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -328,12 +382,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGlossaryEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/glossaryEntries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/glossaryEntries", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -352,12 +410,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GlossaryEntry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/glossaryEntries", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/glossaryEntries", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -374,18 +436,15 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GlossaryEntry>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.glossary_entry
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("glossary_entry"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.glossary_entry
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("glossary_entry"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,9 +461,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -425,12 +491,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/datasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,9 +517,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -466,9 +543,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatasetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/datasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/datasets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -487,9 +571,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -506,12 +597,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AdaptiveMtDataset>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/adaptiveMtDatasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/adaptiveMtDatasets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -528,9 +623,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -551,9 +653,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AdaptiveMtDataset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -570,12 +679,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAdaptiveMtDatasetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/adaptiveMtDatasets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/adaptiveMtDatasets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -595,12 +708,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AdaptiveMtTranslateResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:adaptiveMtTranslate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:adaptiveMtTranslate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -615,9 +732,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AdaptiveMtFile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -634,9 +758,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -657,12 +788,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ImportAdaptiveMtFileResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:importAdaptiveMtFile", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:importAdaptiveMtFile", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -677,12 +812,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAdaptiveMtFilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/adaptiveMtFiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/adaptiveMtFiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,12 +840,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAdaptiveMtSentencesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/adaptiveMtSentences", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/adaptiveMtSentences", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -725,12 +868,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:importData", {
+            let arg = &req.dataset;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:importData", req.dataset),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -745,12 +892,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:exportData", {
+            let arg = &req.dataset;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dataset"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:exportData", req.dataset),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -765,9 +916,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExamplesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/examples", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/examples", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -787,9 +945,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/models", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -804,9 +969,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListModelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/models", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/models", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -826,9 +998,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Model>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -845,9 +1024,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -864,9 +1050,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -886,9 +1079,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -905,9 +1105,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -927,9 +1134,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -946,9 +1160,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -969,9 +1190,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -991,9 +1219,16 @@ impl super::stub::TranslationService for TranslationService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:wait", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:wait", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/video/livestream/v1/src/client.rs
+++ b/src/generated/cloud/video/livestream/v1/src/client.rs
@@ -136,30 +136,18 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_channel(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CreateChannel {
+    pub fn create_channel(&self) -> super::builder::livestream_service::CreateChannel {
         super::builder::livestream_service::CreateChannel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a list of all channels in the specified region.
-    pub fn list_channels(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListChannels {
+    pub fn list_channels(&self) -> super::builder::livestream_service::ListChannels {
         super::builder::livestream_service::ListChannels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified channel.
-    pub fn get_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetChannel {
+    pub fn get_channel(&self) -> super::builder::livestream_service::GetChannel {
         super::builder::livestream_service::GetChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified channel.
@@ -173,12 +161,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteChannel {
+    pub fn delete_channel(&self) -> super::builder::livestream_service::DeleteChannel {
         super::builder::livestream_service::DeleteChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified channel.
@@ -192,12 +176,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_channel(
-        &self,
-        channel: impl Into<crate::model::Channel>,
-    ) -> super::builder::livestream_service::UpdateChannel {
+    pub fn update_channel(&self) -> super::builder::livestream_service::UpdateChannel {
         super::builder::livestream_service::UpdateChannel::new(self.inner.clone())
-            .set_channel(channel.into())
     }
 
     /// Starts the specified channel. Part of the video pipeline will be created
@@ -212,12 +192,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::StartChannel {
+    pub fn start_channel(&self) -> super::builder::livestream_service::StartChannel {
         super::builder::livestream_service::StartChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stops the specified channel. Part of the video pipeline will be released
@@ -232,12 +208,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_channel(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::StopChannel {
+    pub fn stop_channel(&self) -> super::builder::livestream_service::StopChannel {
         super::builder::livestream_service::StopChannel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an input with the provided unique ID in the specified region.
@@ -251,29 +223,18 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_input(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CreateInput {
+    pub fn create_input(&self) -> super::builder::livestream_service::CreateInput {
         super::builder::livestream_service::CreateInput::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a list of all inputs in the specified region.
-    pub fn list_inputs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListInputs {
+    pub fn list_inputs(&self) -> super::builder::livestream_service::ListInputs {
         super::builder::livestream_service::ListInputs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified input.
-    pub fn get_input(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetInput {
-        super::builder::livestream_service::GetInput::new(self.inner.clone()).set_name(name.into())
+    pub fn get_input(&self) -> super::builder::livestream_service::GetInput {
+        super::builder::livestream_service::GetInput::new(self.inner.clone())
     }
 
     /// Deletes the specified input.
@@ -287,12 +248,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_input(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteInput {
+    pub fn delete_input(&self) -> super::builder::livestream_service::DeleteInput {
         super::builder::livestream_service::DeleteInput::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified input.
@@ -306,64 +263,38 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_input(
-        &self,
-        input: impl Into<crate::model::Input>,
-    ) -> super::builder::livestream_service::UpdateInput {
+    pub fn update_input(&self) -> super::builder::livestream_service::UpdateInput {
         super::builder::livestream_service::UpdateInput::new(self.inner.clone())
-            .set_input(input.into())
     }
 
     /// Creates an event with the provided unique ID in the specified channel.
-    pub fn create_event(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CreateEvent {
+    pub fn create_event(&self) -> super::builder::livestream_service::CreateEvent {
         super::builder::livestream_service::CreateEvent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a list of all events in the specified channel.
-    pub fn list_events(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListEvents {
+    pub fn list_events(&self) -> super::builder::livestream_service::ListEvents {
         super::builder::livestream_service::ListEvents::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified event.
-    pub fn get_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetEvent {
-        super::builder::livestream_service::GetEvent::new(self.inner.clone()).set_name(name.into())
+    pub fn get_event(&self) -> super::builder::livestream_service::GetEvent {
+        super::builder::livestream_service::GetEvent::new(self.inner.clone())
     }
 
     /// Deletes the specified event.
-    pub fn delete_event(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteEvent {
+    pub fn delete_event(&self) -> super::builder::livestream_service::DeleteEvent {
         super::builder::livestream_service::DeleteEvent::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of all clips in the specified channel.
-    pub fn list_clips(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListClips {
+    pub fn list_clips(&self) -> super::builder::livestream_service::ListClips {
         super::builder::livestream_service::ListClips::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified clip.
-    pub fn get_clip(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetClip {
-        super::builder::livestream_service::GetClip::new(self.inner.clone()).set_name(name.into())
+    pub fn get_clip(&self) -> super::builder::livestream_service::GetClip {
+        super::builder::livestream_service::GetClip::new(self.inner.clone())
     }
 
     /// Creates a clip with the provided clip ID in the specified channel.
@@ -377,12 +308,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_clip(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CreateClip {
+    pub fn create_clip(&self) -> super::builder::livestream_service::CreateClip {
         super::builder::livestream_service::CreateClip::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified clip job resource. This method only deletes the clip
@@ -397,12 +324,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_clip(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteClip {
+    pub fn delete_clip(&self) -> super::builder::livestream_service::DeleteClip {
         super::builder::livestream_service::DeleteClip::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Asset with the provided unique ID in the specified
@@ -417,12 +340,8 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_asset(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CreateAsset {
+    pub fn create_asset(&self) -> super::builder::livestream_service::CreateAsset {
         super::builder::livestream_service::CreateAsset::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes the specified asset if it is not used.
@@ -436,37 +355,23 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteAsset {
+    pub fn delete_asset(&self) -> super::builder::livestream_service::DeleteAsset {
         super::builder::livestream_service::DeleteAsset::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the specified asset.
-    pub fn get_asset(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetAsset {
-        super::builder::livestream_service::GetAsset::new(self.inner.clone()).set_name(name.into())
+    pub fn get_asset(&self) -> super::builder::livestream_service::GetAsset {
+        super::builder::livestream_service::GetAsset::new(self.inner.clone())
     }
 
     /// Returns a list of all assets in the specified region.
-    pub fn list_assets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListAssets {
+    pub fn list_assets(&self) -> super::builder::livestream_service::ListAssets {
         super::builder::livestream_service::ListAssets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified pool.
-    pub fn get_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetPool {
-        super::builder::livestream_service::GetPool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_pool(&self) -> super::builder::livestream_service::GetPool {
+        super::builder::livestream_service::GetPool::new(self.inner.clone())
     }
 
     /// Updates the specified pool.
@@ -480,73 +385,45 @@ impl LivestreamService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_pool(
-        &self,
-        pool: impl Into<crate::model::Pool>,
-    ) -> super::builder::livestream_service::UpdatePool {
+    pub fn update_pool(&self) -> super::builder::livestream_service::UpdatePool {
         super::builder::livestream_service::UpdatePool::new(self.inner.clone())
-            .set_pool(pool.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::livestream_service::ListLocations {
         super::builder::livestream_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::livestream_service::GetLocation {
         super::builder::livestream_service::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::livestream_service::ListOperations {
         super::builder::livestream_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::livestream_service::GetOperation {
         super::builder::livestream_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::livestream_service::DeleteOperation {
         super::builder::livestream_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::livestream_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::livestream_service::CancelOperation {
         super::builder::livestream_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/channels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/channels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListChannelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/channels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/channels", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,9 +104,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Channel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +130,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,18 +158,15 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.channel
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.channel
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +190,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -185,9 +214,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,9 +238,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/inputs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/inputs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -221,9 +264,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInputsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/inputs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/inputs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -244,9 +294,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Input>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -263,9 +320,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -283,18 +347,15 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.input
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("input"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.input
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("input"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +377,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Event>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/events", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/events", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -335,9 +403,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListEventsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/events", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/events", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -358,9 +433,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Event>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +459,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -401,9 +490,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClipsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clips", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clips", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -424,9 +520,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Clip>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,9 +546,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clips", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/clips", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -462,9 +572,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -482,9 +599,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -501,9 +625,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -521,9 +652,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Asset>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -540,9 +678,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAssetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/assets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/assets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -563,9 +708,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Pool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -582,18 +734,15 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -615,9 +764,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -637,9 +793,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,9 +819,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -678,9 +848,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -697,9 +874,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -720,9 +904,16 @@ impl super::stub::LivestreamService for LivestreamService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -159,10 +159,15 @@ impl super::stub::LivestreamService for LivestreamService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.channel
+            let arg = &req
+                .channel
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("channel"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("channel.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -348,10 +353,15 @@ impl super::stub::LivestreamService for LivestreamService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.input
+            let arg = &req
+                .input
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("input"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("input.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -735,10 +745,15 @@ impl super::stub::LivestreamService for LivestreamService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.pool
+            let arg = &req
+                .pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/video/stitcher/v1/src/client.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/client.rs
@@ -135,30 +135,18 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cdn_key(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateCdnKey {
+    pub fn create_cdn_key(&self) -> super::builder::video_stitcher_service::CreateCdnKey {
         super::builder::video_stitcher_service::CreateCdnKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all CDN keys in the specified project and location.
-    pub fn list_cdn_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::ListCdnKeys {
+    pub fn list_cdn_keys(&self) -> super::builder::video_stitcher_service::ListCdnKeys {
         super::builder::video_stitcher_service::ListCdnKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified CDN key.
-    pub fn get_cdn_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetCdnKey {
+    pub fn get_cdn_key(&self) -> super::builder::video_stitcher_service::GetCdnKey {
         super::builder::video_stitcher_service::GetCdnKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified CDN key.
@@ -172,12 +160,8 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cdn_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::DeleteCdnKey {
+    pub fn delete_cdn_key(&self) -> super::builder::video_stitcher_service::DeleteCdnKey {
         super::builder::video_stitcher_service::DeleteCdnKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified CDN key. Only update fields specified
@@ -192,87 +176,63 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cdn_key(
-        &self,
-        cdn_key: impl Into<crate::model::CdnKey>,
-    ) -> super::builder::video_stitcher_service::UpdateCdnKey {
+    pub fn update_cdn_key(&self) -> super::builder::video_stitcher_service::UpdateCdnKey {
         super::builder::video_stitcher_service::UpdateCdnKey::new(self.inner.clone())
-            .set_cdn_key(cdn_key.into())
     }
 
     /// Creates a client side playback VOD session and returns the full
     /// tracking and playback metadata of the session.
-    pub fn create_vod_session(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateVodSession {
+    pub fn create_vod_session(&self) -> super::builder::video_stitcher_service::CreateVodSession {
         super::builder::video_stitcher_service::CreateVodSession::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the full tracking, playback metadata, and relevant ad-ops
     /// logs for the specified VOD session.
-    pub fn get_vod_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetVodSession {
+    pub fn get_vod_session(&self) -> super::builder::video_stitcher_service::GetVodSession {
         super::builder::video_stitcher_service::GetVodSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of detailed stitching information of the specified VOD
     /// session.
     pub fn list_vod_stitch_details(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::ListVodStitchDetails {
         super::builder::video_stitcher_service::ListVodStitchDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified stitching information for the specified VOD session.
     pub fn get_vod_stitch_detail(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::GetVodStitchDetail {
         super::builder::video_stitcher_service::GetVodStitchDetail::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Return the list of ad tag details for the specified VOD session.
     pub fn list_vod_ad_tag_details(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::ListVodAdTagDetails {
         super::builder::video_stitcher_service::ListVodAdTagDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified ad tag detail for the specified VOD session.
     pub fn get_vod_ad_tag_detail(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::GetVodAdTagDetail {
         super::builder::video_stitcher_service::GetVodAdTagDetail::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Return the list of ad tag details for the specified live session.
     pub fn list_live_ad_tag_details(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::ListLiveAdTagDetails {
         super::builder::video_stitcher_service::ListLiveAdTagDetails::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified ad tag detail for the specified live session.
     pub fn get_live_ad_tag_detail(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::video_stitcher_service::GetLiveAdTagDetail {
         super::builder::video_stitcher_service::GetLiveAdTagDetail::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a slate.
@@ -286,30 +246,18 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_slate(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateSlate {
+    pub fn create_slate(&self) -> super::builder::video_stitcher_service::CreateSlate {
         super::builder::video_stitcher_service::CreateSlate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all slates in the specified project and location.
-    pub fn list_slates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::ListSlates {
+    pub fn list_slates(&self) -> super::builder::video_stitcher_service::ListSlates {
         super::builder::video_stitcher_service::ListSlates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified slate.
-    pub fn get_slate(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetSlate {
+    pub fn get_slate(&self) -> super::builder::video_stitcher_service::GetSlate {
         super::builder::video_stitcher_service::GetSlate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified slate.
@@ -323,12 +271,8 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_slate(
-        &self,
-        slate: impl Into<crate::model::Slate>,
-    ) -> super::builder::video_stitcher_service::UpdateSlate {
+    pub fn update_slate(&self) -> super::builder::video_stitcher_service::UpdateSlate {
         super::builder::video_stitcher_service::UpdateSlate::new(self.inner.clone())
-            .set_slate(slate.into())
     }
 
     /// Deletes the specified slate.
@@ -342,30 +286,18 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_slate(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::DeleteSlate {
+    pub fn delete_slate(&self) -> super::builder::video_stitcher_service::DeleteSlate {
         super::builder::video_stitcher_service::DeleteSlate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new live session.
-    pub fn create_live_session(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateLiveSession {
+    pub fn create_live_session(&self) -> super::builder::video_stitcher_service::CreateLiveSession {
         super::builder::video_stitcher_service::CreateLiveSession::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the details for the specified live session.
-    pub fn get_live_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetLiveSession {
+    pub fn get_live_session(&self) -> super::builder::video_stitcher_service::GetLiveSession {
         super::builder::video_stitcher_service::GetLiveSession::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Registers the live config with the provided unique ID in
@@ -380,32 +312,20 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_live_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateLiveConfig {
+    pub fn create_live_config(&self) -> super::builder::video_stitcher_service::CreateLiveConfig {
         super::builder::video_stitcher_service::CreateLiveConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all live configs managed by the Video Stitcher that
     /// belong to the specified project and region.
-    pub fn list_live_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::ListLiveConfigs {
+    pub fn list_live_configs(&self) -> super::builder::video_stitcher_service::ListLiveConfigs {
         super::builder::video_stitcher_service::ListLiveConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified live config managed by the Video
     /// Stitcher service.
-    pub fn get_live_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetLiveConfig {
+    pub fn get_live_config(&self) -> super::builder::video_stitcher_service::GetLiveConfig {
         super::builder::video_stitcher_service::GetLiveConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified live config.
@@ -419,12 +339,8 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_live_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::DeleteLiveConfig {
+    pub fn delete_live_config(&self) -> super::builder::video_stitcher_service::DeleteLiveConfig {
         super::builder::video_stitcher_service::DeleteLiveConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified LiveConfig. Only update fields specified
@@ -439,12 +355,8 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_live_config(
-        &self,
-        live_config: impl Into<crate::model::LiveConfig>,
-    ) -> super::builder::video_stitcher_service::UpdateLiveConfig {
+    pub fn update_live_config(&self) -> super::builder::video_stitcher_service::UpdateLiveConfig {
         super::builder::video_stitcher_service::UpdateLiveConfig::new(self.inner.clone())
-            .set_live_config(live_config.into())
     }
 
     /// Registers the VOD config with the provided unique ID in
@@ -459,32 +371,20 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_vod_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CreateVodConfig {
+    pub fn create_vod_config(&self) -> super::builder::video_stitcher_service::CreateVodConfig {
         super::builder::video_stitcher_service::CreateVodConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all VOD configs managed by the Video Stitcher API that
     /// belong to the specified project and region.
-    pub fn list_vod_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::ListVodConfigs {
+    pub fn list_vod_configs(&self) -> super::builder::video_stitcher_service::ListVodConfigs {
         super::builder::video_stitcher_service::ListVodConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the specified VOD config managed by the Video
     /// Stitcher API service.
-    pub fn get_vod_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetVodConfig {
+    pub fn get_vod_config(&self) -> super::builder::video_stitcher_service::GetVodConfig {
         super::builder::video_stitcher_service::GetVodConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the specified VOD config.
@@ -498,12 +398,8 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_vod_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::DeleteVodConfig {
+    pub fn delete_vod_config(&self) -> super::builder::video_stitcher_service::DeleteVodConfig {
         super::builder::video_stitcher_service::DeleteVodConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the specified VOD config. Only update fields specified
@@ -518,55 +414,35 @@ impl VideoStitcherService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_vod_config(
-        &self,
-        vod_config: impl Into<crate::model::VodConfig>,
-    ) -> super::builder::video_stitcher_service::UpdateVodConfig {
+    pub fn update_vod_config(&self) -> super::builder::video_stitcher_service::UpdateVodConfig {
         super::builder::video_stitcher_service::UpdateVodConfig::new(self.inner.clone())
-            .set_vod_config(vod_config.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::video_stitcher_service::ListOperations {
         super::builder::video_stitcher_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::video_stitcher_service::GetOperation {
         super::builder::video_stitcher_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::video_stitcher_service::DeleteOperation {
         super::builder::video_stitcher_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_stitcher_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::video_stitcher_service::CancelOperation {
         super::builder::video_stitcher_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cdnKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/cdnKeys", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,9 +73,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCdnKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cdnKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/cdnKeys", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,9 +103,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CdnKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -108,9 +129,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,18 +155,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cdn_key
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cdn_key"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cdn_key
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cdn_key"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -161,12 +186,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VodSession>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/vodSessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/vodSessions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -183,9 +212,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VodSession>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,12 +238,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVodStitchDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vodStitchDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vodStitchDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,9 +266,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VodStitchDetail>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -245,12 +292,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVodAdTagDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vodAdTagDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vodAdTagDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -269,9 +320,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VodAdTagDetail>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,12 +346,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLiveAdTagDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/liveAdTagDetails", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/liveAdTagDetails", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -312,9 +374,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LiveAdTagDetail>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -331,9 +400,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/slates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/slates", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -350,9 +426,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSlatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/slates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/slates", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -373,9 +456,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Slate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -392,18 +482,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.slate
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("slate"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.slate
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("slate"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -424,9 +511,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,12 +537,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LiveSession>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/liveSessions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/liveSessions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -465,9 +563,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LiveSession>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -484,12 +589,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/liveConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/liveConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +617,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLiveConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/liveConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/liveConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -534,9 +647,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LiveConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -553,9 +673,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -572,18 +699,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.live_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("live_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.live_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("live_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -606,12 +730,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/vodConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/vodConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -630,12 +758,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVodConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vodConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vodConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,9 +788,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VodConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -675,9 +814,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -694,18 +840,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.vod_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("vod_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.vod_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("vod_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -728,9 +871,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -750,9 +900,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -769,9 +926,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -792,9 +956,16 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -156,10 +156,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cdn_key
+            let arg = &req
+                .cdn_key
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cdn_key"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cdn_key.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -483,10 +488,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.slate
+            let arg = &req
+                .slate
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("slate"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("slate.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -700,10 +710,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.live_config
+            let arg = &req
+                .live_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("live_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("live_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -841,10 +856,15 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.vod_config
+            let arg = &req
+                .vod_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("vod_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("vod_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/video/transcoder/v1/src/client.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/client.rs
@@ -126,72 +126,42 @@ impl TranscoderService {
     }
 
     /// Creates a job in the specified region.
-    pub fn create_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::CreateJob {
+    pub fn create_job(&self) -> super::builder::transcoder_service::CreateJob {
         super::builder::transcoder_service::CreateJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists jobs in the specified region.
-    pub fn list_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::ListJobs {
+    pub fn list_jobs(&self) -> super::builder::transcoder_service::ListJobs {
         super::builder::transcoder_service::ListJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the job data.
-    pub fn get_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::GetJob {
-        super::builder::transcoder_service::GetJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job(&self) -> super::builder::transcoder_service::GetJob {
+        super::builder::transcoder_service::GetJob::new(self.inner.clone())
     }
 
     /// Deletes a job.
-    pub fn delete_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::DeleteJob {
-        super::builder::transcoder_service::DeleteJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_job(&self) -> super::builder::transcoder_service::DeleteJob {
+        super::builder::transcoder_service::DeleteJob::new(self.inner.clone())
     }
 
     /// Creates a job template in the specified region.
-    pub fn create_job_template(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::CreateJobTemplate {
+    pub fn create_job_template(&self) -> super::builder::transcoder_service::CreateJobTemplate {
         super::builder::transcoder_service::CreateJobTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists job templates in the specified region.
-    pub fn list_job_templates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::ListJobTemplates {
+    pub fn list_job_templates(&self) -> super::builder::transcoder_service::ListJobTemplates {
         super::builder::transcoder_service::ListJobTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns the job template data.
-    pub fn get_job_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::GetJobTemplate {
+    pub fn get_job_template(&self) -> super::builder::transcoder_service::GetJobTemplate {
         super::builder::transcoder_service::GetJobTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a job template.
-    pub fn delete_job_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::transcoder_service::DeleteJobTemplate {
+    pub fn delete_job_template(&self) -> super::builder::transcoder_service::DeleteJobTemplate {
         super::builder::transcoder_service::DeleteJobTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/video/transcoder/v1/src/transport.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +70,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +100,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Job>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -105,9 +126,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -129,12 +157,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/jobTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/jobTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,12 +184,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jobTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/jobTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,9 +214,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +240,16 @@ impl super::stub::TranscoderService for TranscoderService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/videointelligence/v1/src/client.rs
+++ b/src/generated/cloud/videointelligence/v1/src/client.rs
@@ -141,44 +141,28 @@ impl VideoIntelligenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_intelligence_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::video_intelligence_service::ListOperations {
         super::builder::video_intelligence_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_intelligence_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::video_intelligence_service::GetOperation {
         super::builder::video_intelligence_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_intelligence_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::video_intelligence_service::DeleteOperation {
         super::builder::video_intelligence_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::video_intelligence_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::video_intelligence_service::CancelOperation {
         super::builder::video_intelligence_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/transport.rs
+++ b/src/generated/cloud/videointelligence/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/videos:annotate".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/videos:annotate".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +64,16 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,9 +93,16 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,9 +119,16 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,9 +149,16 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/vision/v1/src/client.rs
+++ b/src/generated/cloud/vision/v1/src/client.rs
@@ -186,11 +186,8 @@ impl ImageAnnotator {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::image_annotator::GetOperation {
-        super::builder::image_annotator::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::image_annotator::GetOperation {
+        super::builder::image_annotator::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -320,12 +317,8 @@ impl ProductSearch {
     ///
     /// * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
     ///   4096 characters.
-    pub fn create_product_set(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::CreateProductSet {
+    pub fn create_product_set(&self) -> super::builder::product_search::CreateProductSet {
         super::builder::product_search::CreateProductSet::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists ProductSets in an unspecified order.
@@ -334,12 +327,8 @@ impl ProductSearch {
     ///
     /// * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
     ///   than 1.
-    pub fn list_product_sets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::ListProductSets {
+    pub fn list_product_sets(&self) -> super::builder::product_search::ListProductSets {
         super::builder::product_search::ListProductSets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information associated with a ProductSet.
@@ -347,11 +336,8 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the ProductSet does not exist.
-    pub fn get_product_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::GetProductSet {
-        super::builder::product_search::GetProductSet::new(self.inner.clone()).set_name(name.into())
+    pub fn get_product_set(&self) -> super::builder::product_search::GetProductSet {
+        super::builder::product_search::GetProductSet::new(self.inner.clone())
     }
 
     /// Makes changes to a ProductSet resource.
@@ -362,24 +348,16 @@ impl ProductSearch {
     /// * Returns NOT_FOUND if the ProductSet does not exist.
     /// * Returns INVALID_ARGUMENT if display_name is present in update_mask but
     ///   missing from the request or longer than 4096 characters.
-    pub fn update_product_set(
-        &self,
-        product_set: impl Into<crate::model::ProductSet>,
-    ) -> super::builder::product_search::UpdateProductSet {
+    pub fn update_product_set(&self) -> super::builder::product_search::UpdateProductSet {
         super::builder::product_search::UpdateProductSet::new(self.inner.clone())
-            .set_product_set(product_set.into())
     }
 
     /// Permanently deletes a ProductSet. Products and ReferenceImages in the
     /// ProductSet are not deleted.
     ///
     /// The actual image files are not deleted from Google Cloud Storage.
-    pub fn delete_product_set(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::DeleteProductSet {
+    pub fn delete_product_set(&self) -> super::builder::product_search::DeleteProductSet {
         super::builder::product_search::DeleteProductSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates and returns a new product resource.
@@ -390,12 +368,8 @@ impl ProductSearch {
     ///   characters.
     /// * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
     /// * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-    pub fn create_product(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::CreateProduct {
+    pub fn create_product(&self) -> super::builder::product_search::CreateProduct {
         super::builder::product_search::CreateProduct::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists products in an unspecified order.
@@ -403,12 +377,8 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-    pub fn list_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::ListProducts {
+    pub fn list_products(&self) -> super::builder::product_search::ListProducts {
         super::builder::product_search::ListProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information associated with a Product.
@@ -416,11 +386,8 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the Product does not exist.
-    pub fn get_product(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::GetProduct {
-        super::builder::product_search::GetProduct::new(self.inner.clone()).set_name(name.into())
+    pub fn get_product(&self) -> super::builder::product_search::GetProduct {
+        super::builder::product_search::GetProduct::new(self.inner.clone())
     }
 
     /// Makes changes to a Product resource.
@@ -438,12 +405,8 @@ impl ProductSearch {
     /// * Returns INVALID_ARGUMENT if description is present in update_mask but is
     ///   longer than 4096 characters.
     /// * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-    pub fn update_product(
-        &self,
-        product: impl Into<crate::model::Product>,
-    ) -> super::builder::product_search::UpdateProduct {
+    pub fn update_product(&self) -> super::builder::product_search::UpdateProduct {
         super::builder::product_search::UpdateProduct::new(self.inner.clone())
-            .set_product(product.into())
     }
 
     /// Permanently deletes a product and its reference images.
@@ -451,11 +414,8 @@ impl ProductSearch {
     /// Metadata of the product and all its images will be deleted right away, but
     /// search queries against ProductSets containing the product may still work
     /// until all related caches are refreshed.
-    pub fn delete_product(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::DeleteProduct {
-        super::builder::product_search::DeleteProduct::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_product(&self) -> super::builder::product_search::DeleteProduct {
+        super::builder::product_search::DeleteProduct::new(self.inner.clone())
     }
 
     /// Creates and returns a new ReferenceImage resource.
@@ -477,12 +437,8 @@ impl ProductSearch {
     /// * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
     ///   compatible with the parent product's product_category is detected.
     /// * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-    pub fn create_reference_image(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::CreateReferenceImage {
+    pub fn create_reference_image(&self) -> super::builder::product_search::CreateReferenceImage {
         super::builder::product_search::CreateReferenceImage::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Permanently deletes a reference image.
@@ -492,12 +448,8 @@ impl ProductSearch {
     /// caches are refreshed.
     ///
     /// The actual image files are not deleted from Google Cloud Storage.
-    pub fn delete_reference_image(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::DeleteReferenceImage {
+    pub fn delete_reference_image(&self) -> super::builder::product_search::DeleteReferenceImage {
         super::builder::product_search::DeleteReferenceImage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists reference images.
@@ -507,12 +459,8 @@ impl ProductSearch {
     /// * Returns NOT_FOUND if the parent product does not exist.
     /// * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
     ///   than 1.
-    pub fn list_reference_images(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::ListReferenceImages {
+    pub fn list_reference_images(&self) -> super::builder::product_search::ListReferenceImages {
         super::builder::product_search::ListReferenceImages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information associated with a ReferenceImage.
@@ -520,12 +468,8 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the specified image does not exist.
-    pub fn get_reference_image(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::GetReferenceImage {
+    pub fn get_reference_image(&self) -> super::builder::product_search::GetReferenceImage {
         super::builder::product_search::GetReferenceImage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Adds a Product to the specified ProductSet. If the Product is already
@@ -538,19 +482,15 @@ impl ProductSearch {
     /// * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
     pub fn add_product_to_product_set(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::product_search::AddProductToProductSet {
         super::builder::product_search::AddProductToProductSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Removes a Product from the specified ProductSet.
     pub fn remove_product_from_product_set(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::product_search::RemoveProductFromProductSet {
         super::builder::product_search::RemoveProductFromProductSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the Products in a ProductSet, in an unspecified order. If the
@@ -562,10 +502,8 @@ impl ProductSearch {
     /// * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
     pub fn list_products_in_product_set(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::product_search::ListProductsInProductSet {
         super::builder::product_search::ListProductsInProductSet::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Asynchronous API that imports a list of reference images to specified
@@ -592,12 +530,8 @@ impl ProductSearch {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_product_sets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::ImportProductSets {
+    pub fn import_product_sets(&self) -> super::builder::product_search::ImportProductSets {
         super::builder::product_search::ImportProductSets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Asynchronous API to delete all Products in a ProductSet or all Products
@@ -636,21 +570,14 @@ impl ProductSearch {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn purge_products(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::product_search::PurgeProducts {
+    pub fn purge_products(&self) -> super::builder::product_search::PurgeProducts {
         super::builder::product_search::PurgeProducts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::product_search::GetOperation {
-        super::builder::product_search::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::product_search::GetOperation {
+        super::builder::product_search::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -263,10 +263,15 @@ impl super::stub::ProductSearch for ProductSearch {
     ) -> Result<gax::response::Response<crate::model::ProductSet>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.product_set
+            let arg = &req
+                .product_set
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("product_set"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product_set.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -405,10 +410,15 @@ impl super::stub::ProductSearch for ProductSearch {
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.product
+            let arg = &req
+                .product
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("product"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("product.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchAnnotateImagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/images:annotate".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/images:annotate".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +64,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchAnnotateFilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/files:annotate".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/files:annotate".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -80,12 +82,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/images:asyncBatchAnnotate".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/images:asyncBatchAnnotate".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -100,12 +100,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/files:asyncBatchAnnotate".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/files:asyncBatchAnnotate".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -120,9 +118,16 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,12 +181,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProductSet>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/productSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/productSets", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,12 +208,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProductSetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/productSets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/productSets", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -223,9 +236,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProductSet>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,18 +262,15 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProductSet>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.product_set
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("product_set"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.product_set
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("product_set"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -276,9 +293,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -299,12 +323,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/products", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/products", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -322,9 +350,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProductsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/products", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/products", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -343,9 +378,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -362,18 +404,15 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Product>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.product
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("product"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.product
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("product"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,9 +435,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -419,12 +465,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReferenceImage>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/referenceImages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/referenceImages", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -442,9 +492,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -465,12 +522,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReferenceImagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/referenceImages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/referenceImages", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,9 +550,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReferenceImage>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +576,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addProduct", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addProduct", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -533,12 +605,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeProduct", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeProduct", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -558,9 +634,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProductsInProductSetResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/products", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/products", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -579,12 +662,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/productSets:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/productSets:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -599,12 +686,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/products:purge", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/products:purge", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -619,9 +710,16 @@ impl super::stub::ProductSearch for ProductSearch {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/vmmigration/v1/src/client.rs
+++ b/src/generated/cloud/vmmigration/v1/src/client.rs
@@ -119,19 +119,13 @@ impl VmMigration {
     }
 
     /// Lists Sources in a given project and location.
-    pub fn list_sources(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListSources {
-        super::builder::vm_migration::ListSources::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_sources(&self) -> super::builder::vm_migration::ListSources {
+        super::builder::vm_migration::ListSources::new(self.inner.clone())
     }
 
     /// Gets details of a single Source.
-    pub fn get_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetSource {
-        super::builder::vm_migration::GetSource::new(self.inner.clone()).set_name(name.into())
+    pub fn get_source(&self) -> super::builder::vm_migration::GetSource {
+        super::builder::vm_migration::GetSource::new(self.inner.clone())
     }
 
     /// Creates a new Source in a given project and location.
@@ -145,12 +139,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_source(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateSource {
+    pub fn create_source(&self) -> super::builder::vm_migration::CreateSource {
         super::builder::vm_migration::CreateSource::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single Source.
@@ -164,12 +154,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_source(
-        &self,
-        source: impl Into<crate::model::Source>,
-    ) -> super::builder::vm_migration::UpdateSource {
+    pub fn update_source(&self) -> super::builder::vm_migration::UpdateSource {
         super::builder::vm_migration::UpdateSource::new(self.inner.clone())
-            .set_source(source.into())
     }
 
     /// Deletes a single Source.
@@ -183,11 +169,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_source(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::DeleteSource {
-        super::builder::vm_migration::DeleteSource::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_source(&self) -> super::builder::vm_migration::DeleteSource {
+        super::builder::vm_migration::DeleteSource::new(self.inner.clone())
     }
 
     /// List remote source's inventory of VMs.
@@ -195,30 +178,18 @@ impl VmMigration {
     /// Compute Engine). The inventory describes the list of existing VMs in that
     /// source. Note that this operation lists the VMs on the remote source, as
     /// opposed to listing the MigratingVms resources in the vmmigration service.
-    pub fn fetch_inventory(
-        &self,
-        source: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::FetchInventory {
+    pub fn fetch_inventory(&self) -> super::builder::vm_migration::FetchInventory {
         super::builder::vm_migration::FetchInventory::new(self.inner.clone())
-            .set_source(source.into())
     }
 
     /// Lists Utilization Reports of the given Source.
-    pub fn list_utilization_reports(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListUtilizationReports {
+    pub fn list_utilization_reports(&self) -> super::builder::vm_migration::ListUtilizationReports {
         super::builder::vm_migration::ListUtilizationReports::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a single Utilization Report.
-    pub fn get_utilization_report(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetUtilizationReport {
+    pub fn get_utilization_report(&self) -> super::builder::vm_migration::GetUtilizationReport {
         super::builder::vm_migration::GetUtilizationReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new UtilizationReport.
@@ -234,10 +205,8 @@ impl VmMigration {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_utilization_report(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vm_migration::CreateUtilizationReport {
         super::builder::vm_migration::CreateUtilizationReport::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single Utilization Report.
@@ -253,28 +222,20 @@ impl VmMigration {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_utilization_report(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vm_migration::DeleteUtilizationReport {
         super::builder::vm_migration::DeleteUtilizationReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DatacenterConnectors in a given Source.
     pub fn list_datacenter_connectors(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vm_migration::ListDatacenterConnectors {
         super::builder::vm_migration::ListDatacenterConnectors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single DatacenterConnector.
-    pub fn get_datacenter_connector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetDatacenterConnector {
+    pub fn get_datacenter_connector(&self) -> super::builder::vm_migration::GetDatacenterConnector {
         super::builder::vm_migration::GetDatacenterConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new DatacenterConnector in a given Source.
@@ -290,10 +251,8 @@ impl VmMigration {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_datacenter_connector(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vm_migration::CreateDatacenterConnector {
         super::builder::vm_migration::CreateDatacenterConnector::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single DatacenterConnector.
@@ -309,10 +268,8 @@ impl VmMigration {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_datacenter_connector(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vm_migration::DeleteDatacenterConnector {
         super::builder::vm_migration::DeleteDatacenterConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Upgrades the appliance relate to this DatacenterConnector to the in-place
@@ -327,12 +284,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn upgrade_appliance(
-        &self,
-        datacenter_connector: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::UpgradeAppliance {
+    pub fn upgrade_appliance(&self) -> super::builder::vm_migration::UpgradeAppliance {
         super::builder::vm_migration::UpgradeAppliance::new(self.inner.clone())
-            .set_datacenter_connector(datacenter_connector.into())
     }
 
     /// Creates a new MigratingVm in a given Source.
@@ -346,29 +299,18 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_migrating_vm(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateMigratingVm {
+    pub fn create_migrating_vm(&self) -> super::builder::vm_migration::CreateMigratingVm {
         super::builder::vm_migration::CreateMigratingVm::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists MigratingVms in a given Source.
-    pub fn list_migrating_vms(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListMigratingVms {
+    pub fn list_migrating_vms(&self) -> super::builder::vm_migration::ListMigratingVms {
         super::builder::vm_migration::ListMigratingVms::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single MigratingVm.
-    pub fn get_migrating_vm(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetMigratingVm {
-        super::builder::vm_migration::GetMigratingVm::new(self.inner.clone()).set_name(name.into())
+    pub fn get_migrating_vm(&self) -> super::builder::vm_migration::GetMigratingVm {
+        super::builder::vm_migration::GetMigratingVm::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single MigratingVm.
@@ -382,12 +324,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_migrating_vm(
-        &self,
-        migrating_vm: impl Into<crate::model::MigratingVm>,
-    ) -> super::builder::vm_migration::UpdateMigratingVm {
+    pub fn update_migrating_vm(&self) -> super::builder::vm_migration::UpdateMigratingVm {
         super::builder::vm_migration::UpdateMigratingVm::new(self.inner.clone())
-            .set_migrating_vm(migrating_vm.into())
     }
 
     /// Deletes a single MigratingVm.
@@ -401,12 +339,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_migrating_vm(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::DeleteMigratingVm {
+    pub fn delete_migrating_vm(&self) -> super::builder::vm_migration::DeleteMigratingVm {
         super::builder::vm_migration::DeleteMigratingVm::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts migration for a VM. Starts the process of uploading
@@ -421,12 +355,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_migration(
-        &self,
-        migrating_vm: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::StartMigration {
+    pub fn start_migration(&self) -> super::builder::vm_migration::StartMigration {
         super::builder::vm_migration::StartMigration::new(self.inner.clone())
-            .set_migrating_vm(migrating_vm.into())
     }
 
     /// Resumes a migration for a VM. When called on a paused migration, will start
@@ -443,12 +373,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn resume_migration(
-        &self,
-        migrating_vm: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ResumeMigration {
+    pub fn resume_migration(&self) -> super::builder::vm_migration::ResumeMigration {
         super::builder::vm_migration::ResumeMigration::new(self.inner.clone())
-            .set_migrating_vm(migrating_vm.into())
     }
 
     /// Pauses a migration for a VM. If cycle tasks are running they will be
@@ -464,12 +390,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn pause_migration(
-        &self,
-        migrating_vm: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::PauseMigration {
+    pub fn pause_migration(&self) -> super::builder::vm_migration::PauseMigration {
         super::builder::vm_migration::PauseMigration::new(self.inner.clone())
-            .set_migrating_vm(migrating_vm.into())
     }
 
     /// Marks a migration as completed, deleting migration resources that are no
@@ -484,12 +406,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn finalize_migration(
-        &self,
-        migrating_vm: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::FinalizeMigration {
+    pub fn finalize_migration(&self) -> super::builder::vm_migration::FinalizeMigration {
         super::builder::vm_migration::FinalizeMigration::new(self.inner.clone())
-            .set_migrating_vm(migrating_vm.into())
     }
 
     /// Initiates a Clone of a specific migrating VM.
@@ -503,12 +421,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_clone_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateCloneJob {
+    pub fn create_clone_job(&self) -> super::builder::vm_migration::CreateCloneJob {
         super::builder::vm_migration::CreateCloneJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Initiates the cancellation of a running clone job.
@@ -522,28 +436,18 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn cancel_clone_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CancelCloneJob {
-        super::builder::vm_migration::CancelCloneJob::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_clone_job(&self) -> super::builder::vm_migration::CancelCloneJob {
+        super::builder::vm_migration::CancelCloneJob::new(self.inner.clone())
     }
 
     /// Lists CloneJobs of a given migrating VM.
-    pub fn list_clone_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListCloneJobs {
+    pub fn list_clone_jobs(&self) -> super::builder::vm_migration::ListCloneJobs {
         super::builder::vm_migration::ListCloneJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CloneJob.
-    pub fn get_clone_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetCloneJob {
-        super::builder::vm_migration::GetCloneJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_clone_job(&self) -> super::builder::vm_migration::GetCloneJob {
+        super::builder::vm_migration::GetCloneJob::new(self.inner.clone())
     }
 
     /// Initiates a Cutover of a specific migrating VM.
@@ -559,12 +463,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cutover_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateCutoverJob {
+    pub fn create_cutover_job(&self) -> super::builder::vm_migration::CreateCutoverJob {
         super::builder::vm_migration::CreateCutoverJob::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Initiates the cancellation of a running cutover job.
@@ -578,45 +478,28 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn cancel_cutover_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CancelCutoverJob {
+    pub fn cancel_cutover_job(&self) -> super::builder::vm_migration::CancelCutoverJob {
         super::builder::vm_migration::CancelCutoverJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists CutoverJobs of a given migrating VM.
-    pub fn list_cutover_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListCutoverJobs {
+    pub fn list_cutover_jobs(&self) -> super::builder::vm_migration::ListCutoverJobs {
         super::builder::vm_migration::ListCutoverJobs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single CutoverJob.
-    pub fn get_cutover_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetCutoverJob {
-        super::builder::vm_migration::GetCutoverJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_cutover_job(&self) -> super::builder::vm_migration::GetCutoverJob {
+        super::builder::vm_migration::GetCutoverJob::new(self.inner.clone())
     }
 
     /// Lists Groups in a given project and location.
-    pub fn list_groups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListGroups {
-        super::builder::vm_migration::ListGroups::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_groups(&self) -> super::builder::vm_migration::ListGroups {
+        super::builder::vm_migration::ListGroups::new(self.inner.clone())
     }
 
     /// Gets details of a single Group.
-    pub fn get_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetGroup {
-        super::builder::vm_migration::GetGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_group(&self) -> super::builder::vm_migration::GetGroup {
+        super::builder::vm_migration::GetGroup::new(self.inner.clone())
     }
 
     /// Creates a new Group in a given project and location.
@@ -630,11 +513,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_group(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateGroup {
-        super::builder::vm_migration::CreateGroup::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_group(&self) -> super::builder::vm_migration::CreateGroup {
+        super::builder::vm_migration::CreateGroup::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Group.
@@ -648,11 +528,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_group(
-        &self,
-        group: impl Into<crate::model::Group>,
-    ) -> super::builder::vm_migration::UpdateGroup {
-        super::builder::vm_migration::UpdateGroup::new(self.inner.clone()).set_group(group.into())
+    pub fn update_group(&self) -> super::builder::vm_migration::UpdateGroup {
+        super::builder::vm_migration::UpdateGroup::new(self.inner.clone())
     }
 
     /// Deletes a single Group.
@@ -666,11 +543,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::DeleteGroup {
-        super::builder::vm_migration::DeleteGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_group(&self) -> super::builder::vm_migration::DeleteGroup {
+        super::builder::vm_migration::DeleteGroup::new(self.inner.clone())
     }
 
     /// Adds a MigratingVm to a Group.
@@ -684,12 +558,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn add_group_migration(
-        &self,
-        group: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::AddGroupMigration {
+    pub fn add_group_migration(&self) -> super::builder::vm_migration::AddGroupMigration {
         super::builder::vm_migration::AddGroupMigration::new(self.inner.clone())
-            .set_group(group.into())
     }
 
     /// Removes a MigratingVm from a Group.
@@ -703,36 +573,24 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn remove_group_migration(
-        &self,
-        group: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::RemoveGroupMigration {
+    pub fn remove_group_migration(&self) -> super::builder::vm_migration::RemoveGroupMigration {
         super::builder::vm_migration::RemoveGroupMigration::new(self.inner.clone())
-            .set_group(group.into())
     }
 
     /// Lists TargetProjects in a given project.
     ///
     /// NOTE: TargetProject is a global resource; hence the only supported value
     /// for location is `global`.
-    pub fn list_target_projects(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListTargetProjects {
+    pub fn list_target_projects(&self) -> super::builder::vm_migration::ListTargetProjects {
         super::builder::vm_migration::ListTargetProjects::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single TargetProject.
     ///
     /// NOTE: TargetProject is a global resource; hence the only supported value
     /// for location is `global`.
-    pub fn get_target_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetTargetProject {
+    pub fn get_target_project(&self) -> super::builder::vm_migration::GetTargetProject {
         super::builder::vm_migration::GetTargetProject::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new TargetProject in a given project.
@@ -749,12 +607,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_target_project(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CreateTargetProject {
+    pub fn create_target_project(&self) -> super::builder::vm_migration::CreateTargetProject {
         super::builder::vm_migration::CreateTargetProject::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single TargetProject.
@@ -771,12 +625,8 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_target_project(
-        &self,
-        target_project: impl Into<crate::model::TargetProject>,
-    ) -> super::builder::vm_migration::UpdateTargetProject {
+    pub fn update_target_project(&self) -> super::builder::vm_migration::UpdateTargetProject {
         super::builder::vm_migration::UpdateTargetProject::new(self.inner.clone())
-            .set_target_project(target_project.into())
     }
 
     /// Deletes a single TargetProject.
@@ -793,85 +643,55 @@ impl VmMigration {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_target_project(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::DeleteTargetProject {
+    pub fn delete_target_project(&self) -> super::builder::vm_migration::DeleteTargetProject {
         super::builder::vm_migration::DeleteTargetProject::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ReplicationCycles in a given MigratingVM.
-    pub fn list_replication_cycles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListReplicationCycles {
+    pub fn list_replication_cycles(&self) -> super::builder::vm_migration::ListReplicationCycles {
         super::builder::vm_migration::ListReplicationCycles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single ReplicationCycle.
-    pub fn get_replication_cycle(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetReplicationCycle {
+    pub fn get_replication_cycle(&self) -> super::builder::vm_migration::GetReplicationCycle {
         super::builder::vm_migration::GetReplicationCycle::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListLocations {
-        super::builder::vm_migration::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::vm_migration::ListLocations {
+        super::builder::vm_migration::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetLocation {
-        super::builder::vm_migration::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::vm_migration::GetLocation {
+        super::builder::vm_migration::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::ListOperations {
-        super::builder::vm_migration::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::vm_migration::ListOperations {
+        super::builder::vm_migration::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::GetOperation {
-        super::builder::vm_migration::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::vm_migration::GetOperation {
+        super::builder::vm_migration::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::DeleteOperation {
-        super::builder::vm_migration::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::vm_migration::DeleteOperation {
+        super::builder::vm_migration::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vm_migration::CancelOperation {
-        super::builder::vm_migration::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::vm_migration::CancelOperation {
+        super::builder::vm_migration::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -129,10 +129,15 @@ impl super::stub::VmMigration for VmMigration {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.source
+            let arg = &req
+                .source
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("source.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -547,10 +552,15 @@ impl super::stub::VmMigration for VmMigration {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.migrating_vm
+            let arg = &req
+                .migrating_vm
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("migrating_vm"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migrating_vm.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -999,10 +1009,15 @@ impl super::stub::VmMigration for VmMigration {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.group
+            let arg = &req
+                .group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1188,10 +1203,15 @@ impl super::stub::VmMigration for VmMigration {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.target_project
+            let arg = &req
+                .target_project
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("target_project"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("target_project.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSourcesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/sources", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Source>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,9 +102,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/sources", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/sources", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,18 +128,15 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.source
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("source"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.source
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("source"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -140,9 +158,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,12 +185,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchInventoryResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchInventory", {
+            let arg = &req.source;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("source"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchInventory", req.source),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -183,12 +212,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUtilizationReportsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/utilizationReports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/utilizationReports", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -210,9 +243,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UtilizationReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -230,12 +270,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/utilizationReports", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/utilizationReports", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,9 +298,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,12 +325,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatacenterConnectorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/datacenterConnectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/datacenterConnectors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,9 +355,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DatacenterConnector>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,12 +381,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/datacenterConnectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/datacenterConnectors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -343,9 +409,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -363,12 +436,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:upgradeAppliance", {
+            let arg = &req.datacenter_connector;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("datacenter_connector"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:upgradeAppliance", req.datacenter_connector),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -383,12 +460,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/migratingVms", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/migratingVms", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -407,12 +488,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMigratingVmsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/migratingVms", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/migratingVms", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -434,9 +519,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MigratingVm>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -454,18 +546,15 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.migrating_vm
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("migrating_vm"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.migrating_vm
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("migrating_vm"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -489,9 +578,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -508,12 +604,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:startMigration", {
+            let arg = &req.migrating_vm;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migrating_vm"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:startMigration", req.migrating_vm),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -528,12 +628,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resumeMigration", {
+            let arg = &req.migrating_vm;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migrating_vm"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resumeMigration", req.migrating_vm),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -548,12 +652,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pauseMigration", {
+            let arg = &req.migrating_vm;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migrating_vm"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:pauseMigration", req.migrating_vm),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -568,12 +676,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:finalizeMigration", {
+            let arg = &req.migrating_vm;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("migrating_vm"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:finalizeMigration", req.migrating_vm),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -588,12 +700,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cloneJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cloneJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -612,9 +728,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -629,12 +752,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCloneJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cloneJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cloneJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -655,9 +782,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CloneJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -674,12 +808,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/cutoverJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/cutoverJobs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -698,9 +836,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -715,12 +860,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCutoverJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/cutoverJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/cutoverJobs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,9 +890,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CutoverJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -760,9 +916,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/groups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/groups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -783,9 +946,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -802,9 +972,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/groups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/groups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -821,18 +998,15 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -854,9 +1028,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -874,12 +1055,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addGroupMigration", {
+            let arg = &req.group;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addGroupMigration", req.group),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -894,12 +1079,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:removeGroupMigration", {
+            let arg = &req.group;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:removeGroupMigration", req.group),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -914,12 +1103,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTargetProjectsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/targetProjects", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/targetProjects", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -940,9 +1133,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TargetProject>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -959,12 +1159,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/targetProjects", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/targetProjects", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -983,18 +1187,15 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.target_project
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("target_project"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.target_project
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("target_project"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1018,9 +1219,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1038,12 +1246,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListReplicationCyclesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/replicationCycles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/replicationCycles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1064,9 +1276,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReplicationCycle>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1083,9 +1302,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1105,9 +1331,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1124,9 +1357,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1146,9 +1386,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1165,9 +1412,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1188,9 +1442,16 @@ impl super::stub::VmMigration for VmMigration {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/vmwareengine/v1/src/client.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/client.rs
@@ -119,21 +119,13 @@ impl VmwareEngine {
     }
 
     /// Lists `PrivateCloud` resources in a given project and location.
-    pub fn list_private_clouds(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListPrivateClouds {
+    pub fn list_private_clouds(&self) -> super::builder::vmware_engine::ListPrivateClouds {
         super::builder::vmware_engine::ListPrivateClouds::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a `PrivateCloud` resource by its resource name.
-    pub fn get_private_cloud(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetPrivateCloud {
+    pub fn get_private_cloud(&self) -> super::builder::vmware_engine::GetPrivateCloud {
         super::builder::vmware_engine::GetPrivateCloud::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `PrivateCloud` resource in a given project and location.
@@ -153,12 +145,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_private_cloud(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreatePrivateCloud {
+    pub fn create_private_cloud(&self) -> super::builder::vmware_engine::CreatePrivateCloud {
         super::builder::vmware_engine::CreatePrivateCloud::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies a `PrivateCloud` resource. Only the following fields can be
@@ -179,12 +167,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_private_cloud(
-        &self,
-        private_cloud: impl Into<crate::model::PrivateCloud>,
-    ) -> super::builder::vmware_engine::UpdatePrivateCloud {
+    pub fn update_private_cloud(&self) -> super::builder::vmware_engine::UpdatePrivateCloud {
         super::builder::vmware_engine::UpdatePrivateCloud::new(self.inner.clone())
-            .set_private_cloud(private_cloud.into())
     }
 
     /// Schedules a `PrivateCloud` resource for deletion.
@@ -212,12 +196,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_private_cloud(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeletePrivateCloud {
+    pub fn delete_private_cloud(&self) -> super::builder::vmware_engine::DeletePrivateCloud {
         super::builder::vmware_engine::DeletePrivateCloud::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Restores a private cloud that was previously scheduled for deletion by
@@ -234,29 +214,18 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn undelete_private_cloud(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::UndeletePrivateCloud {
+    pub fn undelete_private_cloud(&self) -> super::builder::vmware_engine::UndeletePrivateCloud {
         super::builder::vmware_engine::UndeletePrivateCloud::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `Cluster` resources in a given private cloud.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::vmware_engine::ListClusters {
         super::builder::vmware_engine::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a `Cluster` resource by its resource name.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetCluster {
-        super::builder::vmware_engine::GetCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn get_cluster(&self) -> super::builder::vmware_engine::GetCluster {
+        super::builder::vmware_engine::GetCluster::new(self.inner.clone())
     }
 
     /// Creates a new cluster in a given private cloud.
@@ -273,12 +242,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::vmware_engine::CreateCluster {
         super::builder::vmware_engine::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies a `Cluster` resource. Only fields specified in `updateMask` are
@@ -298,12 +263,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_cluster(
-        &self,
-        cluster: impl Into<crate::model::Cluster>,
-    ) -> super::builder::vmware_engine::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::vmware_engine::UpdateCluster {
         super::builder::vmware_engine::UpdateCluster::new(self.inner.clone())
-            .set_cluster(cluster.into())
     }
 
     /// Deletes a `Cluster` resource. To avoid unintended data loss, migrate or
@@ -320,56 +281,37 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteCluster {
-        super::builder::vmware_engine::DeleteCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_cluster(&self) -> super::builder::vmware_engine::DeleteCluster {
+        super::builder::vmware_engine::DeleteCluster::new(self.inner.clone())
     }
 
     /// Lists nodes in a given cluster.
-    pub fn list_nodes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListNodes {
-        super::builder::vmware_engine::ListNodes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_nodes(&self) -> super::builder::vmware_engine::ListNodes {
+        super::builder::vmware_engine::ListNodes::new(self.inner.clone())
     }
 
     /// Gets details of a single node.
-    pub fn get_node(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetNode {
-        super::builder::vmware_engine::GetNode::new(self.inner.clone()).set_name(name.into())
+    pub fn get_node(&self) -> super::builder::vmware_engine::GetNode {
+        super::builder::vmware_engine::GetNode::new(self.inner.clone())
     }
 
     /// Lists external IP addresses assigned to VMware workload VMs in a given
     /// private cloud.
-    pub fn list_external_addresses(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListExternalAddresses {
+    pub fn list_external_addresses(&self) -> super::builder::vmware_engine::ListExternalAddresses {
         super::builder::vmware_engine::ListExternalAddresses::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists external IP addresses assigned to VMware workload VMs within the
     /// scope of the given network policy.
     pub fn fetch_network_policy_external_addresses(
         &self,
-        network_policy: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::FetchNetworkPolicyExternalAddresses {
         super::builder::vmware_engine::FetchNetworkPolicyExternalAddresses::new(self.inner.clone())
-            .set_network_policy(network_policy.into())
     }
 
     /// Gets details of a single external IP address.
-    pub fn get_external_address(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetExternalAddress {
+    pub fn get_external_address(&self) -> super::builder::vmware_engine::GetExternalAddress {
         super::builder::vmware_engine::GetExternalAddress::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `ExternalAddress` resource in a given private cloud. The
@@ -385,12 +327,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_external_address(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreateExternalAddress {
+    pub fn create_external_address(&self) -> super::builder::vmware_engine::CreateExternalAddress {
         super::builder::vmware_engine::CreateExternalAddress::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single external IP address.
@@ -410,12 +348,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_external_address(
-        &self,
-        external_address: impl Into<crate::model::ExternalAddress>,
-    ) -> super::builder::vmware_engine::UpdateExternalAddress {
+    pub fn update_external_address(&self) -> super::builder::vmware_engine::UpdateExternalAddress {
         super::builder::vmware_engine::UpdateExternalAddress::new(self.inner.clone())
-            .set_external_address(external_address.into())
     }
 
     /// Deletes a single external IP address. When you delete an external IP
@@ -431,29 +365,18 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_external_address(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteExternalAddress {
+    pub fn delete_external_address(&self) -> super::builder::vmware_engine::DeleteExternalAddress {
         super::builder::vmware_engine::DeleteExternalAddress::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists subnets in a given private cloud.
-    pub fn list_subnets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListSubnets {
+    pub fn list_subnets(&self) -> super::builder::vmware_engine::ListSubnets {
         super::builder::vmware_engine::ListSubnets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single subnet.
-    pub fn get_subnet(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetSubnet {
-        super::builder::vmware_engine::GetSubnet::new(self.inner.clone()).set_name(name.into())
+    pub fn get_subnet(&self) -> super::builder::vmware_engine::GetSubnet {
+        super::builder::vmware_engine::GetSubnet::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single subnet. Only fields specified in
@@ -472,30 +395,20 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_subnet(
-        &self,
-        subnet: impl Into<crate::model::Subnet>,
-    ) -> super::builder::vmware_engine::UpdateSubnet {
+    pub fn update_subnet(&self) -> super::builder::vmware_engine::UpdateSubnet {
         super::builder::vmware_engine::UpdateSubnet::new(self.inner.clone())
-            .set_subnet(subnet.into())
     }
 
     /// Lists `ExternalAccessRule` resources in the specified network policy.
     pub fn list_external_access_rules(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ListExternalAccessRules {
         super::builder::vmware_engine::ListExternalAccessRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single external access rule.
-    pub fn get_external_access_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetExternalAccessRule {
+    pub fn get_external_access_rule(&self) -> super::builder::vmware_engine::GetExternalAccessRule {
         super::builder::vmware_engine::GetExternalAccessRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new external access rule in a given network policy.
@@ -511,10 +424,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_external_access_rule(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::CreateExternalAccessRule {
         super::builder::vmware_engine::CreateExternalAccessRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single external access rule.
@@ -531,10 +442,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_external_access_rule(
         &self,
-        external_access_rule: impl Into<crate::model::ExternalAccessRule>,
     ) -> super::builder::vmware_engine::UpdateExternalAccessRule {
         super::builder::vmware_engine::UpdateExternalAccessRule::new(self.inner.clone())
-            .set_external_access_rule(external_access_rule.into())
     }
 
     /// Deletes a single external access rule.
@@ -550,29 +459,19 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_external_access_rule(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::DeleteExternalAccessRule {
         super::builder::vmware_engine::DeleteExternalAccessRule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists logging servers configured for a given private
     /// cloud.
-    pub fn list_logging_servers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListLoggingServers {
+    pub fn list_logging_servers(&self) -> super::builder::vmware_engine::ListLoggingServers {
         super::builder::vmware_engine::ListLoggingServers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a logging server.
-    pub fn get_logging_server(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetLoggingServer {
+    pub fn get_logging_server(&self) -> super::builder::vmware_engine::GetLoggingServer {
         super::builder::vmware_engine::GetLoggingServer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a new logging server for a given private cloud.
@@ -586,12 +485,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_logging_server(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreateLoggingServer {
+    pub fn create_logging_server(&self) -> super::builder::vmware_engine::CreateLoggingServer {
         super::builder::vmware_engine::CreateLoggingServer::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the parameters of a single logging server.
@@ -606,12 +501,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_logging_server(
-        &self,
-        logging_server: impl Into<crate::model::LoggingServer>,
-    ) -> super::builder::vmware_engine::UpdateLoggingServer {
+    pub fn update_logging_server(&self) -> super::builder::vmware_engine::UpdateLoggingServer {
         super::builder::vmware_engine::UpdateLoggingServer::new(self.inner.clone())
-            .set_logging_server(logging_server.into())
     }
 
     /// Deletes a single logging server.
@@ -625,47 +516,30 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_logging_server(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteLoggingServer {
+    pub fn delete_logging_server(&self) -> super::builder::vmware_engine::DeleteLoggingServer {
         super::builder::vmware_engine::DeleteLoggingServer::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists node types
-    pub fn list_node_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListNodeTypes {
+    pub fn list_node_types(&self) -> super::builder::vmware_engine::ListNodeTypes {
         super::builder::vmware_engine::ListNodeTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single `NodeType`.
-    pub fn get_node_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetNodeType {
-        super::builder::vmware_engine::GetNodeType::new(self.inner.clone()).set_name(name.into())
+    pub fn get_node_type(&self) -> super::builder::vmware_engine::GetNodeType {
+        super::builder::vmware_engine::GetNodeType::new(self.inner.clone())
     }
 
     /// Gets details of credentials for NSX appliance.
-    pub fn show_nsx_credentials(
-        &self,
-        private_cloud: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ShowNsxCredentials {
+    pub fn show_nsx_credentials(&self) -> super::builder::vmware_engine::ShowNsxCredentials {
         super::builder::vmware_engine::ShowNsxCredentials::new(self.inner.clone())
-            .set_private_cloud(private_cloud.into())
     }
 
     /// Gets details of credentials for Vcenter appliance.
     pub fn show_vcenter_credentials(
         &self,
-        private_cloud: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ShowVcenterCredentials {
         super::builder::vmware_engine::ShowVcenterCredentials::new(self.inner.clone())
-            .set_private_cloud(private_cloud.into())
     }
 
     /// Resets credentials of the NSX appliance.
@@ -679,12 +553,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn reset_nsx_credentials(
-        &self,
-        private_cloud: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ResetNsxCredentials {
+    pub fn reset_nsx_credentials(&self) -> super::builder::vmware_engine::ResetNsxCredentials {
         super::builder::vmware_engine::ResetNsxCredentials::new(self.inner.clone())
-            .set_private_cloud(private_cloud.into())
     }
 
     /// Resets credentials of the Vcenter appliance.
@@ -700,19 +570,13 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn reset_vcenter_credentials(
         &self,
-        private_cloud: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ResetVcenterCredentials {
         super::builder::vmware_engine::ResetVcenterCredentials::new(self.inner.clone())
-            .set_private_cloud(private_cloud.into())
     }
 
     /// Gets details of the `DnsForwarding` config.
-    pub fn get_dns_forwarding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetDnsForwarding {
+    pub fn get_dns_forwarding(&self) -> super::builder::vmware_engine::GetDnsForwarding {
         super::builder::vmware_engine::GetDnsForwarding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the parameters of the `DnsForwarding` config, like associated
@@ -727,34 +591,22 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_dns_forwarding(
-        &self,
-        dns_forwarding: impl Into<crate::model::DnsForwarding>,
-    ) -> super::builder::vmware_engine::UpdateDnsForwarding {
+    pub fn update_dns_forwarding(&self) -> super::builder::vmware_engine::UpdateDnsForwarding {
         super::builder::vmware_engine::UpdateDnsForwarding::new(self.inner.clone())
-            .set_dns_forwarding(dns_forwarding.into())
     }
 
     /// Retrieves a `NetworkPeering` resource by its resource name. The resource
     /// contains details of the network peering, such as peered
     /// networks, import and export custom route configurations, and peering state.
     /// NetworkPeering is a global resource and location can only be global.
-    pub fn get_network_peering(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetNetworkPeering {
+    pub fn get_network_peering(&self) -> super::builder::vmware_engine::GetNetworkPeering {
         super::builder::vmware_engine::GetNetworkPeering::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `NetworkPeering` resources in a given project. NetworkPeering is a
     /// global resource and location can only be global.
-    pub fn list_network_peerings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListNetworkPeerings {
+    pub fn list_network_peerings(&self) -> super::builder::vmware_engine::ListNetworkPeerings {
         super::builder::vmware_engine::ListNetworkPeerings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new network peering between the peer network and VMware Engine
@@ -770,12 +622,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_network_peering(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreateNetworkPeering {
+    pub fn create_network_peering(&self) -> super::builder::vmware_engine::CreateNetworkPeering {
         super::builder::vmware_engine::CreateNetworkPeering::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a `NetworkPeering` resource. When a network peering is deleted for
@@ -792,12 +640,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_network_peering(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteNetworkPeering {
+    pub fn delete_network_peering(&self) -> super::builder::vmware_engine::DeleteNetworkPeering {
         super::builder::vmware_engine::DeleteNetworkPeering::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Modifies a `NetworkPeering` resource. Only the `description` field can be
@@ -813,22 +657,14 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_network_peering(
-        &self,
-        network_peering: impl Into<crate::model::NetworkPeering>,
-    ) -> super::builder::vmware_engine::UpdateNetworkPeering {
+    pub fn update_network_peering(&self) -> super::builder::vmware_engine::UpdateNetworkPeering {
         super::builder::vmware_engine::UpdateNetworkPeering::new(self.inner.clone())
-            .set_network_peering(network_peering.into())
     }
 
     /// Lists the network peering routes exchanged over a peering connection.
     /// NetworkPeering is a global resource and location can only be global.
-    pub fn list_peering_routes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListPeeringRoutes {
+    pub fn list_peering_routes(&self) -> super::builder::vmware_engine::ListPeeringRoutes {
         super::builder::vmware_engine::ListPeeringRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new HCX activation key in a given private cloud.
@@ -844,46 +680,28 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_hcx_activation_key(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::CreateHcxActivationKey {
         super::builder::vmware_engine::CreateHcxActivationKey::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists `HcxActivationKey` resources in a given private cloud.
-    pub fn list_hcx_activation_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListHcxActivationKeys {
+    pub fn list_hcx_activation_keys(&self) -> super::builder::vmware_engine::ListHcxActivationKeys {
         super::builder::vmware_engine::ListHcxActivationKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a `HcxActivationKey` resource by its resource name.
-    pub fn get_hcx_activation_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetHcxActivationKey {
+    pub fn get_hcx_activation_key(&self) -> super::builder::vmware_engine::GetHcxActivationKey {
         super::builder::vmware_engine::GetHcxActivationKey::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves a `NetworkPolicy` resource by its resource name.
-    pub fn get_network_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetNetworkPolicy {
+    pub fn get_network_policy(&self) -> super::builder::vmware_engine::GetNetworkPolicy {
         super::builder::vmware_engine::GetNetworkPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `NetworkPolicy` resources in a specified project and location.
-    pub fn list_network_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListNetworkPolicies {
+    pub fn list_network_policies(&self) -> super::builder::vmware_engine::ListNetworkPolicies {
         super::builder::vmware_engine::ListNetworkPolicies::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new network policy in a given VMware Engine network of a
@@ -899,12 +717,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_network_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::CreateNetworkPolicy {
+    pub fn create_network_policy(&self) -> super::builder::vmware_engine::CreateNetworkPolicy {
         super::builder::vmware_engine::CreateNetworkPolicy::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies a `NetworkPolicy` resource. Only the following fields can be
@@ -929,12 +743,8 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_network_policy(
-        &self,
-        network_policy: impl Into<crate::model::NetworkPolicy>,
-    ) -> super::builder::vmware_engine::UpdateNetworkPolicy {
+    pub fn update_network_policy(&self) -> super::builder::vmware_engine::UpdateNetworkPolicy {
         super::builder::vmware_engine::UpdateNetworkPolicy::new(self.inner.clone())
-            .set_network_policy(network_policy.into())
     }
 
     /// Deletes a `NetworkPolicy` resource. A network policy cannot be deleted
@@ -950,30 +760,22 @@ impl VmwareEngine {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_network_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteNetworkPolicy {
+    pub fn delete_network_policy(&self) -> super::builder::vmware_engine::DeleteNetworkPolicy {
         super::builder::vmware_engine::DeleteNetworkPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Consumer VPCs bound to Management DNS Zone of a given private cloud.
     pub fn list_management_dns_zone_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ListManagementDnsZoneBindings {
         super::builder::vmware_engine::ListManagementDnsZoneBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a 'ManagementDnsZoneBinding' resource by its resource name.
     pub fn get_management_dns_zone_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::GetManagementDnsZoneBinding {
         super::builder::vmware_engine::GetManagementDnsZoneBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new `ManagementDnsZoneBinding` resource in a private cloud.
@@ -995,10 +797,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_management_dns_zone_binding(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::CreateManagementDnsZoneBinding {
         super::builder::vmware_engine::CreateManagementDnsZoneBinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a `ManagementDnsZoneBinding` resource.
@@ -1015,10 +815,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_management_dns_zone_binding(
         &self,
-        management_dns_zone_binding: impl Into<crate::model::ManagementDnsZoneBinding>,
     ) -> super::builder::vmware_engine::UpdateManagementDnsZoneBinding {
         super::builder::vmware_engine::UpdateManagementDnsZoneBinding::new(self.inner.clone())
-            .set_management_dns_zone_binding(management_dns_zone_binding.into())
     }
 
     /// Deletes a `ManagementDnsZoneBinding` resource. When a management DNS zone
@@ -1036,10 +834,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_management_dns_zone_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::DeleteManagementDnsZoneBinding {
         super::builder::vmware_engine::DeleteManagementDnsZoneBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retries to create a `ManagementDnsZoneBinding` resource that is
@@ -1056,10 +852,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn repair_management_dns_zone_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::RepairManagementDnsZoneBinding {
         super::builder::vmware_engine::RepairManagementDnsZoneBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new VMware Engine network that can be used by a private cloud.
@@ -1075,10 +869,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_vmware_engine_network(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::CreateVmwareEngineNetwork {
         super::builder::vmware_engine::CreateVmwareEngineNetwork::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies a VMware Engine network resource. Only the following fields can be
@@ -1096,10 +888,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_vmware_engine_network(
         &self,
-        vmware_engine_network: impl Into<crate::model::VmwareEngineNetwork>,
     ) -> super::builder::vmware_engine::UpdateVmwareEngineNetwork {
         super::builder::vmware_engine::UpdateVmwareEngineNetwork::new(self.inner.clone())
-            .set_vmware_engine_network(vmware_engine_network.into())
     }
 
     /// Deletes a `VmwareEngineNetwork` resource. You can only delete a VMware
@@ -1118,10 +908,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_vmware_engine_network(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::DeleteVmwareEngineNetwork {
         super::builder::vmware_engine::DeleteVmwareEngineNetwork::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves a `VmwareEngineNetwork` resource by its resource name. The
@@ -1130,19 +918,15 @@ impl VmwareEngine {
     /// (for example, `CREATING`, `ACTIVE`, `DELETING`).
     pub fn get_vmware_engine_network(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::GetVmwareEngineNetwork {
         super::builder::vmware_engine::GetVmwareEngineNetwork::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `VmwareEngineNetwork` resources in a given project and location.
     pub fn list_vmware_engine_networks(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ListVmwareEngineNetworks {
         super::builder::vmware_engine::ListVmwareEngineNetworks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new private connection that can be used for accessing private
@@ -1159,30 +943,22 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_private_connection(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::CreatePrivateConnection {
         super::builder::vmware_engine::CreatePrivateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a `PrivateConnection` resource by its resource name. The resource
     /// contains details of the private connection, such as connected
     /// network, routing mode and state.
-    pub fn get_private_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetPrivateConnection {
+    pub fn get_private_connection(&self) -> super::builder::vmware_engine::GetPrivateConnection {
         super::builder::vmware_engine::GetPrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists `PrivateConnection` resources in a given project and location.
     pub fn list_private_connections(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ListPrivateConnections {
         super::builder::vmware_engine::ListPrivateConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Modifies a `PrivateConnection` resource. Only `description` and
@@ -1200,10 +976,8 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_private_connection(
         &self,
-        private_connection: impl Into<crate::model::PrivateConnection>,
     ) -> super::builder::vmware_engine::UpdatePrivateConnection {
         super::builder::vmware_engine::UpdatePrivateConnection::new(self.inner.clone())
-            .set_private_connection(private_connection.into())
     }
 
     /// Deletes a `PrivateConnection` resource. When a private connection is
@@ -1221,19 +995,15 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_private_connection(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::DeletePrivateConnection {
         super::builder::vmware_engine::DeletePrivateConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the private connection routes exchanged over a peering connection.
     pub fn list_private_connection_peering_routes(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::ListPrivateConnectionPeeringRoutes {
         super::builder::vmware_engine::ListPrivateConnectionPeeringRoutes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Grants the bind permission to the customer provided principal(user /
@@ -1252,21 +1022,15 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn grant_dns_bind_permission(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::GrantDnsBindPermission {
         super::builder::vmware_engine::GrantDnsBindPermission::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets all the principals having bind permission on the intranet VPC
     /// associated with the consumer project granted by the Grant API.
     /// DnsBindPermission is a global resource and location can only be global.
-    pub fn get_dns_bind_permission(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetDnsBindPermission {
+    pub fn get_dns_bind_permission(&self) -> super::builder::vmware_engine::GetDnsBindPermission {
         super::builder::vmware_engine::GetDnsBindPermission::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Revokes the bind permission from the customer provided principal(user /
@@ -1284,26 +1048,18 @@ impl VmwareEngine {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn revoke_dns_bind_permission(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::vmware_engine::RevokeDnsBindPermission {
         super::builder::vmware_engine::RevokeDnsBindPermission::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListLocations {
-        super::builder::vmware_engine::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::vmware_engine::ListLocations {
+        super::builder::vmware_engine::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetLocation {
-        super::builder::vmware_engine::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::vmware_engine::GetLocation {
+        super::builder::vmware_engine::GetLocation::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -1311,22 +1067,14 @@ impl VmwareEngine {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::vmware_engine::SetIamPolicy {
         super::builder::vmware_engine::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::vmware_engine::GetIamPolicy {
         super::builder::vmware_engine::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -1336,42 +1084,28 @@ impl VmwareEngine {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::vmware_engine::TestIamPermissions {
         super::builder::vmware_engine::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::ListOperations {
-        super::builder::vmware_engine::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::vmware_engine::ListOperations {
+        super::builder::vmware_engine::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::GetOperation {
-        super::builder::vmware_engine::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::vmware_engine::GetOperation {
+        super::builder::vmware_engine::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vmware_engine::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::vmware_engine::DeleteOperation {
         super::builder::vmware_engine::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -132,10 +132,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.private_cloud
+            let arg = &req
+                .private_cloud
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("private_cloud"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_cloud.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -305,10 +310,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.cluster
+            let arg = &req
+                .cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -532,10 +542,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.external_address
+            let arg = &req
+                .external_address
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("external_address"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("external_address.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -645,10 +660,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.subnet
+            let arg = &req
+                .subnet
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("subnet.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -758,10 +778,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.external_access_rule
+            let arg = &req
+                .external_access_rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("external_access_rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("external_access_rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -901,10 +926,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.logging_server
+            let arg = &req
+                .logging_server
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("logging_server"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("logging_server.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1142,10 +1172,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dns_forwarding
+            let arg = &req
+                .dns_forwarding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dns_forwarding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dns_forwarding.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1285,10 +1320,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.network_peering
+            let arg = &req
+                .network_peering
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("network_peering"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("network_peering.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1512,10 +1552,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.network_policy
+            let arg = &req
+                .network_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("network_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("network_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1658,10 +1703,17 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.management_dns_zone_binding
+            let arg = &req
+                .management_dns_zone_binding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("management_dns_zone_binding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "management_dns_zone_binding.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1769,10 +1821,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.vmware_engine_network
+            let arg = &req
+                .vmware_engine_network
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("vmware_engine_network"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("vmware_engine_network.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1969,10 +2026,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.private_connection
+            let arg = &req
+                .private_connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("private_connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPrivateCloudsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/privateClouds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/privateClouds", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PrivateCloud>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/privateClouds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/privateClouds", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,18 +131,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.private_cloud
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("private_cloud"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.private_cloud
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("private_cloud"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -151,9 +163,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,9 +195,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +219,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,9 +249,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -235,12 +275,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,18 +304,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -296,9 +337,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -316,9 +364,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNodesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nodes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/nodes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -337,9 +392,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Node>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -356,12 +418,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExternalAddressesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/externalAddresses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/externalAddresses", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -383,12 +449,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<crate::model::FetchNetworkPolicyExternalAddressesResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:fetchExternalAddresses", {
+            let arg = &req.network_policy;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("network_policy"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:fetchExternalAddresses", req.network_policy),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -407,9 +477,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalAddress>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -426,12 +503,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/externalAddresses", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/externalAddresses", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -450,18 +531,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.external_address
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("external_address"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.external_address
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("external_address"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,9 +563,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -505,9 +590,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSubnetsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/subnets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/subnets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -526,9 +618,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Subnet>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -545,18 +644,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.subnet
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.subnet
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("subnet"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -577,12 +673,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExternalAccessRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/externalAccessRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/externalAccessRules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -603,9 +703,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExternalAccessRule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -622,12 +729,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/externalAccessRules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/externalAccessRules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -646,18 +757,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.external_access_rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("external_access_rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.external_access_rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("external_access_rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -681,9 +789,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,12 +816,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLoggingServersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/loggingServers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/loggingServers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -727,9 +846,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LoggingServer>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -746,12 +872,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/loggingServers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/loggingServers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -770,18 +900,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.logging_server
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("logging_server"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.logging_server
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("logging_server"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -805,9 +932,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -825,12 +959,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNodeTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nodeTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/nodeTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -850,9 +988,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NodeType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -869,12 +1014,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Credentials>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:showNsxCredentials", {
+            let arg = &req.private_cloud;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_cloud"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:showNsxCredentials", req.private_cloud),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -891,12 +1040,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Credentials>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:showVcenterCredentials", {
+            let arg = &req.private_cloud;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_cloud"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:showVcenterCredentials", req.private_cloud),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -914,12 +1067,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetNsxCredentials", {
+            let arg = &req.private_cloud;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_cloud"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetNsxCredentials", req.private_cloud),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -934,12 +1091,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetVcenterCredentials", {
+            let arg = &req.private_cloud;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("private_cloud"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetVcenterCredentials", req.private_cloud),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -954,9 +1115,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DnsForwarding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -973,18 +1141,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dns_forwarding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dns_forwarding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dns_forwarding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dns_forwarding"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1008,9 +1173,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NetworkPeering>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1027,12 +1199,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNetworkPeeringsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/networkPeerings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/networkPeerings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1053,12 +1229,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/networkPeerings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/networkPeerings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1077,9 +1257,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1097,18 +1284,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.network_peering
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("network_peering"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.network_peering
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("network_peering"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1132,12 +1316,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPeeringRoutesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/peeringRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/peeringRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1157,12 +1345,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/hcxActivationKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/hcxActivationKeys", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1181,12 +1373,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListHcxActivationKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/hcxActivationKeys", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/hcxActivationKeys", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1205,9 +1401,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HcxActivationKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1224,9 +1427,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NetworkPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1243,12 +1453,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNetworkPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/networkPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/networkPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1269,12 +1483,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/networkPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/networkPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1293,18 +1511,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.network_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("network_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.network_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("network_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1328,9 +1543,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1348,12 +1570,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListManagementDnsZoneBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/managementDnsZoneBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/managementDnsZoneBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1374,9 +1600,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ManagementDnsZoneBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1393,12 +1626,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/managementDnsZoneBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/managementDnsZoneBindings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1420,20 +1657,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.management_dns_zone_binding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("management_dns_zone_binding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.management_dns_zone_binding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing(
-                            "management_dns_zone_binding"
-                        ))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1457,9 +1689,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1477,9 +1716,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:repair", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:repair", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1494,12 +1740,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/vmwareEngineNetworks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/vmwareEngineNetworks", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1518,18 +1768,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.vmware_engine_network
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("vmware_engine_network"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.vmware_engine_network
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("vmware_engine_network"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1553,9 +1800,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1574,9 +1828,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VmwareEngineNetwork>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1593,12 +1854,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVmwareEngineNetworksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/vmwareEngineNetworks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/vmwareEngineNetworks", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1619,12 +1884,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1643,9 +1912,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PrivateConnection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1662,12 +1938,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPrivateConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/privateConnections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/privateConnections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1688,18 +1968,15 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.private_connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("private_connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.private_connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("private_connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1723,9 +2000,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1744,12 +2028,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
     ) -> Result<gax::response::Response<crate::model::ListPrivateConnectionPeeringRoutesResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/peeringRoutes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/peeringRoutes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1768,9 +2056,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:grant", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:grant", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1785,9 +2080,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DnsBindPermission>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1804,9 +2106,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:revoke", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:revoke", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1821,9 +2130,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1843,9 +2159,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1862,12 +2185,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1882,12 +2209,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1914,12 +2245,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1934,9 +2269,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1956,9 +2298,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1975,9 +2324,16 @@ impl super::stub::VmwareEngine for VmwareEngine {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/vpcaccess/v1/src/client.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/client.rs
@@ -133,31 +133,19 @@ impl VpcAccessService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_connector(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::CreateConnector {
+    pub fn create_connector(&self) -> super::builder::vpc_access_service::CreateConnector {
         super::builder::vpc_access_service::CreateConnector::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Serverless VPC Access connector. Returns NOT_FOUND if the resource
     /// does not exist.
-    pub fn get_connector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::GetConnector {
+    pub fn get_connector(&self) -> super::builder::vpc_access_service::GetConnector {
         super::builder::vpc_access_service::GetConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Serverless VPC Access connectors.
-    pub fn list_connectors(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::ListConnectors {
+    pub fn list_connectors(&self) -> super::builder::vpc_access_service::ListConnectors {
         super::builder::vpc_access_service::ListConnectors::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a Serverless VPC Access connector. Returns NOT_FOUND if the
@@ -172,42 +160,26 @@ impl VpcAccessService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_connector(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::DeleteConnector {
+    pub fn delete_connector(&self) -> super::builder::vpc_access_service::DeleteConnector {
         super::builder::vpc_access_service::DeleteConnector::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::vpc_access_service::ListLocations {
         super::builder::vpc_access_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::vpc_access_service::ListOperations {
         super::builder::vpc_access_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::vpc_access_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::vpc_access_service::GetOperation {
         super::builder::vpc_access_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/vpcaccess/v1/src/transport.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/connectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/connectors", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +73,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connector>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +99,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/connectors", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/connectors", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +127,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -131,9 +153,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -153,9 +182,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +211,16 @@ impl super::stub::VpcAccessService for VpcAccessService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/webrisk/v1/src/client.rs
+++ b/src/generated/cloud/webrisk/v1/src/client.rs
@@ -158,12 +158,8 @@ impl WebRiskService {
     /// protect users that could get exposed to this threat in the future. Only
     /// allowlisted projects can use this method during Early Access. Please reach
     /// out to Sales or your customer engineer to obtain access.
-    pub fn create_submission(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::CreateSubmission {
+    pub fn create_submission(&self) -> super::builder::web_risk_service::CreateSubmission {
         super::builder::web_risk_service::CreateSubmission::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Submits a URI suspected of containing malicious content to be reviewed.
@@ -186,55 +182,35 @@ impl WebRiskService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn submit_uri(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::SubmitUri {
+    pub fn submit_uri(&self) -> super::builder::web_risk_service::SubmitUri {
         super::builder::web_risk_service::SubmitUri::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::web_risk_service::ListOperations {
         super::builder::web_risk_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::web_risk_service::GetOperation {
         super::builder::web_risk_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::web_risk_service::DeleteOperation {
         super::builder::web_risk_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_risk_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::web_risk_service::CancelOperation {
         super::builder::web_risk_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -46,12 +46,10 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ComputeThreatListDiffResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/threatLists:computeDiff".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                "/v1/threatLists:computeDiff".to_string(),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -80,9 +78,10 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchUrisResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/uris:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/uris:search".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,9 +103,10 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchHashesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/hashes:search".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/hashes:search".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -128,12 +128,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Submission>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/submissions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/submissions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,12 +154,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/uris:submit", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/uris:submit", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,9 +178,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,9 +207,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -211,9 +233,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -234,9 +263,16 @@ impl super::stub::WebRiskService for WebRiskService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/websecurityscanner/v1/src/client.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/client.rs
@@ -123,120 +123,70 @@ impl WebSecurityScanner {
     }
 
     /// Creates a new ScanConfig.
-    pub fn create_scan_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::CreateScanConfig {
+    pub fn create_scan_config(&self) -> super::builder::web_security_scanner::CreateScanConfig {
         super::builder::web_security_scanner::CreateScanConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an existing ScanConfig and its child resources.
-    pub fn delete_scan_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::DeleteScanConfig {
+    pub fn delete_scan_config(&self) -> super::builder::web_security_scanner::DeleteScanConfig {
         super::builder::web_security_scanner::DeleteScanConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a ScanConfig.
-    pub fn get_scan_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::GetScanConfig {
+    pub fn get_scan_config(&self) -> super::builder::web_security_scanner::GetScanConfig {
         super::builder::web_security_scanner::GetScanConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ScanConfigs under a given project.
-    pub fn list_scan_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::ListScanConfigs {
+    pub fn list_scan_configs(&self) -> super::builder::web_security_scanner::ListScanConfigs {
         super::builder::web_security_scanner::ListScanConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a ScanConfig. This method support partial update of a ScanConfig.
-    pub fn update_scan_config(
-        &self,
-        scan_config: impl Into<crate::model::ScanConfig>,
-    ) -> super::builder::web_security_scanner::UpdateScanConfig {
+    pub fn update_scan_config(&self) -> super::builder::web_security_scanner::UpdateScanConfig {
         super::builder::web_security_scanner::UpdateScanConfig::new(self.inner.clone())
-            .set_scan_config(scan_config.into())
     }
 
     /// Start a ScanRun according to the given ScanConfig.
-    pub fn start_scan_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::StartScanRun {
+    pub fn start_scan_run(&self) -> super::builder::web_security_scanner::StartScanRun {
         super::builder::web_security_scanner::StartScanRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a ScanRun.
-    pub fn get_scan_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::GetScanRun {
+    pub fn get_scan_run(&self) -> super::builder::web_security_scanner::GetScanRun {
         super::builder::web_security_scanner::GetScanRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists ScanRuns under a given ScanConfig, in descending order of ScanRun
     /// stop time.
-    pub fn list_scan_runs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::ListScanRuns {
+    pub fn list_scan_runs(&self) -> super::builder::web_security_scanner::ListScanRuns {
         super::builder::web_security_scanner::ListScanRuns::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Stops a ScanRun. The stopped ScanRun is returned.
-    pub fn stop_scan_run(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::StopScanRun {
+    pub fn stop_scan_run(&self) -> super::builder::web_security_scanner::StopScanRun {
         super::builder::web_security_scanner::StopScanRun::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List CrawledUrls under a given ScanRun.
-    pub fn list_crawled_urls(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::ListCrawledUrls {
+    pub fn list_crawled_urls(&self) -> super::builder::web_security_scanner::ListCrawledUrls {
         super::builder::web_security_scanner::ListCrawledUrls::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a Finding.
-    pub fn get_finding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::GetFinding {
+    pub fn get_finding(&self) -> super::builder::web_security_scanner::GetFinding {
         super::builder::web_security_scanner::GetFinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List Findings under a given ScanRun.
-    pub fn list_findings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::web_security_scanner::ListFindings {
+    pub fn list_findings(&self) -> super::builder::web_security_scanner::ListFindings {
         super::builder::web_security_scanner::ListFindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// List all FindingTypeStats under a given ScanRun.
     pub fn list_finding_type_stats(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::web_security_scanner::ListFindingTypeStats {
         super::builder::web_security_scanner::ListFindingTypeStats::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -157,10 +157,15 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
     ) -> Result<gax::response::Response<crate::model::ScanConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.scan_config
+            let arg = &req
+                .scan_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("scan_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("scan_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/scanConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/scanConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,9 +102,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,12 +128,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListScanConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/scanConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/scanConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -134,18 +156,15 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.scan_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("scan_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.scan_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("scan_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +187,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanRun>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -185,9 +211,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanRun>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -204,9 +237,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListScanRunsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/scanRuns", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/scanRuns", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -225,9 +265,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ScanRun>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,12 +289,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCrawledUrlsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/crawledUrls", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/crawledUrls", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -266,9 +317,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Finding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,9 +343,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/findings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/findings", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,12 +372,16 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFindingTypeStatsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/findingTypeStats", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/findingTypeStats", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/workflows/executions/v1/src/client.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/client.rs
@@ -123,36 +123,22 @@ impl Executions {
     /// the given name. The method returns executions of all workflow
     /// revisions. Returned executions are ordered by their start time (newest
     /// first).
-    pub fn list_executions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::executions::ListExecutions {
+    pub fn list_executions(&self) -> super::builder::executions::ListExecutions {
         super::builder::executions::ListExecutions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new execution using the latest revision of the given workflow.
-    pub fn create_execution(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::executions::CreateExecution {
+    pub fn create_execution(&self) -> super::builder::executions::CreateExecution {
         super::builder::executions::CreateExecution::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns an execution of the given name.
-    pub fn get_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::GetExecution {
-        super::builder::executions::GetExecution::new(self.inner.clone()).set_name(name.into())
+    pub fn get_execution(&self) -> super::builder::executions::GetExecution {
+        super::builder::executions::GetExecution::new(self.inner.clone())
     }
 
     /// Cancels an execution of the given name.
-    pub fn cancel_execution(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::executions::CancelExecution {
-        super::builder::executions::CancelExecution::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_execution(&self) -> super::builder::executions::CancelExecution {
+        super::builder::executions::CancelExecution::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExecutionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/executions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/executions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -73,12 +77,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/executions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/executions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -95,9 +103,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,9 +130,16 @@ impl super::stub::Executions for Executions {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Execution>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -124,19 +124,13 @@ impl Workflows {
 
     /// Lists workflows in a given project and location.
     /// The default order is not specified.
-    pub fn list_workflows(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workflows::ListWorkflows {
-        super::builder::workflows::ListWorkflows::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_workflows(&self) -> super::builder::workflows::ListWorkflows {
+        super::builder::workflows::ListWorkflows::new(self.inner.clone())
     }
 
     /// Gets details of a single workflow.
-    pub fn get_workflow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::GetWorkflow {
-        super::builder::workflows::GetWorkflow::new(self.inner.clone()).set_name(name.into())
+    pub fn get_workflow(&self) -> super::builder::workflows::GetWorkflow {
+        super::builder::workflows::GetWorkflow::new(self.inner.clone())
     }
 
     /// Creates a new workflow. If a workflow with the specified name already
@@ -152,11 +146,8 @@ impl Workflows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_workflow(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workflows::CreateWorkflow {
-        super::builder::workflows::CreateWorkflow::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_workflow(&self) -> super::builder::workflows::CreateWorkflow {
+        super::builder::workflows::CreateWorkflow::new(self.inner.clone())
     }
 
     /// Deletes a workflow with the specified name.
@@ -172,11 +163,8 @@ impl Workflows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_workflow(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::DeleteWorkflow {
-        super::builder::workflows::DeleteWorkflow::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_workflow(&self) -> super::builder::workflows::DeleteWorkflow {
+        super::builder::workflows::DeleteWorkflow::new(self.inner.clone())
     }
 
     /// Updates an existing workflow.
@@ -194,66 +182,43 @@ impl Workflows {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_workflow(
-        &self,
-        workflow: impl Into<crate::model::Workflow>,
-    ) -> super::builder::workflows::UpdateWorkflow {
+    pub fn update_workflow(&self) -> super::builder::workflows::UpdateWorkflow {
         super::builder::workflows::UpdateWorkflow::new(self.inner.clone())
-            .set_workflow(workflow.into())
     }
 
     /// Lists revisions for a given workflow.
-    pub fn list_workflow_revisions(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::ListWorkflowRevisions {
+    pub fn list_workflow_revisions(&self) -> super::builder::workflows::ListWorkflowRevisions {
         super::builder::workflows::ListWorkflowRevisions::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::ListLocations {
-        super::builder::workflows::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::workflows::ListLocations {
+        super::builder::workflows::ListLocations::new(self.inner.clone())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::GetLocation {
-        super::builder::workflows::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::workflows::GetLocation {
+        super::builder::workflows::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::ListOperations {
-        super::builder::workflows::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::workflows::ListOperations {
+        super::builder::workflows::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::GetOperation {
-        super::builder::workflows::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::workflows::GetOperation {
+        super::builder::workflows::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workflows::DeleteOperation {
-        super::builder::workflows::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::workflows::DeleteOperation {
+        super::builder::workflows::DeleteOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkflowsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workflows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workflows", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workflow>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -92,12 +103,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workflows", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workflows", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,9 +130,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -134,18 +156,15 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workflow
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workflow"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workflow
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workflow"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,12 +187,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkflowRevisionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:listRevisions", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:listRevisions", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,9 +215,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -214,9 +244,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -233,9 +270,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -255,9 +299,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,9 +325,16 @@ impl super::stub::Workflows for Workflows {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -157,10 +157,15 @@ impl super::stub::Workflows for Workflows {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workflow
+            let arg = &req
+                .workflow
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workflow"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workflow.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/workstations/v1/src/client.rs
+++ b/src/generated/cloud/workstations/v1/src/client.rs
@@ -119,21 +119,15 @@ impl Workstations {
     }
 
     /// Returns the requested workstation cluster.
-    pub fn get_workstation_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GetWorkstationCluster {
+    pub fn get_workstation_cluster(&self) -> super::builder::workstations::GetWorkstationCluster {
         super::builder::workstations::GetWorkstationCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns all workstation clusters in the specified location.
     pub fn list_workstation_clusters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workstations::ListWorkstationClusters {
         super::builder::workstations::ListWorkstationClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new workstation cluster.
@@ -149,10 +143,8 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_workstation_cluster(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workstations::CreateWorkstationCluster {
         super::builder::workstations::CreateWorkstationCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing workstation cluster.
@@ -168,10 +160,8 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_workstation_cluster(
         &self,
-        workstation_cluster: impl Into<crate::model::WorkstationCluster>,
     ) -> super::builder::workstations::UpdateWorkstationCluster {
         super::builder::workstations::UpdateWorkstationCluster::new(self.inner.clone())
-            .set_workstation_cluster(workstation_cluster.into())
     }
 
     /// Deletes the specified workstation cluster.
@@ -187,38 +177,26 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_workstation_cluster(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::workstations::DeleteWorkstationCluster {
         super::builder::workstations::DeleteWorkstationCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the requested workstation configuration.
-    pub fn get_workstation_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GetWorkstationConfig {
+    pub fn get_workstation_config(&self) -> super::builder::workstations::GetWorkstationConfig {
         super::builder::workstations::GetWorkstationConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns all workstation configurations in the specified cluster.
-    pub fn list_workstation_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workstations::ListWorkstationConfigs {
+    pub fn list_workstation_configs(&self) -> super::builder::workstations::ListWorkstationConfigs {
         super::builder::workstations::ListWorkstationConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns all workstation configurations in the specified cluster on which
     /// the caller has the "workstations.workstation.create" permission.
     pub fn list_usable_workstation_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workstations::ListUsableWorkstationConfigs {
         super::builder::workstations::ListUsableWorkstationConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new workstation configuration.
@@ -234,10 +212,8 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_workstation_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::workstations::CreateWorkstationConfig {
         super::builder::workstations::CreateWorkstationConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing workstation configuration.
@@ -253,10 +229,8 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_workstation_config(
         &self,
-        workstation_config: impl Into<crate::model::WorkstationConfig>,
     ) -> super::builder::workstations::UpdateWorkstationConfig {
         super::builder::workstations::UpdateWorkstationConfig::new(self.inner.clone())
-            .set_workstation_config(workstation_config.into())
     }
 
     /// Deletes the specified workstation configuration.
@@ -272,37 +246,24 @@ impl Workstations {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_workstation_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::workstations::DeleteWorkstationConfig {
         super::builder::workstations::DeleteWorkstationConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the requested workstation.
-    pub fn get_workstation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GetWorkstation {
-        super::builder::workstations::GetWorkstation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_workstation(&self) -> super::builder::workstations::GetWorkstation {
+        super::builder::workstations::GetWorkstation::new(self.inner.clone())
     }
 
     /// Returns all Workstations using the specified workstation configuration.
-    pub fn list_workstations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workstations::ListWorkstations {
+    pub fn list_workstations(&self) -> super::builder::workstations::ListWorkstations {
         super::builder::workstations::ListWorkstations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns all workstations using the specified workstation configuration
     /// on which the caller has the "workstations.workstations.use" permission.
-    pub fn list_usable_workstations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workstations::ListUsableWorkstations {
+    pub fn list_usable_workstations(&self) -> super::builder::workstations::ListUsableWorkstations {
         super::builder::workstations::ListUsableWorkstations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new workstation.
@@ -316,12 +277,8 @@ impl Workstations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_workstation(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::workstations::CreateWorkstation {
+    pub fn create_workstation(&self) -> super::builder::workstations::CreateWorkstation {
         super::builder::workstations::CreateWorkstation::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an existing workstation.
@@ -335,12 +292,8 @@ impl Workstations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_workstation(
-        &self,
-        workstation: impl Into<crate::model::Workstation>,
-    ) -> super::builder::workstations::UpdateWorkstation {
+    pub fn update_workstation(&self) -> super::builder::workstations::UpdateWorkstation {
         super::builder::workstations::UpdateWorkstation::new(self.inner.clone())
-            .set_workstation(workstation.into())
     }
 
     /// Deletes the specified workstation.
@@ -354,12 +307,8 @@ impl Workstations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_workstation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::DeleteWorkstation {
+    pub fn delete_workstation(&self) -> super::builder::workstations::DeleteWorkstation {
         super::builder::workstations::DeleteWorkstation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts running a workstation so that users can connect to it.
@@ -373,12 +322,8 @@ impl Workstations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn start_workstation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::StartWorkstation {
+    pub fn start_workstation(&self) -> super::builder::workstations::StartWorkstation {
         super::builder::workstations::StartWorkstation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Stops running a workstation, reducing costs.
@@ -392,21 +337,14 @@ impl Workstations {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn stop_workstation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::StopWorkstation {
-        super::builder::workstations::StopWorkstation::new(self.inner.clone()).set_name(name.into())
+    pub fn stop_workstation(&self) -> super::builder::workstations::StopWorkstation {
+        super::builder::workstations::StopWorkstation::new(self.inner.clone())
     }
 
     /// Returns a short-lived credential that can be used to send authenticated and
     /// authorized traffic to a workstation.
-    pub fn generate_access_token(
-        &self,
-        workstation: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GenerateAccessToken {
+    pub fn generate_access_token(&self) -> super::builder::workstations::GenerateAccessToken {
         super::builder::workstations::GenerateAccessToken::new(self.inner.clone())
-            .set_workstation(workstation.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -414,22 +352,14 @@ impl Workstations {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::workstations::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::workstations::SetIamPolicy {
         super::builder::workstations::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::workstations::GetIamPolicy {
         super::builder::workstations::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -439,51 +369,35 @@ impl Workstations {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::workstations::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::workstations::TestIamPermissions {
         super::builder::workstations::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::ListOperations {
-        super::builder::workstations::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::workstations::ListOperations {
+        super::builder::workstations::ListOperations::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::GetOperation {
-        super::builder::workstations::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::workstations::GetOperation {
+        super::builder::workstations::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::DeleteOperation {
-        super::builder::workstations::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::workstations::DeleteOperation {
+        super::builder::workstations::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::workstations::CancelOperation {
-        super::builder::workstations::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::workstations::CancelOperation {
+        super::builder::workstations::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -129,10 +129,15 @@ impl super::stub::Workstations for Workstations {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workstation_cluster
+            let arg = &req
+                .workstation_cluster
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workstation_cluster"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workstation_cluster.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -301,10 +306,15 @@ impl super::stub::Workstations for Workstations {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workstation_config
+            let arg = &req
+                .workstation_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workstation_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workstation_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -473,10 +483,15 @@ impl super::stub::Workstations for Workstations {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.workstation
+            let arg = &req
+                .workstation
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("workstation"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workstation.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkstationCluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,12 +72,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkstationClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workstationClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workstationClusters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workstationClusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workstationClusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,18 +128,15 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workstation_cluster
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workstation_cluster"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workstation_cluster
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workstation_cluster"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,9 +161,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -171,9 +190,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkstationConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,12 +216,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkstationConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workstationConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workstationConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -214,12 +244,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsableWorkstationConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workstationConfigs:listUsable", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workstationConfigs:listUsable", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -238,12 +272,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workstationConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workstationConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -262,18 +300,15 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workstation_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workstation_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workstation_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workstation_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -298,9 +333,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -320,9 +362,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Workstation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -339,12 +388,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkstationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workstations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workstations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -363,12 +416,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsableWorkstationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workstations:listUsable", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workstations:listUsable", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -387,12 +444,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workstations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workstations", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -411,18 +472,15 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.workstation
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("workstation"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.workstation
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("workstation"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,9 +505,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -468,9 +533,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:start", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:start", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,9 +557,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:stop", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:stop", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -502,12 +581,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAccessTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateAccessToken", {
+            let arg = &req.workstation;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("workstation"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateAccessToken", req.workstation),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -522,12 +605,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -542,12 +629,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -574,12 +665,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -594,9 +689,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -616,9 +718,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -635,9 +744,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -658,9 +774,16 @@ impl super::stub::Workstations for Workstations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/container/v1/src/client.rs
+++ b/src/generated/container/v1/src/client.rs
@@ -120,20 +120,13 @@ impl ClusterManager {
 
     /// Lists all clusters owned by a project in either the specified zone or all
     /// zones.
-    pub fn list_clusters(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::ListClusters {
+    pub fn list_clusters(&self) -> super::builder::cluster_manager::ListClusters {
         super::builder::cluster_manager::ListClusters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the details of a specific cluster.
-    pub fn get_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::GetCluster {
-        super::builder::cluster_manager::GetCluster::new(self.inner.clone()).set_name(name.into())
+    pub fn get_cluster(&self) -> super::builder::cluster_manager::GetCluster {
+        super::builder::cluster_manager::GetCluster::new(self.inner.clone())
     }
 
     /// Creates a cluster, consisting of the specified number and type of Google
@@ -150,66 +143,40 @@ impl ClusterManager {
     ///
     /// Finally, an entry is added to the project's global metadata indicating
     /// which CIDR range the cluster is using.
-    pub fn create_cluster(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::CreateCluster {
+    pub fn create_cluster(&self) -> super::builder::cluster_manager::CreateCluster {
         super::builder::cluster_manager::CreateCluster::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the settings of a specific cluster.
-    pub fn update_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::UpdateCluster {
+    pub fn update_cluster(&self) -> super::builder::cluster_manager::UpdateCluster {
         super::builder::cluster_manager::UpdateCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the version and/or image type for the specified node pool.
-    pub fn update_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::UpdateNodePool {
+    pub fn update_node_pool(&self) -> super::builder::cluster_manager::UpdateNodePool {
         super::builder::cluster_manager::UpdateNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the autoscaling settings for the specified node pool.
     pub fn set_node_pool_autoscaling(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::SetNodePoolAutoscaling {
         super::builder::cluster_manager::SetNodePoolAutoscaling::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the logging service for a specific cluster.
-    pub fn set_logging_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetLoggingService {
+    pub fn set_logging_service(&self) -> super::builder::cluster_manager::SetLoggingService {
         super::builder::cluster_manager::SetLoggingService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the monitoring service for a specific cluster.
-    pub fn set_monitoring_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetMonitoringService {
+    pub fn set_monitoring_service(&self) -> super::builder::cluster_manager::SetMonitoringService {
         super::builder::cluster_manager::SetMonitoringService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the addons for a specific cluster.
-    pub fn set_addons_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetAddonsConfig {
+    pub fn set_addons_config(&self) -> super::builder::cluster_manager::SetAddonsConfig {
         super::builder::cluster_manager::SetAddonsConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the locations for a specific cluster.
@@ -217,30 +184,20 @@ impl ClusterManager {
     /// [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update)
     /// instead.
     #[deprecated]
-    pub fn set_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetLocations {
-        super::builder::cluster_manager::SetLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn set_locations(&self) -> super::builder::cluster_manager::SetLocations {
+        super::builder::cluster_manager::SetLocations::new(self.inner.clone())
     }
 
     /// Updates the master for a specific cluster.
-    pub fn update_master(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::UpdateMaster {
-        super::builder::cluster_manager::UpdateMaster::new(self.inner.clone()).set_name(name.into())
+    pub fn update_master(&self) -> super::builder::cluster_manager::UpdateMaster {
+        super::builder::cluster_manager::UpdateMaster::new(self.inner.clone())
     }
 
     /// Sets master auth materials. Currently supports changing the admin password
     /// or a specific cluster, either via password generation or explicitly setting
     /// the password.
-    pub fn set_master_auth(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetMasterAuth {
+    pub fn set_master_auth(&self) -> super::builder::cluster_manager::SetMasterAuth {
         super::builder::cluster_manager::SetMasterAuth::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes the cluster, including the Kubernetes endpoint and all worker
@@ -252,156 +209,97 @@ impl ClusterManager {
     /// Other Google Compute Engine resources that might be in use by the cluster,
     /// such as load balancer resources, are not deleted if they weren't present
     /// when the cluster was initially created.
-    pub fn delete_cluster(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::DeleteCluster {
+    pub fn delete_cluster(&self) -> super::builder::cluster_manager::DeleteCluster {
         super::builder::cluster_manager::DeleteCluster::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all operations in a project in a specific zone or all zones.
-    pub fn list_operations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::ListOperations {
+    pub fn list_operations(&self) -> super::builder::cluster_manager::ListOperations {
         super::builder::cluster_manager::ListOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the specified operation.
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::GetOperation {
-        super::builder::cluster_manager::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cluster_manager::GetOperation {
+        super::builder::cluster_manager::GetOperation::new(self.inner.clone())
     }
 
     /// Cancels the specified operation.
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::cluster_manager::CancelOperation {
         super::builder::cluster_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns configuration info about the Google Kubernetes Engine service.
-    pub fn get_server_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::GetServerConfig {
+    pub fn get_server_config(&self) -> super::builder::cluster_manager::GetServerConfig {
         super::builder::cluster_manager::GetServerConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
-    pub fn get_json_web_keys(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::GetJSONWebKeys {
+    pub fn get_json_web_keys(&self) -> super::builder::cluster_manager::GetJSONWebKeys {
         super::builder::cluster_manager::GetJSONWebKeys::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the node pools for a cluster.
-    pub fn list_node_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::ListNodePools {
+    pub fn list_node_pools(&self) -> super::builder::cluster_manager::ListNodePools {
         super::builder::cluster_manager::ListNodePools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves the requested node pool.
-    pub fn get_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::GetNodePool {
-        super::builder::cluster_manager::GetNodePool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_node_pool(&self) -> super::builder::cluster_manager::GetNodePool {
+        super::builder::cluster_manager::GetNodePool::new(self.inner.clone())
     }
 
     /// Creates a node pool for a cluster.
-    pub fn create_node_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::CreateNodePool {
+    pub fn create_node_pool(&self) -> super::builder::cluster_manager::CreateNodePool {
         super::builder::cluster_manager::CreateNodePool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a node pool from a cluster.
-    pub fn delete_node_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::DeleteNodePool {
+    pub fn delete_node_pool(&self) -> super::builder::cluster_manager::DeleteNodePool {
         super::builder::cluster_manager::DeleteNodePool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// CompleteNodePoolUpgrade will signal an on-going node pool upgrade to
     /// complete.
     pub fn complete_node_pool_upgrade(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::CompleteNodePoolUpgrade {
         super::builder::cluster_manager::CompleteNodePoolUpgrade::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Rolls back a previously Aborted or Failed NodePool upgrade.
     /// This makes no changes if the last upgrade successfully completed.
     pub fn rollback_node_pool_upgrade(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::RollbackNodePoolUpgrade {
         super::builder::cluster_manager::RollbackNodePoolUpgrade::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the NodeManagement options for a node pool.
     pub fn set_node_pool_management(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::SetNodePoolManagement {
         super::builder::cluster_manager::SetNodePoolManagement::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets labels on a cluster.
-    pub fn set_labels(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetLabels {
-        super::builder::cluster_manager::SetLabels::new(self.inner.clone()).set_name(name.into())
+    pub fn set_labels(&self) -> super::builder::cluster_manager::SetLabels {
+        super::builder::cluster_manager::SetLabels::new(self.inner.clone())
     }
 
     /// Enables or disables the ABAC authorization mechanism on a cluster.
-    pub fn set_legacy_abac(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetLegacyAbac {
+    pub fn set_legacy_abac(&self) -> super::builder::cluster_manager::SetLegacyAbac {
         super::builder::cluster_manager::SetLegacyAbac::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts master IP rotation.
-    pub fn start_ip_rotation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::StartIPRotation {
+    pub fn start_ip_rotation(&self) -> super::builder::cluster_manager::StartIPRotation {
         super::builder::cluster_manager::StartIPRotation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Completes master IP rotation.
-    pub fn complete_ip_rotation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::CompleteIPRotation {
+    pub fn complete_ip_rotation(&self) -> super::builder::cluster_manager::CompleteIPRotation {
         super::builder::cluster_manager::CompleteIPRotation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the size for a specific node pool. The new size will be used for all
@@ -409,48 +307,32 @@ impl ClusterManager {
     /// [NodePool.locations][google.container.v1.NodePool.locations].
     ///
     /// [google.container.v1.NodePool.locations]: crate::model::NodePool::locations
-    pub fn set_node_pool_size(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetNodePoolSize {
+    pub fn set_node_pool_size(&self) -> super::builder::cluster_manager::SetNodePoolSize {
         super::builder::cluster_manager::SetNodePoolSize::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Enables or disables Network Policy for a cluster.
-    pub fn set_network_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetNetworkPolicy {
+    pub fn set_network_policy(&self) -> super::builder::cluster_manager::SetNetworkPolicy {
         super::builder::cluster_manager::SetNetworkPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the maintenance policy for a cluster.
-    pub fn set_maintenance_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cluster_manager::SetMaintenancePolicy {
+    pub fn set_maintenance_policy(&self) -> super::builder::cluster_manager::SetMaintenancePolicy {
         super::builder::cluster_manager::SetMaintenancePolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists subnetworks that are usable for creating clusters in a project.
     pub fn list_usable_subnetworks(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::ListUsableSubnetworks {
         super::builder::cluster_manager::ListUsableSubnetworks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Checks the cluster compatibility with Autopilot mode, and returns a list of
     /// compatibility issues.
     pub fn check_autopilot_compatibility(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::cluster_manager::CheckAutopilotCompatibility {
         super::builder::cluster_manager::CheckAutopilotCompatibility::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/container/v1/src/transport.rs
+++ b/src/generated/container/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListClustersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/clusters", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,9 +74,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Cluster>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +103,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/clusters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/clusters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -109,9 +127,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -126,9 +151,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -143,12 +175,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setAutoscaling", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setAutoscaling", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -163,12 +199,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setLogging", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setLogging", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -183,12 +223,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setMonitoring", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setMonitoring", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -203,9 +247,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setAddons", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:setAddons", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -220,12 +271,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setLocations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setLocations", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,12 +295,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:updateMaster", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:updateMaster", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,12 +319,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setMasterAuth", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setMasterAuth", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -280,9 +343,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -302,12 +372,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/operations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -326,9 +400,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,9 +429,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -370,12 +458,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServerConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serverConfig", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serverConfig", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -394,9 +486,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetJSONWebKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/jwks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/jwks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -413,12 +512,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNodePoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/nodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/nodePools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -438,9 +541,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NodePool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -461,12 +571,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/nodePools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/nodePools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -481,9 +595,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,12 +625,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:completeUpgrade", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:completeUpgrade", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -529,9 +654,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:rollback", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:rollback", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,12 +678,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setManagement", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setManagement", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -566,12 +702,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setResourceLabels", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setResourceLabels", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -586,12 +726,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setLegacyAbac", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setLegacyAbac", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -606,12 +750,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:startIpRotation", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:startIpRotation", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -626,12 +774,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:completeIpRotation", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:completeIpRotation", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -646,9 +798,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setSize", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:setSize", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -663,12 +822,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setNetworkPolicy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setNetworkPolicy", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -683,12 +846,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setMaintenancePolicy", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setMaintenancePolicy", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -703,12 +870,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsableSubnetworksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/aggregated/usableSubnetworks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/aggregated/usableSubnetworks", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -728,12 +899,16 @@ impl super::stub::ClusterManager for ClusterManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CheckAutopilotCompatibilityResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:checkAutopilotCompatibility", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:checkAutopilotCompatibility", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/datastore/admin/v1/src/client.rs
+++ b/src/generated/datastore/admin/v1/src/client.rs
@@ -182,12 +182,8 @@ impl DatastoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_entities(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::ExportEntities {
+    pub fn export_entities(&self) -> super::builder::datastore_admin::ExportEntities {
         super::builder::datastore_admin::ExportEntities::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Imports entities into Google Cloud Datastore. Existing entities with the
@@ -205,12 +201,8 @@ impl DatastoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_entities(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::ImportEntities {
+    pub fn import_entities(&self) -> super::builder::datastore_admin::ImportEntities {
         super::builder::datastore_admin::ImportEntities::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Creates the specified index.
@@ -240,12 +232,8 @@ impl DatastoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_index(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::CreateIndex {
+    pub fn create_index(&self) -> super::builder::datastore_admin::CreateIndex {
         super::builder::datastore_admin::CreateIndex::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Deletes an existing index.
@@ -273,78 +261,47 @@ impl DatastoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_index(
-        &self,
-        project_id: impl Into<std::string::String>,
-        index_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::DeleteIndex {
+    pub fn delete_index(&self) -> super::builder::datastore_admin::DeleteIndex {
         super::builder::datastore_admin::DeleteIndex::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_index_id(index_id.into())
     }
 
     /// Gets an index.
-    pub fn get_index(
-        &self,
-        project_id: impl Into<std::string::String>,
-        index_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::GetIndex {
+    pub fn get_index(&self) -> super::builder::datastore_admin::GetIndex {
         super::builder::datastore_admin::GetIndex::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_index_id(index_id.into())
     }
 
     /// Lists the indexes that match the specified filters.  Datastore uses an
     /// eventually consistent query to fetch the list of indexes and may
     /// occasionally return stale results.
-    pub fn list_indexes(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::ListIndexes {
+    pub fn list_indexes(&self) -> super::builder::datastore_admin::ListIndexes {
         super::builder::datastore_admin::ListIndexes::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::datastore_admin::ListOperations {
         super::builder::datastore_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::GetOperation {
-        super::builder::datastore_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::datastore_admin::GetOperation {
+        super::builder::datastore_admin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::datastore_admin::DeleteOperation {
         super::builder::datastore_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::datastore_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::datastore_admin::CancelOperation {
         super::builder::datastore_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}:export", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}:export", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}:import", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}:import", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/indexes", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/indexes", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +118,26 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/indexes/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.index_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("index_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v1/projects/{}/indexes/{}", req.project_id, req.index_id),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -128,12 +154,26 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Index>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/indexes/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.index_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("index_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/indexes/{}", req.project_id, req.index_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,12 +190,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIndexesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/indexes", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/indexes", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +219,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -197,9 +248,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -216,9 +274,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,9 +304,16 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/artifactregistry/v1/src/client.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/client.rs
@@ -133,75 +133,43 @@ impl ArtifactRegistry {
     }
 
     /// Lists docker images.
-    pub fn list_docker_images(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListDockerImages {
+    pub fn list_docker_images(&self) -> super::builder::artifact_registry::ListDockerImages {
         super::builder::artifact_registry::ListDockerImages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a docker image.
-    pub fn get_docker_image(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetDockerImage {
+    pub fn get_docker_image(&self) -> super::builder::artifact_registry::GetDockerImage {
         super::builder::artifact_registry::GetDockerImage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists maven artifacts.
-    pub fn list_maven_artifacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListMavenArtifacts {
+    pub fn list_maven_artifacts(&self) -> super::builder::artifact_registry::ListMavenArtifacts {
         super::builder::artifact_registry::ListMavenArtifacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a maven artifact.
-    pub fn get_maven_artifact(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetMavenArtifact {
+    pub fn get_maven_artifact(&self) -> super::builder::artifact_registry::GetMavenArtifact {
         super::builder::artifact_registry::GetMavenArtifact::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists npm packages.
-    pub fn list_npm_packages(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListNpmPackages {
+    pub fn list_npm_packages(&self) -> super::builder::artifact_registry::ListNpmPackages {
         super::builder::artifact_registry::ListNpmPackages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a npm package.
-    pub fn get_npm_package(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetNpmPackage {
+    pub fn get_npm_package(&self) -> super::builder::artifact_registry::GetNpmPackage {
         super::builder::artifact_registry::GetNpmPackage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists python packages.
-    pub fn list_python_packages(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListPythonPackages {
+    pub fn list_python_packages(&self) -> super::builder::artifact_registry::ListPythonPackages {
         super::builder::artifact_registry::ListPythonPackages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a python package.
-    pub fn get_python_package(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetPythonPackage {
+    pub fn get_python_package(&self) -> super::builder::artifact_registry::GetPythonPackage {
         super::builder::artifact_registry::GetPythonPackage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports Apt artifacts. The returned Operation will complete once the
@@ -218,12 +186,8 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_apt_artifacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ImportAptArtifacts {
+    pub fn import_apt_artifacts(&self) -> super::builder::artifact_registry::ImportAptArtifacts {
         super::builder::artifact_registry::ImportAptArtifacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Imports Yum (RPM) artifacts. The returned Operation will complete once the
@@ -240,30 +204,18 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_yum_artifacts(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ImportYumArtifacts {
+    pub fn import_yum_artifacts(&self) -> super::builder::artifact_registry::ImportYumArtifacts {
         super::builder::artifact_registry::ImportYumArtifacts::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists repositories.
-    pub fn list_repositories(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListRepositories {
+    pub fn list_repositories(&self) -> super::builder::artifact_registry::ListRepositories {
         super::builder::artifact_registry::ListRepositories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a repository.
-    pub fn get_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetRepository {
+    pub fn get_repository(&self) -> super::builder::artifact_registry::GetRepository {
         super::builder::artifact_registry::GetRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a repository. The returned Operation will finish once the
@@ -278,21 +230,13 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_repository(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::CreateRepository {
+    pub fn create_repository(&self) -> super::builder::artifact_registry::CreateRepository {
         super::builder::artifact_registry::CreateRepository::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a repository.
-    pub fn update_repository(
-        &self,
-        repository: impl Into<crate::model::Repository>,
-    ) -> super::builder::artifact_registry::UpdateRepository {
+    pub fn update_repository(&self) -> super::builder::artifact_registry::UpdateRepository {
         super::builder::artifact_registry::UpdateRepository::new(self.inner.clone())
-            .set_repository(repository.into())
     }
 
     /// Deletes a repository and all of its contents. The returned Operation will
@@ -308,29 +252,18 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteRepository {
+    pub fn delete_repository(&self) -> super::builder::artifact_registry::DeleteRepository {
         super::builder::artifact_registry::DeleteRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists packages.
-    pub fn list_packages(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListPackages {
+    pub fn list_packages(&self) -> super::builder::artifact_registry::ListPackages {
         super::builder::artifact_registry::ListPackages::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a package.
-    pub fn get_package(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetPackage {
-        super::builder::artifact_registry::GetPackage::new(self.inner.clone()).set_name(name.into())
+    pub fn get_package(&self) -> super::builder::artifact_registry::GetPackage {
+        super::builder::artifact_registry::GetPackage::new(self.inner.clone())
     }
 
     /// Deletes a package and all of its versions and tags. The returned operation
@@ -345,29 +278,18 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_package(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeletePackage {
+    pub fn delete_package(&self) -> super::builder::artifact_registry::DeletePackage {
         super::builder::artifact_registry::DeletePackage::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists versions.
-    pub fn list_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListVersions {
+    pub fn list_versions(&self) -> super::builder::artifact_registry::ListVersions {
         super::builder::artifact_registry::ListVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a version
-    pub fn get_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetVersion {
-        super::builder::artifact_registry::GetVersion::new(self.inner.clone()).set_name(name.into())
+    pub fn get_version(&self) -> super::builder::artifact_registry::GetVersion {
+        super::builder::artifact_registry::GetVersion::new(self.inner.clone())
     }
 
     /// Deletes a version and all of its content. The returned operation will
@@ -382,12 +304,8 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_version(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteVersion {
+    pub fn delete_version(&self) -> super::builder::artifact_registry::DeleteVersion {
         super::builder::artifact_registry::DeleteVersion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes multiple versions across a repository. The returned operation will
@@ -402,38 +320,23 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn batch_delete_versions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::BatchDeleteVersions {
+    pub fn batch_delete_versions(&self) -> super::builder::artifact_registry::BatchDeleteVersions {
         super::builder::artifact_registry::BatchDeleteVersions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a version.
-    pub fn update_version(
-        &self,
-        version: impl Into<crate::model::Version>,
-    ) -> super::builder::artifact_registry::UpdateVersion {
+    pub fn update_version(&self) -> super::builder::artifact_registry::UpdateVersion {
         super::builder::artifact_registry::UpdateVersion::new(self.inner.clone())
-            .set_version(version.into())
     }
 
     /// Lists files.
-    pub fn list_files(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListFiles {
+    pub fn list_files(&self) -> super::builder::artifact_registry::ListFiles {
         super::builder::artifact_registry::ListFiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a file.
-    pub fn get_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetFile {
-        super::builder::artifact_registry::GetFile::new(self.inner.clone()).set_name(name.into())
+    pub fn get_file(&self) -> super::builder::artifact_registry::GetFile {
+        super::builder::artifact_registry::GetFile::new(self.inner.clone())
     }
 
     /// Deletes a file and all of its content. It is only allowed on generic
@@ -449,193 +352,115 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_file(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteFile {
-        super::builder::artifact_registry::DeleteFile::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_file(&self) -> super::builder::artifact_registry::DeleteFile {
+        super::builder::artifact_registry::DeleteFile::new(self.inner.clone())
     }
 
     /// Updates a file.
-    pub fn update_file(
-        &self,
-        file: impl Into<crate::model::File>,
-    ) -> super::builder::artifact_registry::UpdateFile {
-        super::builder::artifact_registry::UpdateFile::new(self.inner.clone()).set_file(file.into())
+    pub fn update_file(&self) -> super::builder::artifact_registry::UpdateFile {
+        super::builder::artifact_registry::UpdateFile::new(self.inner.clone())
     }
 
     /// Lists tags.
-    pub fn list_tags(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListTags {
+    pub fn list_tags(&self) -> super::builder::artifact_registry::ListTags {
         super::builder::artifact_registry::ListTags::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a tag.
-    pub fn get_tag(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetTag {
-        super::builder::artifact_registry::GetTag::new(self.inner.clone()).set_name(name.into())
+    pub fn get_tag(&self) -> super::builder::artifact_registry::GetTag {
+        super::builder::artifact_registry::GetTag::new(self.inner.clone())
     }
 
     /// Creates a tag.
-    pub fn create_tag(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::CreateTag {
+    pub fn create_tag(&self) -> super::builder::artifact_registry::CreateTag {
         super::builder::artifact_registry::CreateTag::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a tag.
-    pub fn update_tag(
-        &self,
-        tag: impl Into<crate::model::Tag>,
-    ) -> super::builder::artifact_registry::UpdateTag {
-        super::builder::artifact_registry::UpdateTag::new(self.inner.clone()).set_tag(tag.into())
+    pub fn update_tag(&self) -> super::builder::artifact_registry::UpdateTag {
+        super::builder::artifact_registry::UpdateTag::new(self.inner.clone())
     }
 
     /// Deletes a tag.
-    pub fn delete_tag(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteTag {
-        super::builder::artifact_registry::DeleteTag::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_tag(&self) -> super::builder::artifact_registry::DeleteTag {
+        super::builder::artifact_registry::DeleteTag::new(self.inner.clone())
     }
 
     /// Creates a rule.
-    pub fn create_rule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::CreateRule {
+    pub fn create_rule(&self) -> super::builder::artifact_registry::CreateRule {
         super::builder::artifact_registry::CreateRule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists rules.
-    pub fn list_rules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListRules {
+    pub fn list_rules(&self) -> super::builder::artifact_registry::ListRules {
         super::builder::artifact_registry::ListRules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a rule.
-    pub fn get_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetRule {
-        super::builder::artifact_registry::GetRule::new(self.inner.clone()).set_name(name.into())
+    pub fn get_rule(&self) -> super::builder::artifact_registry::GetRule {
+        super::builder::artifact_registry::GetRule::new(self.inner.clone())
     }
 
     /// Updates a rule.
-    pub fn update_rule(
-        &self,
-        rule: impl Into<crate::model::Rule>,
-    ) -> super::builder::artifact_registry::UpdateRule {
-        super::builder::artifact_registry::UpdateRule::new(self.inner.clone()).set_rule(rule.into())
+    pub fn update_rule(&self) -> super::builder::artifact_registry::UpdateRule {
+        super::builder::artifact_registry::UpdateRule::new(self.inner.clone())
     }
 
     /// Deletes a rule.
-    pub fn delete_rule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteRule {
-        super::builder::artifact_registry::DeleteRule::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_rule(&self) -> super::builder::artifact_registry::DeleteRule {
+        super::builder::artifact_registry::DeleteRule::new(self.inner.clone())
     }
 
     /// Updates the IAM policy for a given resource.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::artifact_registry::SetIamPolicy {
         super::builder::artifact_registry::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the IAM policy for a given resource.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::artifact_registry::GetIamPolicy {
         super::builder::artifact_registry::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Tests if the caller has a list of permissions on a resource.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::artifact_registry::TestIamPermissions {
         super::builder::artifact_registry::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Retrieves the Settings for the Project.
-    pub fn get_project_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetProjectSettings {
+    pub fn get_project_settings(&self) -> super::builder::artifact_registry::GetProjectSettings {
         super::builder::artifact_registry::GetProjectSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the Settings for the Project.
     pub fn update_project_settings(
         &self,
-        project_settings: impl Into<crate::model::ProjectSettings>,
     ) -> super::builder::artifact_registry::UpdateProjectSettings {
         super::builder::artifact_registry::UpdateProjectSettings::new(self.inner.clone())
-            .set_project_settings(project_settings.into())
     }
 
     /// Retrieves the VPCSC Config for the Project.
-    pub fn get_vpcsc_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetVPCSCConfig {
+    pub fn get_vpcsc_config(&self) -> super::builder::artifact_registry::GetVPCSCConfig {
         super::builder::artifact_registry::GetVPCSCConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the VPCSC Config for the Project.
-    pub fn update_vpcsc_config(
-        &self,
-        vpcsc_config: impl Into<crate::model::VPCSCConfig>,
-    ) -> super::builder::artifact_registry::UpdateVPCSCConfig {
+    pub fn update_vpcsc_config(&self) -> super::builder::artifact_registry::UpdateVPCSCConfig {
         super::builder::artifact_registry::UpdateVPCSCConfig::new(self.inner.clone())
-            .set_vpcsc_config(vpcsc_config.into())
     }
 
     /// Updates a package.
-    pub fn update_package(
-        &self,
-        package: impl Into<crate::model::Package>,
-    ) -> super::builder::artifact_registry::UpdatePackage {
+    pub fn update_package(&self) -> super::builder::artifact_registry::UpdatePackage {
         super::builder::artifact_registry::UpdatePackage::new(self.inner.clone())
-            .set_package(package.into())
     }
 
     /// Lists attachments.
-    pub fn list_attachments(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListAttachments {
+    pub fn list_attachments(&self) -> super::builder::artifact_registry::ListAttachments {
         super::builder::artifact_registry::ListAttachments::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an attachment.
-    pub fn get_attachment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetAttachment {
+    pub fn get_attachment(&self) -> super::builder::artifact_registry::GetAttachment {
         super::builder::artifact_registry::GetAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an attachment. The returned Operation will finish once the
@@ -650,12 +475,8 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_attachment(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::CreateAttachment {
+    pub fn create_attachment(&self) -> super::builder::artifact_registry::CreateAttachment {
         super::builder::artifact_registry::CreateAttachment::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an attachment. The returned Operation will
@@ -671,40 +492,24 @@ impl ArtifactRegistry {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_attachment(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::DeleteAttachment {
+    pub fn delete_attachment(&self) -> super::builder::artifact_registry::DeleteAttachment {
         super::builder::artifact_registry::DeleteAttachment::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::ListLocations {
+    pub fn list_locations(&self) -> super::builder::artifact_registry::ListLocations {
         super::builder::artifact_registry::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetLocation {
+    pub fn get_location(&self) -> super::builder::artifact_registry::GetLocation {
         super::builder::artifact_registry::GetLocation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::artifact_registry::GetOperation {
+    pub fn get_operation(&self) -> super::builder::artifact_registry::GetOperation {
         super::builder::artifact_registry::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDockerImagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dockerImages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dockerImages", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,9 +75,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DockerImage>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,12 +101,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMavenArtifactsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/mavenArtifacts", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/mavenArtifacts", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -114,9 +129,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MavenArtifact>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -133,12 +155,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNpmPackagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/npmPackages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/npmPackages", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -157,9 +183,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NpmPackage>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -176,12 +209,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPythonPackagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/pythonPackages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/pythonPackages", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,9 +237,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PythonPackage>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -219,12 +263,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/aptArtifacts:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/aptArtifacts:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,12 +287,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/yumArtifacts:import", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/yumArtifacts:import", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -259,12 +311,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRepositoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -285,9 +341,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Repository>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -304,12 +367,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -327,18 +394,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Repository>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.repository
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("repository"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.repository
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("repository"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,9 +425,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -380,9 +451,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPackagesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/packages", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/packages", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -403,9 +481,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Package>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,9 +507,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -441,9 +533,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/versions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/versions", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -465,9 +564,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -485,9 +591,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -505,12 +618,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/versions:batchDelete", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/versions:batchDelete", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -525,18 +642,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.version
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("version"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.version
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,9 +673,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/files", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/files", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -582,9 +703,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::File>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -601,9 +729,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -620,18 +755,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::File>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.file
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("file"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.file
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("file"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -652,9 +784,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTagsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/tags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/tags", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -674,9 +813,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -693,9 +839,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/tags", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/tags", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -711,18 +864,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.tag
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.tag
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -743,9 +893,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -766,9 +923,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/rules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/rules", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -784,9 +948,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/rules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/rules", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -805,9 +976,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -824,18 +1002,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.rule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.rule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -856,9 +1031,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -879,12 +1061,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -899,12 +1085,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -931,12 +1121,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -951,9 +1145,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProjectSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -970,18 +1171,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProjectSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.project_settings
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("project_settings"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.project_settings
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("project_settings"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1004,9 +1202,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VPCSCConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1023,18 +1228,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VPCSCConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.vpcsc_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("vpcsc_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.vpcsc_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("vpcsc_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1057,18 +1259,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Package>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.package
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("package"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.package
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("package"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1091,12 +1290,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAttachmentsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/attachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/attachments", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1116,9 +1319,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Attachment>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1135,12 +1345,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/attachments", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/attachments", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1158,9 +1372,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1177,9 +1398,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/locations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1199,9 +1427,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1218,9 +1453,16 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -395,10 +395,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::Repository>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.repository
+            let arg = &req
+                .repository
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("repository"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("repository.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -643,10 +648,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::Version>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.version
+            let arg = &req
+                .version
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("version"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("version.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -756,10 +766,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::File>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.file
+            let arg = &req
+                .file
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("file"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("file.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -865,10 +880,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::Tag>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.tag
+            let arg = &req
+                .tag
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("tag"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("tag.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1003,10 +1023,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::Rule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.rule
+            let arg = &req
+                .rule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("rule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("rule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1172,10 +1197,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::ProjectSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.project_settings
+            let arg = &req
+                .project_settings
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("project_settings"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_settings.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1229,10 +1259,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::VPCSCConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.vpcsc_config
+            let arg = &req
+                .vpcsc_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("vpcsc_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("vpcsc_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1260,10 +1295,15 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
     ) -> Result<gax::response::Response<crate::model::Package>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.package
+            let arg = &req
+                .package
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("package"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("package.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/devtools/cloudbuild/v1/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/client.rs
@@ -140,49 +140,29 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_build(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::CreateBuild {
+    pub fn create_build(&self) -> super::builder::cloud_build::CreateBuild {
         super::builder::cloud_build::CreateBuild::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Returns information about a previously requested build.
     ///
     /// The `Build` that is returned includes its status (such as `SUCCESS`,
     /// `FAILURE`, or `WORKING`), and timing information.
-    pub fn get_build(
-        &self,
-        project_id: impl Into<std::string::String>,
-        id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::GetBuild {
+    pub fn get_build(&self) -> super::builder::cloud_build::GetBuild {
         super::builder::cloud_build::GetBuild::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_id(id.into())
     }
 
     /// Lists previously requested builds.
     ///
     /// Previously requested builds may still be in-progress, or may have finished
     /// successfully or unsuccessfully.
-    pub fn list_builds(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::ListBuilds {
+    pub fn list_builds(&self) -> super::builder::cloud_build::ListBuilds {
         super::builder::cloud_build::ListBuilds::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Cancels a build in progress.
-    pub fn cancel_build(
-        &self,
-        project_id: impl Into<std::string::String>,
-        id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::CancelBuild {
+    pub fn cancel_build(&self) -> super::builder::cloud_build::CancelBuild {
         super::builder::cloud_build::CancelBuild::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_id(id.into())
     }
 
     /// Creates a new build based on the specified build.
@@ -222,14 +202,8 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn retry_build(
-        &self,
-        project_id: impl Into<std::string::String>,
-        id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::RetryBuild {
+    pub fn retry_build(&self) -> super::builder::cloud_build::RetryBuild {
         super::builder::cloud_build::RetryBuild::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_id(id.into())
     }
 
     /// Approves or rejects a pending build.
@@ -248,72 +222,43 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn approve_build(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::ApproveBuild {
-        super::builder::cloud_build::ApproveBuild::new(self.inner.clone()).set_name(name.into())
+    pub fn approve_build(&self) -> super::builder::cloud_build::ApproveBuild {
+        super::builder::cloud_build::ApproveBuild::new(self.inner.clone())
     }
 
     /// Creates a new `BuildTrigger`.
     ///
     /// This API is experimental.
-    pub fn create_build_trigger(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::CreateBuildTrigger {
+    pub fn create_build_trigger(&self) -> super::builder::cloud_build::CreateBuildTrigger {
         super::builder::cloud_build::CreateBuildTrigger::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Returns information about a `BuildTrigger`.
     ///
     /// This API is experimental.
-    pub fn get_build_trigger(
-        &self,
-        project_id: impl Into<std::string::String>,
-        trigger_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::GetBuildTrigger {
+    pub fn get_build_trigger(&self) -> super::builder::cloud_build::GetBuildTrigger {
         super::builder::cloud_build::GetBuildTrigger::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_trigger_id(trigger_id.into())
     }
 
     /// Lists existing `BuildTrigger`s.
     ///
     /// This API is experimental.
-    pub fn list_build_triggers(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::ListBuildTriggers {
+    pub fn list_build_triggers(&self) -> super::builder::cloud_build::ListBuildTriggers {
         super::builder::cloud_build::ListBuildTriggers::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Deletes a `BuildTrigger` by its project ID and trigger ID.
     ///
     /// This API is experimental.
-    pub fn delete_build_trigger(
-        &self,
-        project_id: impl Into<std::string::String>,
-        trigger_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::DeleteBuildTrigger {
+    pub fn delete_build_trigger(&self) -> super::builder::cloud_build::DeleteBuildTrigger {
         super::builder::cloud_build::DeleteBuildTrigger::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_trigger_id(trigger_id.into())
     }
 
     /// Updates a `BuildTrigger` by its project ID and trigger ID.
     ///
     /// This API is experimental.
-    pub fn update_build_trigger(
-        &self,
-        project_id: impl Into<std::string::String>,
-        trigger_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::UpdateBuildTrigger {
+    pub fn update_build_trigger(&self) -> super::builder::cloud_build::UpdateBuildTrigger {
         super::builder::cloud_build::UpdateBuildTrigger::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_trigger_id(trigger_id.into())
     }
 
     /// Runs a `BuildTrigger` at a particular source revision.
@@ -333,26 +278,14 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_build_trigger(
-        &self,
-        project_id: impl Into<std::string::String>,
-        trigger_id: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::RunBuildTrigger {
+    pub fn run_build_trigger(&self) -> super::builder::cloud_build::RunBuildTrigger {
         super::builder::cloud_build::RunBuildTrigger::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_trigger_id(trigger_id.into())
     }
 
     /// ReceiveTriggerWebhook [Experimental] is called when the API receives a
     /// webhook request targeted at a specific trigger.
-    pub fn receive_trigger_webhook(
-        &self,
-        project_id: impl Into<std::string::String>,
-        trigger: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::ReceiveTriggerWebhook {
+    pub fn receive_trigger_webhook(&self) -> super::builder::cloud_build::ReceiveTriggerWebhook {
         super::builder::cloud_build::ReceiveTriggerWebhook::new(self.inner.clone())
-            .set_project_id(project_id.into())
-            .set_trigger(trigger.into())
     }
 
     /// Creates a `WorkerPool`.
@@ -366,20 +299,13 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_worker_pool(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::CreateWorkerPool {
+    pub fn create_worker_pool(&self) -> super::builder::cloud_build::CreateWorkerPool {
         super::builder::cloud_build::CreateWorkerPool::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns details of a `WorkerPool`.
-    pub fn get_worker_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::GetWorkerPool {
-        super::builder::cloud_build::GetWorkerPool::new(self.inner.clone()).set_name(name.into())
+    pub fn get_worker_pool(&self) -> super::builder::cloud_build::GetWorkerPool {
+        super::builder::cloud_build::GetWorkerPool::new(self.inner.clone())
     }
 
     /// Deletes a `WorkerPool`.
@@ -393,11 +319,8 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_worker_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::DeleteWorkerPool {
-        super::builder::cloud_build::DeleteWorkerPool::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_worker_pool(&self) -> super::builder::cloud_build::DeleteWorkerPool {
+        super::builder::cloud_build::DeleteWorkerPool::new(self.inner.clone())
     }
 
     /// Updates a `WorkerPool`.
@@ -411,40 +334,26 @@ impl CloudBuild {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_worker_pool(
-        &self,
-        worker_pool: impl Into<crate::model::WorkerPool>,
-    ) -> super::builder::cloud_build::UpdateWorkerPool {
+    pub fn update_worker_pool(&self) -> super::builder::cloud_build::UpdateWorkerPool {
         super::builder::cloud_build::UpdateWorkerPool::new(self.inner.clone())
-            .set_worker_pool(worker_pool.into())
     }
 
     /// Lists `WorkerPool`s.
-    pub fn list_worker_pools(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::ListWorkerPools {
+    pub fn list_worker_pools(&self) -> super::builder::cloud_build::ListWorkerPools {
         super::builder::cloud_build::ListWorkerPools::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::GetOperation {
-        super::builder::cloud_build::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::cloud_build::GetOperation {
+        super::builder::cloud_build::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::cloud_build::CancelOperation {
-        super::builder::cloud_build::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::cloud_build::CancelOperation {
+        super::builder::cloud_build::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -561,10 +561,15 @@ impl super::stub::CloudBuild for CloudBuild {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.worker_pool
+            let arg = &req
+                .worker_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("worker_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("worker_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/builds", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/builds", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,12 +71,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Build>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/builds/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/builds/{}", req.project_id, req.id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,12 +108,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBuildsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/builds", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/builds", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -116,12 +138,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Build>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/builds/{}:cancel",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/builds/{}:cancel", req.project_id, req.id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,12 +172,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/builds/{}:retry",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/builds/{}:retry", req.project_id, req.id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -156,9 +206,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:approve", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:approve", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -173,12 +230,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BuildTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/triggers", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/triggers", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -196,15 +257,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BuildTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/triggers/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.trigger_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("trigger_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/triggers/{}",
-                    req.project_id, req.trigger_id
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,12 +294,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBuildTriggersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/triggers", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/triggers", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -247,15 +323,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/triggers/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.trigger_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("trigger_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/triggers/{}",
-                    req.project_id, req.trigger_id
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,15 +364,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BuildTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/triggers/{}",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.trigger_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("trigger_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/projects/{}/triggers/{}",
-                    req.project_id, req.trigger_id
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -308,15 +406,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/triggers/{}:run",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.trigger_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("trigger_id"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/triggers/{}:run",
-                    req.project_id, req.trigger_id
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,15 +441,26 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReceiveTriggerWebhookResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/triggers/{}:webhook",
+            {
+                let arg = &req.project_id;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project_id"));
+                }
+                arg
+            },
+            {
+                let arg = &req.trigger;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("trigger"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/triggers/{}:webhook",
-                    req.project_id, req.trigger
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -357,12 +477,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/workerPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/workerPools", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -381,9 +505,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WorkerPool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -400,9 +531,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -422,18 +560,15 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.worker_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("worker_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.worker_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("worker_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -457,12 +592,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListWorkerPoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/workerPools", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/workerPools", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -481,9 +620,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -500,9 +646,16 @@ impl super::stub::CloudBuild for CloudBuild {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/cloudbuild/v2/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/client.rs
@@ -131,30 +131,18 @@ impl RepositoryManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::CreateConnection {
+    pub fn create_connection(&self) -> super::builder::repository_manager::CreateConnection {
         super::builder::repository_manager::CreateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single connection.
-    pub fn get_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::GetConnection {
+    pub fn get_connection(&self) -> super::builder::repository_manager::GetConnection {
         super::builder::repository_manager::GetConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Connections in a given project and location.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::ListConnections {
+    pub fn list_connections(&self) -> super::builder::repository_manager::ListConnections {
         super::builder::repository_manager::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a single connection.
@@ -168,12 +156,8 @@ impl RepositoryManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_connection(
-        &self,
-        connection: impl Into<crate::model::Connection>,
-    ) -> super::builder::repository_manager::UpdateConnection {
+    pub fn update_connection(&self) -> super::builder::repository_manager::UpdateConnection {
         super::builder::repository_manager::UpdateConnection::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// Deletes a single connection.
@@ -187,12 +171,8 @@ impl RepositoryManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::DeleteConnection {
+    pub fn delete_connection(&self) -> super::builder::repository_manager::DeleteConnection {
         super::builder::repository_manager::DeleteConnection::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a Repository.
@@ -206,12 +186,8 @@ impl RepositoryManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_repository(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::CreateRepository {
+    pub fn create_repository(&self) -> super::builder::repository_manager::CreateRepository {
         super::builder::repository_manager::CreateRepository::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates multiple repositories inside a connection.
@@ -227,28 +203,18 @@ impl RepositoryManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn batch_create_repositories(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::repository_manager::BatchCreateRepositories {
         super::builder::repository_manager::BatchCreateRepositories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets details of a single repository.
-    pub fn get_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::GetRepository {
+    pub fn get_repository(&self) -> super::builder::repository_manager::GetRepository {
         super::builder::repository_manager::GetRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists Repositories in a given connection.
-    pub fn list_repositories(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::ListRepositories {
+    pub fn list_repositories(&self) -> super::builder::repository_manager::ListRepositories {
         super::builder::repository_manager::ListRepositories::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a single repository.
@@ -262,49 +228,33 @@ impl RepositoryManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_repository(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::DeleteRepository {
+    pub fn delete_repository(&self) -> super::builder::repository_manager::DeleteRepository {
         super::builder::repository_manager::DeleteRepository::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Fetches read/write token of a given repository.
     pub fn fetch_read_write_token(
         &self,
-        repository: impl Into<std::string::String>,
     ) -> super::builder::repository_manager::FetchReadWriteToken {
         super::builder::repository_manager::FetchReadWriteToken::new(self.inner.clone())
-            .set_repository(repository.into())
     }
 
     /// Fetches read token of a given repository.
-    pub fn fetch_read_token(
-        &self,
-        repository: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::FetchReadToken {
+    pub fn fetch_read_token(&self) -> super::builder::repository_manager::FetchReadToken {
         super::builder::repository_manager::FetchReadToken::new(self.inner.clone())
-            .set_repository(repository.into())
     }
 
     /// FetchLinkableRepositories get repositories from SCM that are
     /// accessible and could be added to the connection.
     pub fn fetch_linkable_repositories(
         &self,
-        connection: impl Into<std::string::String>,
     ) -> super::builder::repository_manager::FetchLinkableRepositories {
         super::builder::repository_manager::FetchLinkableRepositories::new(self.inner.clone())
-            .set_connection(connection.into())
     }
 
     /// Fetch the list of branches or tags for a given repository.
-    pub fn fetch_git_refs(
-        &self,
-        repository: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::FetchGitRefs {
+    pub fn fetch_git_refs(&self) -> super::builder::repository_manager::FetchGitRefs {
         super::builder::repository_manager::FetchGitRefs::new(self.inner.clone())
-            .set_repository(repository.into())
     }
 
     /// Sets the access control policy on the specified resource. Replaces
@@ -312,22 +262,14 @@ impl RepositoryManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::repository_manager::SetIamPolicy {
         super::builder::repository_manager::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::repository_manager::GetIamPolicy {
         super::builder::repository_manager::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource. If the
@@ -337,33 +279,21 @@ impl RepositoryManager {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::repository_manager::TestIamPermissions {
         super::builder::repository_manager::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::repository_manager::GetOperation {
         super::builder::repository_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::repository_manager::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::repository_manager::CancelOperation {
         super::builder::repository_manager::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -128,10 +128,15 @@ impl super::stub::RepositoryManager for RepositoryManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.connection
+            let arg = &req
+                .connection
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +73,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,12 +99,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,18 +127,15 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.connection
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.connection
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("connection"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -148,9 +160,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,12 +188,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -192,12 +215,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/repositories:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/repositories:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,9 +239,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Repository>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,12 +265,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRepositoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/repositories", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/repositories", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,9 +294,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,12 +322,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchReadWriteTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:accessReadWriteToken", {
+            let arg = &req.repository;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("repository"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:accessReadWriteToken", req.repository),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -297,12 +346,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchReadTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:accessReadToken", {
+            let arg = &req.repository;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("repository"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:accessReadToken", req.repository),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -317,12 +370,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchLinkableRepositoriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:fetchLinkableRepositories", {
+            let arg = &req.connection;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("connection"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:fetchLinkableRepositories", req.connection),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -341,12 +398,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FetchGitRefsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:fetchGitRefs", {
+            let arg = &req.repository;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("repository"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:fetchGitRefs", req.repository),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -364,12 +425,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,12 +449,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,12 +485,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -436,9 +509,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -455,9 +535,16 @@ impl super::stub::RepositoryManager for RepositoryManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/cloudprofiler/v2/src/client.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/client.rs
@@ -142,12 +142,8 @@ impl ProfilerService {
     /// status. To a gRPC client, the extension will be return as a
     /// binary-serialized proto in the trailing metadata item named
     /// "google.rpc.retryinfo-bin".
-    pub fn create_profile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::profiler_service::CreateProfile {
+    pub fn create_profile(&self) -> super::builder::profiler_service::CreateProfile {
         super::builder::profiler_service::CreateProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// CreateOfflineProfile creates a new profile resource in the offline
@@ -158,12 +154,8 @@ impl ProfilerService {
     /// profiler
     /// agent](https://cloud.google.com/profiler/docs/about-profiler#profiling_agent)
     /// instead for profile collection._
-    pub fn create_offline_profile(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::profiler_service::CreateOfflineProfile {
+    pub fn create_offline_profile(&self) -> super::builder::profiler_service::CreateOfflineProfile {
         super::builder::profiler_service::CreateOfflineProfile::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// UpdateProfile updates the profile bytes and labels on the profile resource
@@ -175,12 +167,8 @@ impl ProfilerService {
     /// profiler
     /// agent](https://cloud.google.com/profiler/docs/about-profiler#profiling_agent)
     /// instead for profile collection._
-    pub fn update_profile(
-        &self,
-        profile: impl Into<crate::model::Profile>,
-    ) -> super::builder::profiler_service::UpdateProfile {
+    pub fn update_profile(&self) -> super::builder::profiler_service::UpdateProfile {
         super::builder::profiler_service::UpdateProfile::new(self.inner.clone())
-            .set_profile(profile.into())
     }
 }
 
@@ -287,11 +275,7 @@ impl ExportService {
 
     /// Lists profiles which have been collected so far and for which the caller
     /// has permission to view.
-    pub fn list_profiles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::export_service::ListProfiles {
+    pub fn list_profiles(&self) -> super::builder::export_service::ListProfiles {
         super::builder::export_service::ListProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 }

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ProfilerService for ProfilerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Profile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/profiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/profiles", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::ProfilerService for ProfilerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Profile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/profiles:createOffline", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/profiles:createOffline", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -88,18 +96,15 @@ impl super::stub::ProfilerService for ProfilerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Profile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            &req.profile
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("profile"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v2/{}",
-                    req.profile
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("profile"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,9 +150,16 @@ impl super::stub::ExportService for ExportService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/profiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/profiles", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -97,10 +97,15 @@ impl super::stub::ProfilerService for ProfilerService {
     ) -> Result<gax::response::Response<crate::model::Profile>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v2/{}", {
-            &req.profile
+            let arg = &req
+                .profile
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("profile"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("profile.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/devtools/cloudtrace/v2/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/client.rs
@@ -126,19 +126,12 @@ impl TraceService {
 
     /// Batch writes new spans to new or existing traces. You cannot update
     /// existing spans.
-    pub fn batch_write_spans(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::trace_service::BatchWriteSpans {
+    pub fn batch_write_spans(&self) -> super::builder::trace_service::BatchWriteSpans {
         super::builder::trace_service::BatchWriteSpans::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new span.
-    pub fn create_span(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::trace_service::CreateSpan {
-        super::builder::trace_service::CreateSpan::new(self.inner.clone()).set_name(name.into())
+    pub fn create_span(&self) -> super::builder::trace_service::CreateSpan {
+        super::builder::trace_service::CreateSpan::new(self.inner.clone())
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/transport.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::TraceService for TraceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/traces:batchWrite", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/traces:batchWrite", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -71,9 +75,16 @@ impl super::stub::TraceService for TraceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Span>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/devtools/containeranalysis/v1/src/client.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/client.rs
@@ -140,12 +140,8 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::container_analysis::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::container_analysis::SetIamPolicy {
         super::builder::container_analysis::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a note or an occurrence resource.
@@ -156,12 +152,8 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::container_analysis::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::container_analysis::GetIamPolicy {
         super::builder::container_analysis::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the permissions that a caller has on the specified note or
@@ -171,31 +163,21 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::container_analysis::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::container_analysis::TestIamPermissions {
         super::builder::container_analysis::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets a summary of the number and severity of occurrences.
     pub fn get_vulnerability_occurrences_summary(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::container_analysis::GetVulnerabilityOccurrencesSummary {
         super::builder::container_analysis::GetVulnerabilityOccurrencesSummary::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Generates an SBOM for the given resource.
-    pub fn export_sbom(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::container_analysis::ExportSBOM {
+    pub fn export_sbom(&self) -> super::builder::container_analysis::ExportSBOM {
         super::builder::container_analysis::ExportSBOM::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/devtools/containeranalysis/v1/src/transport.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +118,16 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VulnerabilityOccurrencesSummary>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/occurrences:vulnerabilitySummary", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/occurrences:vulnerabilitySummary", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -129,12 +145,16 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ExportSBOMResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportSBOM", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportSBOM", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/firestore/admin/v1/src/client.rs
+++ b/src/generated/firestore/admin/v1/src/client.rs
@@ -163,45 +163,28 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_index(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::CreateIndex {
+    pub fn create_index(&self) -> super::builder::firestore_admin::CreateIndex {
         super::builder::firestore_admin::CreateIndex::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists composite indexes.
-    pub fn list_indexes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListIndexes {
+    pub fn list_indexes(&self) -> super::builder::firestore_admin::ListIndexes {
         super::builder::firestore_admin::ListIndexes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a composite index.
-    pub fn get_index(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetIndex {
-        super::builder::firestore_admin::GetIndex::new(self.inner.clone()).set_name(name.into())
+    pub fn get_index(&self) -> super::builder::firestore_admin::GetIndex {
+        super::builder::firestore_admin::GetIndex::new(self.inner.clone())
     }
 
     /// Deletes a composite index.
-    pub fn delete_index(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteIndex {
-        super::builder::firestore_admin::DeleteIndex::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_index(&self) -> super::builder::firestore_admin::DeleteIndex {
+        super::builder::firestore_admin::DeleteIndex::new(self.inner.clone())
     }
 
     /// Gets the metadata and configuration for a Field.
-    pub fn get_field(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetField {
-        super::builder::firestore_admin::GetField::new(self.inner.clone()).set_name(name.into())
+    pub fn get_field(&self) -> super::builder::firestore_admin::GetField {
+        super::builder::firestore_admin::GetField::new(self.inner.clone())
     }
 
     /// Updates a field configuration. Currently, field updates apply only to
@@ -234,12 +217,8 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_field(
-        &self,
-        field: impl Into<crate::model::Field>,
-    ) -> super::builder::firestore_admin::UpdateField {
+    pub fn update_field(&self) -> super::builder::firestore_admin::UpdateField {
         super::builder::firestore_admin::UpdateField::new(self.inner.clone())
-            .set_field(field.into())
     }
 
     /// Lists the field configuration and metadata for this database.
@@ -253,12 +232,8 @@ impl FirestoreAdmin {
     /// `ttlConfig:*`.
     ///
     /// [google.firestore.admin.v1.FirestoreAdmin.ListFields]: crate::client::FirestoreAdmin::list_fields
-    pub fn list_fields(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListFields {
+    pub fn list_fields(&self) -> super::builder::firestore_admin::ListFields {
         super::builder::firestore_admin::ListFields::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Exports a copy of all or a subset of documents from Google Cloud Firestore
@@ -282,12 +257,8 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn export_documents(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ExportDocuments {
+    pub fn export_documents(&self) -> super::builder::firestore_admin::ExportDocuments {
         super::builder::firestore_admin::ExportDocuments::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Imports documents into Google Cloud Firestore. Existing documents with the
@@ -305,12 +276,8 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn import_documents(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ImportDocuments {
+    pub fn import_documents(&self) -> super::builder::firestore_admin::ImportDocuments {
         super::builder::firestore_admin::ImportDocuments::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Bulk deletes a subset of documents from Google Cloud Firestore.
@@ -331,12 +298,8 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn bulk_delete_documents(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::BulkDeleteDocuments {
+    pub fn bulk_delete_documents(&self) -> super::builder::firestore_admin::BulkDeleteDocuments {
         super::builder::firestore_admin::BulkDeleteDocuments::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a database.
@@ -350,29 +313,18 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_database(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::CreateDatabase {
+    pub fn create_database(&self) -> super::builder::firestore_admin::CreateDatabase {
         super::builder::firestore_admin::CreateDatabase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a database.
-    pub fn get_database(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetDatabase {
-        super::builder::firestore_admin::GetDatabase::new(self.inner.clone()).set_name(name.into())
+    pub fn get_database(&self) -> super::builder::firestore_admin::GetDatabase {
+        super::builder::firestore_admin::GetDatabase::new(self.inner.clone())
     }
 
     /// List all the databases in the project.
-    pub fn list_databases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListDatabases {
+    pub fn list_databases(&self) -> super::builder::firestore_admin::ListDatabases {
         super::builder::firestore_admin::ListDatabases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a database.
@@ -386,12 +338,8 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_database(
-        &self,
-        database: impl Into<crate::model::Database>,
-    ) -> super::builder::firestore_admin::UpdateDatabase {
+    pub fn update_database(&self) -> super::builder::firestore_admin::UpdateDatabase {
         super::builder::firestore_admin::UpdateDatabase::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Deletes a database.
@@ -405,101 +353,60 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_database(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteDatabase {
+    pub fn delete_database(&self) -> super::builder::firestore_admin::DeleteDatabase {
         super::builder::firestore_admin::DeleteDatabase::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a user creds.
-    pub fn create_user_creds(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::CreateUserCreds {
+    pub fn create_user_creds(&self) -> super::builder::firestore_admin::CreateUserCreds {
         super::builder::firestore_admin::CreateUserCreds::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a user creds resource. Note that the returned resource does not
     /// contain the secret value itself.
-    pub fn get_user_creds(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetUserCreds {
-        super::builder::firestore_admin::GetUserCreds::new(self.inner.clone()).set_name(name.into())
+    pub fn get_user_creds(&self) -> super::builder::firestore_admin::GetUserCreds {
+        super::builder::firestore_admin::GetUserCreds::new(self.inner.clone())
     }
 
     /// List all user creds in the database. Note that the returned resource
     /// does not contain the secret value itself.
-    pub fn list_user_creds(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListUserCreds {
+    pub fn list_user_creds(&self) -> super::builder::firestore_admin::ListUserCreds {
         super::builder::firestore_admin::ListUserCreds::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Enables a user creds. No-op if the user creds are already enabled.
-    pub fn enable_user_creds(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::EnableUserCreds {
+    pub fn enable_user_creds(&self) -> super::builder::firestore_admin::EnableUserCreds {
         super::builder::firestore_admin::EnableUserCreds::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Disables a user creds. No-op if the user creds are already disabled.
-    pub fn disable_user_creds(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DisableUserCreds {
+    pub fn disable_user_creds(&self) -> super::builder::firestore_admin::DisableUserCreds {
         super::builder::firestore_admin::DisableUserCreds::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resets the password of a user creds.
-    pub fn reset_user_password(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ResetUserPassword {
+    pub fn reset_user_password(&self) -> super::builder::firestore_admin::ResetUserPassword {
         super::builder::firestore_admin::ResetUserPassword::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a user creds.
-    pub fn delete_user_creds(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteUserCreds {
+    pub fn delete_user_creds(&self) -> super::builder::firestore_admin::DeleteUserCreds {
         super::builder::firestore_admin::DeleteUserCreds::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets information about a backup.
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetBackup {
-        super::builder::firestore_admin::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::firestore_admin::GetBackup {
+        super::builder::firestore_admin::GetBackup::new(self.inner.clone())
     }
 
     /// Lists all the backups.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListBackups {
+    pub fn list_backups(&self) -> super::builder::firestore_admin::ListBackups {
         super::builder::firestore_admin::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a backup.
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteBackup {
-        super::builder::firestore_admin::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::firestore_admin::DeleteBackup {
+        super::builder::firestore_admin::DeleteBackup::new(self.inner.clone())
     }
 
     /// Creates a new database by restoring from an existing backup.
@@ -536,101 +443,62 @@ impl FirestoreAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_database(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::RestoreDatabase {
+    pub fn restore_database(&self) -> super::builder::firestore_admin::RestoreDatabase {
         super::builder::firestore_admin::RestoreDatabase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a backup schedule on a database.
     /// At most two backup schedules can be configured on a database, one daily
     /// backup schedule and one weekly backup schedule.
-    pub fn create_backup_schedule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::CreateBackupSchedule {
+    pub fn create_backup_schedule(&self) -> super::builder::firestore_admin::CreateBackupSchedule {
         super::builder::firestore_admin::CreateBackupSchedule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a backup schedule.
-    pub fn get_backup_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetBackupSchedule {
+    pub fn get_backup_schedule(&self) -> super::builder::firestore_admin::GetBackupSchedule {
         super::builder::firestore_admin::GetBackupSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List backup schedules.
-    pub fn list_backup_schedules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListBackupSchedules {
+    pub fn list_backup_schedules(&self) -> super::builder::firestore_admin::ListBackupSchedules {
         super::builder::firestore_admin::ListBackupSchedules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a backup schedule.
-    pub fn update_backup_schedule(
-        &self,
-        backup_schedule: impl Into<crate::model::BackupSchedule>,
-    ) -> super::builder::firestore_admin::UpdateBackupSchedule {
+    pub fn update_backup_schedule(&self) -> super::builder::firestore_admin::UpdateBackupSchedule {
         super::builder::firestore_admin::UpdateBackupSchedule::new(self.inner.clone())
-            .set_backup_schedule(backup_schedule.into())
     }
 
     /// Deletes a backup schedule.
-    pub fn delete_backup_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteBackupSchedule {
+    pub fn delete_backup_schedule(&self) -> super::builder::firestore_admin::DeleteBackupSchedule {
         super::builder::firestore_admin::DeleteBackupSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::firestore_admin::ListOperations {
         super::builder::firestore_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::GetOperation {
-        super::builder::firestore_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::firestore_admin::GetOperation {
+        super::builder::firestore_admin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::firestore_admin::DeleteOperation {
         super::builder::firestore_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::firestore_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::firestore_admin::CancelOperation {
         super::builder::firestore_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -182,10 +182,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.field
+            let arg = &req
+                .field
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("field"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("field.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -392,10 +397,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.database
+            let arg = &req
+                .database
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("database"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -816,10 +826,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_schedule
+            let arg = &req
+                .backup_schedule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_schedule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/indexes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/indexes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,9 +70,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListIndexesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/indexes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/indexes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -85,9 +99,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Index>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,9 +125,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -127,9 +155,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Field>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -146,18 +181,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.field
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("field"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.field
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("field"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -178,9 +210,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFieldsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/fields", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/fields", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,12 +239,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:exportDocuments", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:exportDocuments", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -220,12 +263,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:importDocuments", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:importDocuments", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,12 +287,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:bulkDeleteDocuments", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:bulkDeleteDocuments", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,12 +311,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/databases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/databases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -283,9 +338,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Database>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -302,12 +364,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatabasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/databases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/databases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -325,18 +391,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.database
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("database"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.database
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("database"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -359,9 +422,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -379,12 +449,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserCreds>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/userCreds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/userCreds", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -402,9 +476,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserCreds>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -421,12 +502,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUserCredsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/userCreds", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/userCreds", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -443,9 +528,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserCreds>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -460,9 +552,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserCreds>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,12 +576,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UserCreds>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resetPassword", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:resetPassword", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -497,9 +600,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -520,9 +630,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -539,9 +656,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,9 +683,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -582,12 +713,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/databases:restore", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/databases:restore", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -602,12 +737,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupSchedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupSchedules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -624,9 +763,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -643,12 +789,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupSchedulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupSchedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupSchedules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -665,18 +815,15 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_schedule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_schedule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -699,9 +846,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -722,9 +876,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -744,9 +905,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -763,9 +931,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -786,9 +961,16 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/grafeas/v1/src/client.rs
+++ b/src/generated/grafeas/v1/src/client.rs
@@ -132,120 +132,77 @@ impl Grafeas {
     }
 
     /// Gets the specified occurrence.
-    pub fn get_occurrence(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::GetOccurrence {
-        super::builder::grafeas::GetOccurrence::new(self.inner.clone()).set_name(name.into())
+    pub fn get_occurrence(&self) -> super::builder::grafeas::GetOccurrence {
+        super::builder::grafeas::GetOccurrence::new(self.inner.clone())
     }
 
     /// Lists occurrences for the specified project.
-    pub fn list_occurrences(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::ListOccurrences {
-        super::builder::grafeas::ListOccurrences::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_occurrences(&self) -> super::builder::grafeas::ListOccurrences {
+        super::builder::grafeas::ListOccurrences::new(self.inner.clone())
     }
 
     /// Deletes the specified occurrence. For example, use this method to delete an
     /// occurrence when the occurrence is no longer applicable for the given
     /// resource.
-    pub fn delete_occurrence(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::DeleteOccurrence {
-        super::builder::grafeas::DeleteOccurrence::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_occurrence(&self) -> super::builder::grafeas::DeleteOccurrence {
+        super::builder::grafeas::DeleteOccurrence::new(self.inner.clone())
     }
 
     /// Creates a new occurrence.
-    pub fn create_occurrence(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::CreateOccurrence {
-        super::builder::grafeas::CreateOccurrence::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_occurrence(&self) -> super::builder::grafeas::CreateOccurrence {
+        super::builder::grafeas::CreateOccurrence::new(self.inner.clone())
     }
 
     /// Creates new occurrences in batch.
-    pub fn batch_create_occurrences(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::BatchCreateOccurrences {
+    pub fn batch_create_occurrences(&self) -> super::builder::grafeas::BatchCreateOccurrences {
         super::builder::grafeas::BatchCreateOccurrences::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the specified occurrence.
-    pub fn update_occurrence(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::UpdateOccurrence {
-        super::builder::grafeas::UpdateOccurrence::new(self.inner.clone()).set_name(name.into())
+    pub fn update_occurrence(&self) -> super::builder::grafeas::UpdateOccurrence {
+        super::builder::grafeas::UpdateOccurrence::new(self.inner.clone())
     }
 
     /// Gets the note attached to the specified occurrence. Consumer projects can
     /// use this method to get a note that belongs to a provider project.
-    pub fn get_occurrence_note(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::GetOccurrenceNote {
-        super::builder::grafeas::GetOccurrenceNote::new(self.inner.clone()).set_name(name.into())
+    pub fn get_occurrence_note(&self) -> super::builder::grafeas::GetOccurrenceNote {
+        super::builder::grafeas::GetOccurrenceNote::new(self.inner.clone())
     }
 
     /// Gets the specified note.
-    pub fn get_note(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::GetNote {
-        super::builder::grafeas::GetNote::new(self.inner.clone()).set_name(name.into())
+    pub fn get_note(&self) -> super::builder::grafeas::GetNote {
+        super::builder::grafeas::GetNote::new(self.inner.clone())
     }
 
     /// Lists notes for the specified project.
-    pub fn list_notes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::ListNotes {
-        super::builder::grafeas::ListNotes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_notes(&self) -> super::builder::grafeas::ListNotes {
+        super::builder::grafeas::ListNotes::new(self.inner.clone())
     }
 
     /// Deletes the specified note.
-    pub fn delete_note(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::DeleteNote {
-        super::builder::grafeas::DeleteNote::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_note(&self) -> super::builder::grafeas::DeleteNote {
+        super::builder::grafeas::DeleteNote::new(self.inner.clone())
     }
 
     /// Creates a new note.
-    pub fn create_note(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::CreateNote {
-        super::builder::grafeas::CreateNote::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_note(&self) -> super::builder::grafeas::CreateNote {
+        super::builder::grafeas::CreateNote::new(self.inner.clone())
     }
 
     /// Creates new notes in batch.
-    pub fn batch_create_notes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::BatchCreateNotes {
-        super::builder::grafeas::BatchCreateNotes::new(self.inner.clone()).set_parent(parent.into())
+    pub fn batch_create_notes(&self) -> super::builder::grafeas::BatchCreateNotes {
+        super::builder::grafeas::BatchCreateNotes::new(self.inner.clone())
     }
 
     /// Updates the specified note.
-    pub fn update_note(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::UpdateNote {
-        super::builder::grafeas::UpdateNote::new(self.inner.clone()).set_name(name.into())
+    pub fn update_note(&self) -> super::builder::grafeas::UpdateNote {
+        super::builder::grafeas::UpdateNote::new(self.inner.clone())
     }
 
     /// Lists occurrences referencing the specified note. Provider projects can use
     /// this method to get all occurrences across consumer projects referencing the
     /// specified note.
-    pub fn list_note_occurrences(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::grafeas::ListNoteOccurrences {
-        super::builder::grafeas::ListNoteOccurrences::new(self.inner.clone()).set_name(name.into())
+    pub fn list_note_occurrences(&self) -> super::builder::grafeas::ListNoteOccurrences {
+        super::builder::grafeas::ListNoteOccurrences::new(self.inner.clone())
     }
 }

--- a/src/generated/grafeas/v1/src/transport.rs
+++ b/src/generated/grafeas/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Occurrence>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -65,12 +72,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOccurrencesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/occurrences", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/occurrences", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,9 +101,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,12 +131,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Occurrence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/occurrences", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/occurrences", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,12 +157,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchCreateOccurrencesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/occurrences:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/occurrences:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,9 +181,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Occurrence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,9 +213,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Note>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notes", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/notes", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -199,9 +239,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Note>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -218,9 +265,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/notes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/notes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -240,9 +294,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -263,9 +324,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Note>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/notes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/notes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -281,12 +349,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchCreateNotesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/notes:batchCreate", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/notes:batchCreate", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -301,9 +373,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Note>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -324,12 +403,16 @@ impl super::stub::Grafeas for Grafeas {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNoteOccurrencesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/occurrences", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/occurrences", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -147,31 +147,22 @@ impl Iam {
     /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that belongs to a specific project.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn list_service_accounts(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::ListServiceAccounts {
-        super::builder::iam::ListServiceAccounts::new(self.inner.clone()).set_name(name.into())
+    pub fn list_service_accounts(&self) -> super::builder::iam::ListServiceAccounts {
+        super::builder::iam::ListServiceAccounts::new(self.inner.clone())
     }
 
     /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn get_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::GetServiceAccount {
-        super::builder::iam::GetServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service_account(&self) -> super::builder::iam::GetServiceAccount {
+        super::builder::iam::GetServiceAccount::new(self.inner.clone())
     }
 
     /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn create_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::CreateServiceAccount {
-        super::builder::iam::CreateServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn create_service_account(&self) -> super::builder::iam::CreateServiceAccount {
+        super::builder::iam::CreateServiceAccount::new(self.inner.clone())
     }
 
     /// **Note:** We are in the process of deprecating this method. Use
@@ -183,22 +174,15 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.PatchServiceAccount]: crate::client::Iam::patch_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn update_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::UpdateServiceAccount {
-        super::builder::iam::UpdateServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn update_service_account(&self) -> super::builder::iam::UpdateServiceAccount {
+        super::builder::iam::UpdateServiceAccount::new(self.inner.clone())
     }
 
     /// Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn patch_service_account(
-        &self,
-        service_account: impl Into<crate::model::ServiceAccount>,
-    ) -> super::builder::iam::PatchServiceAccount {
+    pub fn patch_service_account(&self) -> super::builder::iam::PatchServiceAccount {
         super::builder::iam::PatchServiceAccount::new(self.inner.clone())
-            .set_service_account(service_account.into())
     }
 
     /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -219,11 +203,8 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.DisableServiceAccount]: crate::client::Iam::disable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn delete_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::DeleteServiceAccount {
-        super::builder::iam::DeleteServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_service_account(&self) -> super::builder::iam::DeleteServiceAccount {
+        super::builder::iam::DeleteServiceAccount::new(self.inner.clone())
     }
 
     /// Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -236,11 +217,8 @@ impl Iam {
     /// that has been permanently removed.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn undelete_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::UndeleteServiceAccount {
-        super::builder::iam::UndeleteServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_service_account(&self) -> super::builder::iam::UndeleteServiceAccount {
+        super::builder::iam::UndeleteServiceAccount::new(self.inner.clone())
     }
 
     /// Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was disabled by
@@ -254,11 +232,8 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.DisableServiceAccount]: crate::client::Iam::disable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn enable_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::EnableServiceAccount {
-        super::builder::iam::EnableServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn enable_service_account(&self) -> super::builder::iam::EnableServiceAccount {
+        super::builder::iam::EnableServiceAccount::new(self.inner.clone())
     }
 
     /// Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] immediately.
@@ -281,41 +256,29 @@ impl Iam {
     /// [google.iam.admin.v1.IAM.DeleteServiceAccount]: crate::client::Iam::delete_service_account
     /// [google.iam.admin.v1.IAM.EnableServiceAccount]: crate::client::Iam::enable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn disable_service_account(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::DisableServiceAccount {
-        super::builder::iam::DisableServiceAccount::new(self.inner.clone()).set_name(name.into())
+    pub fn disable_service_account(&self) -> super::builder::iam::DisableServiceAccount {
+        super::builder::iam::DisableServiceAccount::new(self.inner.clone())
     }
 
     /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn list_service_account_keys(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::ListServiceAccountKeys {
-        super::builder::iam::ListServiceAccountKeys::new(self.inner.clone()).set_name(name.into())
+    pub fn list_service_account_keys(&self) -> super::builder::iam::ListServiceAccountKeys {
+        super::builder::iam::ListServiceAccountKeys::new(self.inner.clone())
     }
 
     /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn get_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::GetServiceAccountKey {
-        super::builder::iam::GetServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn get_service_account_key(&self) -> super::builder::iam::GetServiceAccountKey {
+        super::builder::iam::GetServiceAccountKey::new(self.inner.clone())
     }
 
     /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn create_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::CreateServiceAccountKey {
-        super::builder::iam::CreateServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn create_service_account_key(&self) -> super::builder::iam::CreateServiceAccountKey {
+        super::builder::iam::CreateServiceAccountKey::new(self.inner.clone())
     }
 
     /// Uploads the public key portion of a key pair that you manage, and
@@ -325,11 +288,8 @@ impl Iam {
     /// pair as a service account key.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn upload_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::UploadServiceAccountKey {
-        super::builder::iam::UploadServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn upload_service_account_key(&self) -> super::builder::iam::UploadServiceAccountKey {
+        super::builder::iam::UploadServiceAccountKey::new(self.inner.clone())
     }
 
     /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey]. Deleting a service account key does not
@@ -337,11 +297,8 @@ impl Iam {
     /// account key.
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn delete_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::DeleteServiceAccountKey {
-        super::builder::iam::DeleteServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_service_account_key(&self) -> super::builder::iam::DeleteServiceAccountKey {
+        super::builder::iam::DeleteServiceAccountKey::new(self.inner.clone())
     }
 
     /// Disable a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey]. A disabled service account key can be
@@ -349,21 +306,15 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.EnableServiceAccountKey]: crate::client::Iam::enable_service_account_key
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn disable_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::DisableServiceAccountKey {
-        super::builder::iam::DisableServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn disable_service_account_key(&self) -> super::builder::iam::DisableServiceAccountKey {
+        super::builder::iam::DisableServiceAccountKey::new(self.inner.clone())
     }
 
     /// Enable a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
-    pub fn enable_service_account_key(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::EnableServiceAccountKey {
-        super::builder::iam::EnableServiceAccountKey::new(self.inner.clone()).set_name(name.into())
+    pub fn enable_service_account_key(&self) -> super::builder::iam::EnableServiceAccountKey {
+        super::builder::iam::EnableServiceAccountKey::new(self.inner.clone())
     }
 
     /// **Note:** This method is deprecated. Use the
@@ -377,8 +328,8 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
     #[deprecated]
-    pub fn sign_blob(&self, name: impl Into<std::string::String>) -> super::builder::iam::SignBlob {
-        super::builder::iam::SignBlob::new(self.inner.clone()).set_name(name.into())
+    pub fn sign_blob(&self) -> super::builder::iam::SignBlob {
+        super::builder::iam::SignBlob::new(self.inner.clone())
     }
 
     /// **Note:** This method is deprecated. Use the
@@ -393,8 +344,8 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
     #[deprecated]
-    pub fn sign_jwt(&self, name: impl Into<std::string::String>) -> super::builder::iam::SignJwt {
-        super::builder::iam::SignJwt::new(self.inner.clone()).set_name(name.into())
+    pub fn sign_jwt(&self) -> super::builder::iam::SignJwt {
+        super::builder::iam::SignJwt::new(self.inner.clone())
     }
 
     /// Gets the IAM policy that is attached to a [ServiceAccount][google.iam.admin.v1.ServiceAccount]. This IAM
@@ -409,11 +360,8 @@ impl Iam {
     /// method.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam::GetIamPolicy {
-        super::builder::iam::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::iam::GetIamPolicy {
+        super::builder::iam::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM policy that is attached to a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -437,23 +385,16 @@ impl Iam {
     /// resources](https://cloud.google.com/iam/help/access/manage-other-resources).
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam::SetIamPolicy {
-        super::builder::iam::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::iam::SetIamPolicy {
+        super::builder::iam::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Tests whether the caller has the specified permissions on a
     /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::iam::TestIamPermissions {
         super::builder::iam::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Lists roles that can be granted on a Google Cloud resource. A role is
@@ -474,28 +415,22 @@ impl Iam {
     /// Gets the definition of a [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
-    pub fn get_role(&self, name: impl Into<std::string::String>) -> super::builder::iam::GetRole {
-        super::builder::iam::GetRole::new(self.inner.clone()).set_name(name.into())
+    pub fn get_role(&self) -> super::builder::iam::GetRole {
+        super::builder::iam::GetRole::new(self.inner.clone())
     }
 
     /// Creates a new custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
-    pub fn create_role(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::iam::CreateRole {
-        super::builder::iam::CreateRole::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_role(&self) -> super::builder::iam::CreateRole {
+        super::builder::iam::CreateRole::new(self.inner.clone())
     }
 
     /// Updates the definition of a custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
-    pub fn update_role(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::UpdateRole {
-        super::builder::iam::UpdateRole::new(self.inner.clone()).set_name(name.into())
+    pub fn update_role(&self) -> super::builder::iam::UpdateRole {
+        super::builder::iam::UpdateRole::new(self.inner.clone())
     }
 
     /// Deletes a custom [Role][google.iam.admin.v1.Role].
@@ -519,21 +454,15 @@ impl Iam {
     /// [google.iam.admin.v1.IAM.ListRoles]: crate::client::Iam::list_roles
     /// [google.iam.admin.v1.Role]: crate::model::Role
     /// [google.iam.v1.Policy]: iam_v1::model::Policy
-    pub fn delete_role(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::DeleteRole {
-        super::builder::iam::DeleteRole::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_role(&self) -> super::builder::iam::DeleteRole {
+        super::builder::iam::DeleteRole::new(self.inner.clone())
     }
 
     /// Undeletes a custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
-    pub fn undelete_role(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam::UndeleteRole {
-        super::builder::iam::UndeleteRole::new(self.inner.clone()).set_name(name.into())
+    pub fn undelete_role(&self) -> super::builder::iam::UndeleteRole {
+        super::builder::iam::UndeleteRole::new(self.inner.clone())
     }
 
     /// Lists every permission that you can test on a resource. A permission is

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -147,10 +147,15 @@ impl super::stub::Iam for Iam {
     ) -> Result<gax::response::Response<crate::model::ServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service_account
+            let arg = &req
+                .service_account
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_account"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_account.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -44,12 +44,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceAccountsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/serviceAccounts", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/serviceAccounts", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,12 +98,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/serviceAccounts", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/serviceAccounts", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -107,9 +122,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,18 +146,15 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service_account
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_account"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service_account
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_account"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +169,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -173,9 +199,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UndeleteServiceAccountResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,9 +223,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -212,9 +252,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -234,9 +281,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceAccountKeysResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/keys", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/keys", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -257,9 +311,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccountKey>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -277,9 +338,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccountKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/keys", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/keys", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -294,12 +362,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceAccountKey>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/keys:upload", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/keys:upload", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,9 +386,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -337,9 +416,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:disable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:disable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -359,9 +445,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:enable", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:enable", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -381,9 +474,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SignBlobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:signBlob", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:signBlob", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -398,9 +498,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SignJwtResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:signJwt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:signJwt", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -415,12 +522,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,12 +558,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -467,12 +582,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -487,12 +606,10 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryGrantableRolesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/roles:queryGrantableRoles".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/roles:queryGrantableRoles".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -507,9 +624,10 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRolesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/roles".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/roles".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -531,9 +649,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Role>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -550,9 +675,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Role>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/roles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/roles", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -567,9 +699,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Role>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -590,9 +729,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Role>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -610,9 +756,16 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Role>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -627,12 +780,10 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryTestablePermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/permissions:queryTestablePermissions".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/permissions:queryTestablePermissions".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -647,12 +798,10 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryAuditableServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/iamPolicies:queryAuditableServices".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/iamPolicies:queryAuditableServices".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -667,12 +816,10 @@ impl super::stub::Iam for Iam {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LintPolicyResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/iamPolicies:lintPolicy".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1/iamPolicies:lintPolicy".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/credentials/v1/src/client.rs
+++ b/src/generated/iam/credentials/v1/src/client.rs
@@ -127,36 +127,22 @@ impl IAMCredentials {
     }
 
     /// Generates an OAuth 2.0 access token for a service account.
-    pub fn generate_access_token(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam_credentials::GenerateAccessToken {
+    pub fn generate_access_token(&self) -> super::builder::iam_credentials::GenerateAccessToken {
         super::builder::iam_credentials::GenerateAccessToken::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Generates an OpenID Connect ID token for a service account.
-    pub fn generate_id_token(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam_credentials::GenerateIdToken {
+    pub fn generate_id_token(&self) -> super::builder::iam_credentials::GenerateIdToken {
         super::builder::iam_credentials::GenerateIdToken::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Signs a blob using a service account's system-managed private key.
-    pub fn sign_blob(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam_credentials::SignBlob {
-        super::builder::iam_credentials::SignBlob::new(self.inner.clone()).set_name(name.into())
+    pub fn sign_blob(&self) -> super::builder::iam_credentials::SignBlob {
+        super::builder::iam_credentials::SignBlob::new(self.inner.clone())
     }
 
     /// Signs a JWT using a service account's system-managed private key.
-    pub fn sign_jwt(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::iam_credentials::SignJwt {
-        super::builder::iam_credentials::SignJwt::new(self.inner.clone()).set_name(name.into())
+    pub fn sign_jwt(&self) -> super::builder::iam_credentials::SignJwt {
+        super::builder::iam_credentials::SignJwt::new(self.inner.clone())
     }
 }

--- a/src/generated/iam/credentials/v1/src/transport.rs
+++ b/src/generated/iam/credentials/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::IAMCredentials for IAMCredentials {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateAccessTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateAccessToken", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateAccessToken", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::IAMCredentials for IAMCredentials {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GenerateIdTokenResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:generateIdToken", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:generateIdToken", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +94,16 @@ impl super::stub::IAMCredentials for IAMCredentials {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SignBlobResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:signBlob", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:signBlob", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,9 +118,16 @@ impl super::stub::IAMCredentials for IAMCredentials {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SignJwtResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:signJwt", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:signJwt", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -146,23 +146,15 @@ impl IAMPolicy {
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam_policy::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::iam_policy::SetIamPolicy {
         super::builder::iam_policy::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam_policy::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::iam_policy::GetIamPolicy {
         super::builder::iam_policy::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that a caller has on the specified resource.
@@ -172,11 +164,7 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::iam_policy::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::iam_policy::TestIamPermissions {
         super::builder::iam_policy::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::IAMPolicy for IAMPolicy {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -123,19 +123,13 @@ impl Policies {
     ///
     /// The response lists only policy metadata. In particular, policy rules are
     /// omitted.
-    pub fn list_policies(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policies::ListPolicies {
-        super::builder::policies::ListPolicies::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_policies(&self) -> super::builder::policies::ListPolicies {
+        super::builder::policies::ListPolicies::new(self.inner.clone())
     }
 
     /// Gets a policy.
-    pub fn get_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policies::GetPolicy {
-        super::builder::policies::GetPolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn get_policy(&self) -> super::builder::policies::GetPolicy {
+        super::builder::policies::GetPolicy::new(self.inner.clone())
     }
 
     /// Creates a policy.
@@ -149,11 +143,8 @@ impl Policies {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_policy(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policies::CreatePolicy {
-        super::builder::policies::CreatePolicy::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_policy(&self) -> super::builder::policies::CreatePolicy {
+        super::builder::policies::CreatePolicy::new(self.inner.clone())
     }
 
     /// Updates the specified policy.
@@ -179,11 +170,8 @@ impl Policies {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_policy(
-        &self,
-        policy: impl Into<crate::model::Policy>,
-    ) -> super::builder::policies::UpdatePolicy {
-        super::builder::policies::UpdatePolicy::new(self.inner.clone()).set_policy(policy.into())
+    pub fn update_policy(&self) -> super::builder::policies::UpdatePolicy {
+        super::builder::policies::UpdatePolicy::new(self.inner.clone())
     }
 
     /// Deletes a policy. This action is permanent.
@@ -197,20 +185,14 @@ impl Policies {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policies::DeletePolicy {
-        super::builder::policies::DeletePolicy::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_policy(&self) -> super::builder::policies::DeletePolicy {
+        super::builder::policies::DeletePolicy::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policies::GetOperation {
-        super::builder::policies::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::policies::GetOperation {
+        super::builder::policies::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/iam/v2/src/transport.rs
+++ b/src/generated/iam/v2/src/transport.rs
@@ -126,10 +126,15 @@ impl super::stub::Policies for Policies {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v2/{}", {
-            &req.policy
+            let arg = &req
+                .policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/iam/v2/src/transport.rs
+++ b/src/generated/iam/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -67,9 +74,16 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +100,16 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,18 +125,15 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            &req.policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v2/{}",
-                    req.policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -130,9 +148,16 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -150,9 +175,16 @@ impl super::stub::Policies for Policies {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/v3/src/client.rs
+++ b/src/generated/iam/v3/src/client.rs
@@ -132,21 +132,13 @@ impl PolicyBindings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_policy_binding(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_bindings::CreatePolicyBinding {
+    pub fn create_policy_binding(&self) -> super::builder::policy_bindings::CreatePolicyBinding {
         super::builder::policy_bindings::CreatePolicyBinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a policy binding.
-    pub fn get_policy_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_bindings::GetPolicyBinding {
+    pub fn get_policy_binding(&self) -> super::builder::policy_bindings::GetPolicyBinding {
         super::builder::policy_bindings::GetPolicyBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a policy binding and returns a long-running operation.
@@ -164,12 +156,8 @@ impl PolicyBindings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_policy_binding(
-        &self,
-        policy_binding: impl Into<crate::model::PolicyBinding>,
-    ) -> super::builder::policy_bindings::UpdatePolicyBinding {
+    pub fn update_policy_binding(&self) -> super::builder::policy_bindings::UpdatePolicyBinding {
         super::builder::policy_bindings::UpdatePolicyBinding::new(self.inner.clone())
-            .set_policy_binding(policy_binding.into())
     }
 
     /// Deletes a policy binding and returns a long-running operation.
@@ -185,41 +173,28 @@ impl PolicyBindings {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_policy_binding(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_bindings::DeletePolicyBinding {
+    pub fn delete_policy_binding(&self) -> super::builder::policy_bindings::DeletePolicyBinding {
         super::builder::policy_bindings::DeletePolicyBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists policy bindings.
-    pub fn list_policy_bindings(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::policy_bindings::ListPolicyBindings {
+    pub fn list_policy_bindings(&self) -> super::builder::policy_bindings::ListPolicyBindings {
         super::builder::policy_bindings::ListPolicyBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Search policy bindings by target. Returns all policy binding objects bound
     /// directly to target.
     pub fn search_target_policy_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::policy_bindings::SearchTargetPolicyBindings {
         super::builder::policy_bindings::SearchTargetPolicyBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::policy_bindings::GetOperation {
-        super::builder::policy_bindings::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::policy_bindings::GetOperation {
+        super::builder::policy_bindings::GetOperation::new(self.inner.clone())
     }
 }
 
@@ -340,22 +315,20 @@ impl PrincipalAccessBoundaryPolicies {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_principal_access_boundary_policy(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::principal_access_boundary_policies::CreatePrincipalAccessBoundaryPolicy
     {
-        super::builder::principal_access_boundary_policies::CreatePrincipalAccessBoundaryPolicy::new(self.inner.clone())
-            .set_parent ( parent.into() )
+        super::builder::principal_access_boundary_policies::CreatePrincipalAccessBoundaryPolicy::new(
+            self.inner.clone(),
+        )
     }
 
     /// Gets a principal access boundary policy.
     pub fn get_principal_access_boundary_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::principal_access_boundary_policies::GetPrincipalAccessBoundaryPolicy {
         super::builder::principal_access_boundary_policies::GetPrincipalAccessBoundaryPolicy::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Updates a principal access boundary policy.
@@ -371,11 +344,11 @@ impl PrincipalAccessBoundaryPolicies {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_principal_access_boundary_policy(
         &self,
-        principal_access_boundary_policy: impl Into<crate::model::PrincipalAccessBoundaryPolicy>,
     ) -> super::builder::principal_access_boundary_policies::UpdatePrincipalAccessBoundaryPolicy
     {
-        super::builder::principal_access_boundary_policies::UpdatePrincipalAccessBoundaryPolicy::new(self.inner.clone())
-            .set_principal_access_boundary_policy ( principal_access_boundary_policy.into() )
+        super::builder::principal_access_boundary_policies::UpdatePrincipalAccessBoundaryPolicy::new(
+            self.inner.clone(),
+        )
     }
 
     /// Deletes a principal access boundary policy.
@@ -391,32 +364,28 @@ impl PrincipalAccessBoundaryPolicies {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_principal_access_boundary_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::principal_access_boundary_policies::DeletePrincipalAccessBoundaryPolicy
     {
-        super::builder::principal_access_boundary_policies::DeletePrincipalAccessBoundaryPolicy::new(self.inner.clone())
-            .set_name ( name.into() )
+        super::builder::principal_access_boundary_policies::DeletePrincipalAccessBoundaryPolicy::new(
+            self.inner.clone(),
+        )
     }
 
     /// Lists principal access boundary policies.
     pub fn list_principal_access_boundary_policies(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::principal_access_boundary_policies::ListPrincipalAccessBoundaryPolicies
     {
-        super::builder::principal_access_boundary_policies::ListPrincipalAccessBoundaryPolicies::new(self.inner.clone())
-            .set_parent ( parent.into() )
+        super::builder::principal_access_boundary_policies::ListPrincipalAccessBoundaryPolicies::new(
+            self.inner.clone(),
+        )
     }
 
     /// Returns all policy bindings that bind a specific policy if a user has
     /// searchPolicyBindings permission on that policy.
-    pub fn search_principal_access_boundary_policy_bindings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::principal_access_boundary_policies::SearchPrincipalAccessBoundaryPolicyBindings
+    pub fn search_principal_access_boundary_policy_bindings(&self) -> super::builder::principal_access_boundary_policies::SearchPrincipalAccessBoundaryPolicyBindings
     {
         super::builder::principal_access_boundary_policies::SearchPrincipalAccessBoundaryPolicyBindings::new(self.inner.clone())
-            .set_name ( name.into() )
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -424,9 +393,7 @@ impl PrincipalAccessBoundaryPolicies {
     /// [google.longrunning.Operations]: longrunning::client::Operations
     pub fn get_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::principal_access_boundary_policies::GetOperation {
         super::builder::principal_access_boundary_policies::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/iam/v3/src/transport.rs
+++ b/src/generated/iam/v3/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/policyBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/policyBindings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PolicyBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,18 +100,15 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.policy_binding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy_binding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.policy_binding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy_binding"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,9 +132,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -145,12 +160,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListPolicyBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/policyBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/policyBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -170,15 +189,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchTargetPolicyBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/policyBindings:searchTargetPolicyBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v3/{}/policyBindings:searchTargetPolicyBindings",
-                    req.parent
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -198,9 +218,16 @@ impl super::stub::PolicyBindings for PolicyBindings {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,12 +281,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/principalAccessBoundaryPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/principalAccessBoundaryPolicies", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -281,9 +312,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PrincipalAccessBoundaryPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,20 +338,15 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.principal_access_boundary_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("principal_access_boundary_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.principal_access_boundary_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing(
-                            "principal_access_boundary_policy"
-                        ))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -337,9 +370,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -360,12 +400,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
     ) -> Result<gax::response::Response<crate::model::ListPrincipalAccessBoundaryPoliciesResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/principalAccessBoundaryPolicies", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/principalAccessBoundaryPolicies", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -386,12 +430,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         gax::response::Response<crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse>,
     > {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}:searchPolicyBindings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}:searchPolicyBindings", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -410,9 +458,16 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/iam/v3/src/transport.rs
+++ b/src/generated/iam/v3/src/transport.rs
@@ -101,10 +101,15 @@ impl super::stub::PolicyBindings for PolicyBindings {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.policy_binding
+            let arg = &req
+                .policy_binding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy_binding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy_binding.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -339,10 +344,17 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.principal_access_boundary_policy
+            let arg = &req
+                .principal_access_boundary_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("principal_access_boundary_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "principal_access_boundary_policy.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/identity/accesscontextmanager/v1/src/client.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/client.rs
@@ -141,12 +141,8 @@ impl AccessContextManager {
 
     /// Returns an [access policy]
     /// [google.identity.accesscontextmanager.v1.AccessPolicy] based on the name.
-    pub fn get_access_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::GetAccessPolicy {
+    pub fn get_access_policy(&self) -> super::builder::access_context_manager::GetAccessPolicy {
         super::builder::access_context_manager::GetAccessPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an access policy. This method fails if the organization already has
@@ -188,10 +184,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_access_policy(
         &self,
-        policy: impl Into<crate::model::AccessPolicy>,
     ) -> super::builder::access_context_manager::UpdateAccessPolicy {
         super::builder::access_context_manager::UpdateAccessPolicy::new(self.inner.clone())
-            .set_policy(policy.into())
     }
 
     /// Deletes an [access policy]
@@ -211,32 +205,22 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_access_policy(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::DeleteAccessPolicy {
         super::builder::access_context_manager::DeleteAccessPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all [access levels]
     /// [google.identity.accesscontextmanager.v1.AccessLevel] for an access
     /// policy.
-    pub fn list_access_levels(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::ListAccessLevels {
+    pub fn list_access_levels(&self) -> super::builder::access_context_manager::ListAccessLevels {
         super::builder::access_context_manager::ListAccessLevels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets an [access level]
     /// [google.identity.accesscontextmanager.v1.AccessLevel] based on the resource
     /// name.
-    pub fn get_access_level(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::GetAccessLevel {
+    pub fn get_access_level(&self) -> super::builder::access_context_manager::GetAccessLevel {
         super::builder::access_context_manager::GetAccessLevel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an [access level]
@@ -256,12 +240,8 @@ impl AccessContextManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_access_level(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::CreateAccessLevel {
+    pub fn create_access_level(&self) -> super::builder::access_context_manager::CreateAccessLevel {
         super::builder::access_context_manager::CreateAccessLevel::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an [access level]
@@ -282,12 +262,8 @@ impl AccessContextManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_access_level(
-        &self,
-        access_level: impl Into<crate::model::AccessLevel>,
-    ) -> super::builder::access_context_manager::UpdateAccessLevel {
+    pub fn update_access_level(&self) -> super::builder::access_context_manager::UpdateAccessLevel {
         super::builder::access_context_manager::UpdateAccessLevel::new(self.inner.clone())
-            .set_access_level(access_level.into())
     }
 
     /// Deletes an [access level]
@@ -306,12 +282,8 @@ impl AccessContextManager {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_access_level(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::DeleteAccessLevel {
+    pub fn delete_access_level(&self) -> super::builder::access_context_manager::DeleteAccessLevel {
         super::builder::access_context_manager::DeleteAccessLevel::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Replaces all existing [access levels]
@@ -343,10 +315,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn replace_access_levels(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::ReplaceAccessLevels {
         super::builder::access_context_manager::ReplaceAccessLevels::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all [service perimeters]
@@ -354,10 +324,8 @@ impl AccessContextManager {
     /// access policy.
     pub fn list_service_perimeters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::ListServicePerimeters {
         super::builder::access_context_manager::ListServicePerimeters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a [service perimeter]
@@ -365,10 +333,8 @@ impl AccessContextManager {
     /// resource name.
     pub fn get_service_perimeter(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::GetServicePerimeter {
         super::builder::access_context_manager::GetServicePerimeter::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a [service perimeter]
@@ -391,10 +357,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_service_perimeter(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::CreateServicePerimeter {
         super::builder::access_context_manager::CreateServicePerimeter::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a [service perimeter]
@@ -417,10 +381,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_service_perimeter(
         &self,
-        service_perimeter: impl Into<crate::model::ServicePerimeter>,
     ) -> super::builder::access_context_manager::UpdateServicePerimeter {
         super::builder::access_context_manager::UpdateServicePerimeter::new(self.inner.clone())
-            .set_service_perimeter(service_perimeter.into())
     }
 
     /// Deletes a [service perimeter]
@@ -441,10 +403,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_service_perimeter(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::DeleteServicePerimeter {
         super::builder::access_context_manager::DeleteServicePerimeter::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Replace all existing [service perimeters]
@@ -472,10 +432,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn replace_service_perimeters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::ReplaceServicePerimeters {
         super::builder::access_context_manager::ReplaceServicePerimeters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Commits the dry-run specification for all the [service perimeters]
@@ -507,10 +465,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn commit_service_perimeters(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::CommitServicePerimeters {
         super::builder::access_context_manager::CommitServicePerimeters::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all [GcpUserAccessBindings]
@@ -518,10 +474,8 @@ impl AccessContextManager {
     /// Google Cloud organization.
     pub fn list_gcp_user_access_bindings(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::ListGcpUserAccessBindings {
         super::builder::access_context_manager::ListGcpUserAccessBindings::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the [GcpUserAccessBinding]
@@ -529,10 +483,8 @@ impl AccessContextManager {
     /// the given name.
     pub fn get_gcp_user_access_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::GetGcpUserAccessBinding {
         super::builder::access_context_manager::GetGcpUserAccessBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a [GcpUserAccessBinding]
@@ -557,10 +509,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_gcp_user_access_binding(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::CreateGcpUserAccessBinding {
         super::builder::access_context_manager::CreateGcpUserAccessBinding::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a [GcpUserAccessBinding]
@@ -580,10 +530,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_gcp_user_access_binding(
         &self,
-        gcp_user_access_binding: impl Into<crate::model::GcpUserAccessBinding>,
     ) -> super::builder::access_context_manager::UpdateGcpUserAccessBinding {
         super::builder::access_context_manager::UpdateGcpUserAccessBinding::new(self.inner.clone())
-            .set_gcp_user_access_binding(gcp_user_access_binding.into())
     }
 
     /// Deletes a [GcpUserAccessBinding]
@@ -603,10 +551,8 @@ impl AccessContextManager {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_gcp_user_access_binding(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::DeleteGcpUserAccessBinding {
         super::builder::access_context_manager::DeleteGcpUserAccessBinding::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the IAM policy for the specified Access Context Manager
@@ -617,24 +563,16 @@ impl AccessContextManager {
     /// policy][google.identity.accesscontextmanager.v1.AccessPolicy].
     ///
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::access_context_manager::SetIamPolicy {
         super::builder::access_context_manager::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the IAM policy for the specified Access Context Manager
     /// [access policy][google.identity.accesscontextmanager.v1.AccessPolicy].
     ///
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::access_context_manager::GetIamPolicy {
         super::builder::access_context_manager::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns the IAM permissions that the caller has on the specified Access
@@ -648,20 +586,14 @@ impl AccessContextManager {
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
     pub fn test_iam_permissions(
         &self,
-        resource: impl Into<std::string::String>,
     ) -> super::builder::access_context_manager::TestIamPermissions {
         super::builder::access_context_manager::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::access_context_manager::GetOperation {
+    pub fn get_operation(&self) -> super::builder::access_context_manager::GetOperation {
         super::builder::access_context_manager::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAccessPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/accessPolicies".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/accessPolicies".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +69,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,9 +95,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/accessPolicies".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/accessPolicies".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,18 +113,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,9 +142,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -155,12 +168,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAccessLevelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/accessLevels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/accessLevels", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -180,9 +197,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessLevel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -200,12 +224,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/accessLevels", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/accessLevels", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,18 +250,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.access_level
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("access_level"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.access_level
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("access_level"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -256,9 +281,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -275,12 +307,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/accessLevels:replaceAll", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/accessLevels:replaceAll", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,12 +331,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicePerimetersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/servicePerimeters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/servicePerimeters", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -319,9 +359,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServicePerimeter>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -338,12 +385,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/servicePerimeters", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/servicePerimeters", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -360,18 +411,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.service_perimeter
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_perimeter"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.service_perimeter
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_perimeter"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -394,9 +442,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -413,12 +468,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/servicePerimeters:replaceAll", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/servicePerimeters:replaceAll", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -433,12 +492,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/servicePerimeters:commit", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/servicePerimeters:commit", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -453,12 +516,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGcpUserAccessBindingsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/gcpUserAccessBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/gcpUserAccessBindings", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -477,9 +544,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GcpUserAccessBinding>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -496,12 +570,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/gcpUserAccessBindings", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/gcpUserAccessBindings", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -518,18 +596,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.gcp_user_access_binding
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("gcp_user_access_binding"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.gcp_user_access_binding
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("gcp_user_access_binding"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -552,9 +627,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -571,12 +653,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -591,12 +677,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -611,12 +701,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -631,9 +725,16 @@ impl super::stub::AccessContextManager for AccessContextManager {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -114,10 +114,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.policy
+            let arg = &req
+                .policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -251,10 +256,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.access_level
+            let arg = &req
+                .access_level
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("access_level"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("access_level.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -412,10 +422,15 @@ impl super::stub::AccessContextManager for AccessContextManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.service_perimeter
+            let arg = &req
+                .service_perimeter
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_perimeter"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service_perimeter.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -597,10 +612,17 @@ impl super::stub::AccessContextManager for AccessContextManager {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.gcp_user_access_binding
+            let arg = &req
+                .gcp_user_access_binding
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("gcp_user_access_binding"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "gcp_user_access_binding.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/logging/v2/src/client.rs
+++ b/src/generated/logging/v2/src/client.rs
@@ -124,12 +124,8 @@ impl LoggingServiceV2 {
     /// reappears if it receives new entries. Log entries written shortly before
     /// the delete operation might not be deleted. Entries received after the
     /// delete operation with a timestamp before the operation will be deleted.
-    pub fn delete_log(
-        &self,
-        log_name: impl Into<std::string::String>,
-    ) -> super::builder::logging_service_v_2::DeleteLog {
+    pub fn delete_log(&self) -> super::builder::logging_service_v_2::DeleteLog {
         super::builder::logging_service_v_2::DeleteLog::new(self.inner.clone())
-            .set_log_name(log_name.into())
     }
 
     /// Writes log entries to Logging. This API method is the
@@ -162,45 +158,29 @@ impl LoggingServiceV2 {
 
     /// Lists the logs in projects, organizations, folders, or billing accounts.
     /// Only logs that have entries are listed.
-    pub fn list_logs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::logging_service_v_2::ListLogs {
+    pub fn list_logs(&self) -> super::builder::logging_service_v_2::ListLogs {
         super::builder::logging_service_v_2::ListLogs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::logging_service_v_2::ListOperations {
+    pub fn list_operations(&self) -> super::builder::logging_service_v_2::ListOperations {
         super::builder::logging_service_v_2::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::logging_service_v_2::GetOperation {
+    pub fn get_operation(&self) -> super::builder::logging_service_v_2::GetOperation {
         super::builder::logging_service_v_2::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::logging_service_v_2::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::logging_service_v_2::CancelOperation {
         super::builder::logging_service_v_2::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -307,20 +287,13 @@ impl ConfigServiceV2 {
     }
 
     /// Lists log buckets.
-    pub fn list_buckets(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListBuckets {
+    pub fn list_buckets(&self) -> super::builder::config_service_v_2::ListBuckets {
         super::builder::config_service_v_2::ListBuckets::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a log bucket.
-    pub fn get_bucket(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetBucket {
-        super::builder::config_service_v_2::GetBucket::new(self.inner.clone()).set_name(name.into())
+    pub fn get_bucket(&self) -> super::builder::config_service_v_2::GetBucket {
+        super::builder::config_service_v_2::GetBucket::new(self.inner.clone())
     }
 
     /// Creates a log bucket asynchronously that can be used to store log entries.
@@ -336,12 +309,8 @@ impl ConfigServiceV2 {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_bucket_async(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateBucketAsync {
+    pub fn create_bucket_async(&self) -> super::builder::config_service_v_2::CreateBucketAsync {
         super::builder::config_service_v_2::CreateBucketAsync::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a log bucket asynchronously.
@@ -360,22 +329,14 @@ impl ConfigServiceV2 {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_bucket_async(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateBucketAsync {
+    pub fn update_bucket_async(&self) -> super::builder::config_service_v_2::UpdateBucketAsync {
         super::builder::config_service_v_2::UpdateBucketAsync::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a log bucket that can be used to store log entries. After a bucket
     /// has been created, the bucket's location cannot be changed.
-    pub fn create_bucket(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateBucket {
+    pub fn create_bucket(&self) -> super::builder::config_service_v_2::CreateBucket {
         super::builder::config_service_v_2::CreateBucket::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a log bucket.
@@ -384,12 +345,8 @@ impl ConfigServiceV2 {
     /// `FAILED_PRECONDITION` will be returned.
     ///
     /// After a bucket has been created, the bucket's location cannot be changed.
-    pub fn update_bucket(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateBucket {
+    pub fn update_bucket(&self) -> super::builder::config_service_v_2::UpdateBucket {
         super::builder::config_service_v_2::UpdateBucket::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a log bucket.
@@ -397,49 +354,30 @@ impl ConfigServiceV2 {
     /// Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
     /// After 7 days, the bucket will be purged and all log entries in the bucket
     /// will be permanently deleted.
-    pub fn delete_bucket(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::DeleteBucket {
+    pub fn delete_bucket(&self) -> super::builder::config_service_v_2::DeleteBucket {
         super::builder::config_service_v_2::DeleteBucket::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Undeletes a log bucket. A bucket that has been deleted can be undeleted
     /// within the grace period of 7 days.
-    pub fn undelete_bucket(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UndeleteBucket {
+    pub fn undelete_bucket(&self) -> super::builder::config_service_v_2::UndeleteBucket {
         super::builder::config_service_v_2::UndeleteBucket::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists views on a log bucket.
-    pub fn list_views(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListViews {
+    pub fn list_views(&self) -> super::builder::config_service_v_2::ListViews {
         super::builder::config_service_v_2::ListViews::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a view on a log bucket..
-    pub fn get_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetView {
-        super::builder::config_service_v_2::GetView::new(self.inner.clone()).set_name(name.into())
+    pub fn get_view(&self) -> super::builder::config_service_v_2::GetView {
+        super::builder::config_service_v_2::GetView::new(self.inner.clone())
     }
 
     /// Creates a view over log entries in a log bucket. A bucket may contain a
     /// maximum of 30 views.
-    pub fn create_view(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateView {
+    pub fn create_view(&self) -> super::builder::config_service_v_2::CreateView {
         super::builder::config_service_v_2::CreateView::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a view on a log bucket. This method replaces the following fields
@@ -447,54 +385,34 @@ impl ConfigServiceV2 {
     /// If an `UNAVAILABLE` error is returned, this indicates that system is not in
     /// a state where it can update the view. If this occurs, please try again in a
     /// few minutes.
-    pub fn update_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateView {
+    pub fn update_view(&self) -> super::builder::config_service_v_2::UpdateView {
         super::builder::config_service_v_2::UpdateView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a view on a log bucket.
     /// If an `UNAVAILABLE` error is returned, this indicates that system is not in
     /// a state where it can delete the view. If this occurs, please try again in a
     /// few minutes.
-    pub fn delete_view(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::DeleteView {
+    pub fn delete_view(&self) -> super::builder::config_service_v_2::DeleteView {
         super::builder::config_service_v_2::DeleteView::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists sinks.
-    pub fn list_sinks(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListSinks {
+    pub fn list_sinks(&self) -> super::builder::config_service_v_2::ListSinks {
         super::builder::config_service_v_2::ListSinks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a sink.
-    pub fn get_sink(
-        &self,
-        sink_name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetSink {
+    pub fn get_sink(&self) -> super::builder::config_service_v_2::GetSink {
         super::builder::config_service_v_2::GetSink::new(self.inner.clone())
-            .set_sink_name(sink_name.into())
     }
 
     /// Creates a sink that exports specified log entries to a destination. The
     /// export of newly-ingested log entries begins immediately, unless the sink's
     /// `writer_identity` is not permitted to write to the destination. A sink can
     /// export log entries only from the resource owning the sink.
-    pub fn create_sink(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateSink {
+    pub fn create_sink(&self) -> super::builder::config_service_v_2::CreateSink {
         super::builder::config_service_v_2::CreateSink::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a sink. This method replaces the following fields in the existing
@@ -502,22 +420,14 @@ impl ConfigServiceV2 {
     ///
     /// The updated sink might also have a new `writer_identity`; see the
     /// `unique_writer_identity` field.
-    pub fn update_sink(
-        &self,
-        sink_name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateSink {
+    pub fn update_sink(&self) -> super::builder::config_service_v_2::UpdateSink {
         super::builder::config_service_v_2::UpdateSink::new(self.inner.clone())
-            .set_sink_name(sink_name.into())
     }
 
     /// Deletes a sink. If the sink has a unique `writer_identity`, then that
     /// service account is also deleted.
-    pub fn delete_sink(
-        &self,
-        sink_name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::DeleteSink {
+    pub fn delete_sink(&self) -> super::builder::config_service_v_2::DeleteSink {
         super::builder::config_service_v_2::DeleteSink::new(self.inner.clone())
-            .set_sink_name(sink_name.into())
     }
 
     /// Asynchronously creates a linked dataset in BigQuery which makes it possible
@@ -533,12 +443,8 @@ impl ConfigServiceV2 {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_link(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateLink {
+    pub fn create_link(&self) -> super::builder::config_service_v_2::CreateLink {
         super::builder::config_service_v_2::CreateLink::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a link. This will also delete the corresponding BigQuery linked
@@ -553,77 +459,46 @@ impl ConfigServiceV2 {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn delete_link(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::DeleteLink {
+    pub fn delete_link(&self) -> super::builder::config_service_v_2::DeleteLink {
         super::builder::config_service_v_2::DeleteLink::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists links.
-    pub fn list_links(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListLinks {
+    pub fn list_links(&self) -> super::builder::config_service_v_2::ListLinks {
         super::builder::config_service_v_2::ListLinks::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a link.
-    pub fn get_link(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetLink {
-        super::builder::config_service_v_2::GetLink::new(self.inner.clone()).set_name(name.into())
+    pub fn get_link(&self) -> super::builder::config_service_v_2::GetLink {
+        super::builder::config_service_v_2::GetLink::new(self.inner.clone())
     }
 
     /// Lists all the exclusions on the _Default sink in a parent resource.
-    pub fn list_exclusions(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListExclusions {
+    pub fn list_exclusions(&self) -> super::builder::config_service_v_2::ListExclusions {
         super::builder::config_service_v_2::ListExclusions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the description of an exclusion in the _Default sink.
-    pub fn get_exclusion(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetExclusion {
+    pub fn get_exclusion(&self) -> super::builder::config_service_v_2::GetExclusion {
         super::builder::config_service_v_2::GetExclusion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new exclusion in the _Default sink in a specified parent
     /// resource. Only log entries belonging to that resource can be excluded. You
     /// can have up to 10 exclusions in a resource.
-    pub fn create_exclusion(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CreateExclusion {
+    pub fn create_exclusion(&self) -> super::builder::config_service_v_2::CreateExclusion {
         super::builder::config_service_v_2::CreateExclusion::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Changes one or more properties of an existing exclusion in the _Default
     /// sink.
-    pub fn update_exclusion(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateExclusion {
+    pub fn update_exclusion(&self) -> super::builder::config_service_v_2::UpdateExclusion {
         super::builder::config_service_v_2::UpdateExclusion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an exclusion in the _Default sink.
-    pub fn delete_exclusion(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::DeleteExclusion {
+    pub fn delete_exclusion(&self) -> super::builder::config_service_v_2::DeleteExclusion {
         super::builder::config_service_v_2::DeleteExclusion::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the Logging CMEK settings for the given resource.
@@ -636,12 +511,8 @@ impl ConfigServiceV2 {
     /// See [Enabling CMEK for Log
     /// Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
     /// for more information.
-    pub fn get_cmek_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetCmekSettings {
+    pub fn get_cmek_settings(&self) -> super::builder::config_service_v_2::GetCmekSettings {
         super::builder::config_service_v_2::GetCmekSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the Log Router CMEK settings for the given resource.
@@ -661,12 +532,8 @@ impl ConfigServiceV2 {
     /// for more information.
     ///
     /// [google.logging.v2.ConfigServiceV2.UpdateCmekSettings]: crate::client::ConfigServiceV2::update_cmek_settings
-    pub fn update_cmek_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateCmekSettings {
+    pub fn update_cmek_settings(&self) -> super::builder::config_service_v_2::UpdateCmekSettings {
         super::builder::config_service_v_2::UpdateCmekSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets the Log Router settings for the given resource.
@@ -679,12 +546,8 @@ impl ConfigServiceV2 {
     /// See [Enabling CMEK for Log
     /// Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
     /// for more information.
-    pub fn get_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetSettings {
+    pub fn get_settings(&self) -> super::builder::config_service_v_2::GetSettings {
         super::builder::config_service_v_2::GetSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates the Log Router settings for the given resource.
@@ -705,12 +568,8 @@ impl ConfigServiceV2 {
     /// for more information.
     ///
     /// [google.logging.v2.ConfigServiceV2.UpdateSettings]: crate::client::ConfigServiceV2::update_settings
-    pub fn update_settings(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::UpdateSettings {
+    pub fn update_settings(&self) -> super::builder::config_service_v_2::UpdateSettings {
         super::builder::config_service_v_2::UpdateSettings::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Copies a set of log entries from a log bucket to a Cloud Storage bucket.
@@ -731,34 +590,22 @@ impl ConfigServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::ListOperations {
+    pub fn list_operations(&self) -> super::builder::config_service_v_2::ListOperations {
         super::builder::config_service_v_2::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::GetOperation {
+    pub fn get_operation(&self) -> super::builder::config_service_v_2::GetOperation {
         super::builder::config_service_v_2::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::config_service_v_2::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::config_service_v_2::CancelOperation {
         super::builder::config_service_v_2::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -865,80 +712,48 @@ impl MetricsServiceV2 {
     }
 
     /// Lists logs-based metrics.
-    pub fn list_log_metrics(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::ListLogMetrics {
+    pub fn list_log_metrics(&self) -> super::builder::metrics_service_v_2::ListLogMetrics {
         super::builder::metrics_service_v_2::ListLogMetrics::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a logs-based metric.
-    pub fn get_log_metric(
-        &self,
-        metric_name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::GetLogMetric {
+    pub fn get_log_metric(&self) -> super::builder::metrics_service_v_2::GetLogMetric {
         super::builder::metrics_service_v_2::GetLogMetric::new(self.inner.clone())
-            .set_metric_name(metric_name.into())
     }
 
     /// Creates a logs-based metric.
-    pub fn create_log_metric(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::CreateLogMetric {
+    pub fn create_log_metric(&self) -> super::builder::metrics_service_v_2::CreateLogMetric {
         super::builder::metrics_service_v_2::CreateLogMetric::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates or updates a logs-based metric.
-    pub fn update_log_metric(
-        &self,
-        metric_name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::UpdateLogMetric {
+    pub fn update_log_metric(&self) -> super::builder::metrics_service_v_2::UpdateLogMetric {
         super::builder::metrics_service_v_2::UpdateLogMetric::new(self.inner.clone())
-            .set_metric_name(metric_name.into())
     }
 
     /// Deletes a logs-based metric.
-    pub fn delete_log_metric(
-        &self,
-        metric_name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::DeleteLogMetric {
+    pub fn delete_log_metric(&self) -> super::builder::metrics_service_v_2::DeleteLogMetric {
         super::builder::metrics_service_v_2::DeleteLogMetric::new(self.inner.clone())
-            .set_metric_name(metric_name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::ListOperations {
+    pub fn list_operations(&self) -> super::builder::metrics_service_v_2::ListOperations {
         super::builder::metrics_service_v_2::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::GetOperation {
+    pub fn get_operation(&self) -> super::builder::metrics_service_v_2::GetOperation {
         super::builder::metrics_service_v_2::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_service_v_2::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::metrics_service_v_2::CancelOperation {
         super::builder::metrics_service_v_2::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/logging/v2/src/transport.rs
+++ b/src/generated/logging/v2/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.log_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("log_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.log_name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,9 +76,10 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::WriteLogEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/entries:write".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v2/entries:write".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,9 +94,10 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLogEntriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/entries:list".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v2/entries:list".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,12 +113,10 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
     ) -> Result<gax::response::Response<crate::model::ListMonitoredResourceDescriptorsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v2/monitoredResourceDescriptors".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                "/v2/monitoredResourceDescriptors".to_string(),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -128,9 +135,16 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLogsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/logs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/logs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -153,9 +167,16 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -175,9 +196,16 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -194,9 +222,16 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -239,9 +274,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBucketsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/buckets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/buckets", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -260,9 +302,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogBucket>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -279,12 +328,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/buckets:createAsync", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/buckets:createAsync", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -300,12 +353,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:updateAsync", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:updateAsync", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -326,9 +383,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogBucket>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/buckets", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/buckets", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -344,9 +408,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogBucket>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -367,9 +438,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -390,9 +468,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:undelete", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:undelete", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -412,9 +497,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListViewsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/views", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/views", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -433,9 +525,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogView>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -452,9 +551,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogView>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/views", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/views", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -470,9 +576,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogView>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -493,9 +606,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -516,9 +636,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSinksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/sinks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/sinks", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -537,9 +664,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogSink>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.sink_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("sink_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.sink_name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -556,9 +690,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogSink>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/sinks", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/sinks", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -574,9 +715,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogSink>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.sink_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("sink_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v2/{}", req.sink_name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -598,9 +746,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.sink_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("sink_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.sink_name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -621,9 +776,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/links", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/links", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -639,9 +801,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -658,9 +827,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLinksResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/links", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/links", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -679,9 +855,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Link>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -698,12 +881,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListExclusionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/exclusions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/exclusions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -722,9 +909,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogExclusion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -741,12 +935,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogExclusion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/exclusions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/exclusions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -763,9 +961,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogExclusion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -788,9 +993,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -811,12 +1023,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CmekSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/cmekSettings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/cmekSettings", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -833,12 +1049,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CmekSettings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/cmekSettings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!("/v2/{}/cmekSettings", req.name),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -861,9 +1081,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/settings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/settings", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -880,9 +1107,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Settings>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/settings", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}/settings", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -905,9 +1139,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v2/entries:copy".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v2/entries:copy".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -922,9 +1157,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -944,9 +1186,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -963,9 +1212,16 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1022,9 +1278,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLogMetricsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/metrics", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/metrics", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1043,9 +1306,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogMetric>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.metric_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("metric_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.metric_name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1062,9 +1332,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogMetric>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/metrics", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/metrics", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1079,9 +1356,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::LogMetric>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.metric_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("metric_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, format!("/v2/{}", req.metric_name))
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1096,9 +1380,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.metric_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("metric_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.metric_name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1119,9 +1410,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/operations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/operations", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1141,9 +1439,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1160,9 +1465,16 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -130,32 +130,23 @@ impl Operations {
 
     /// Lists operations that match the specified filter in the request. If the
     /// server doesn't support this method, it returns `UNIMPLEMENTED`.
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::operations::ListOperations {
-        super::builder::operations::ListOperations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_operations(&self) -> super::builder::operations::ListOperations {
+        super::builder::operations::ListOperations::new(self.inner.clone())
     }
 
     /// Gets the latest state of a long-running operation.  Clients can use this
     /// method to poll the operation result at intervals as recommended by the API
     /// service.
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::operations::GetOperation {
-        super::builder::operations::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::operations::GetOperation {
+        super::builder::operations::GetOperation::new(self.inner.clone())
     }
 
     /// Deletes a long-running operation. This method indicates that the client is
     /// no longer interested in the operation result. It does not cancel the
     /// operation. If the server doesn't support this method, it returns
     /// `google.rpc.Code.UNIMPLEMENTED`.
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::operations::DeleteOperation {
-        super::builder::operations::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::operations::DeleteOperation {
+        super::builder::operations::DeleteOperation::new(self.inner.clone())
     }
 
     /// Starts asynchronous cancellation on a long-running operation.  The server
@@ -173,10 +164,7 @@ impl Operations {
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
     /// [google.longrunning.Operations.GetOperation]: crate::client::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::operations::CancelOperation {
-        super::builder::operations::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::operations::CancelOperation {
+        super::builder::operations::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::Operations for Operations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +75,16 @@ impl super::stub::Operations for Operations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,9 +101,16 @@ impl super::stub::Operations for Operations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -110,9 +131,16 @@ impl super::stub::Operations for Operations {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/monitoring/dashboard/v1/src/client.rs
+++ b/src/generated/monitoring/dashboard/v1/src/client.rs
@@ -127,12 +127,8 @@ impl DashboardsService {
     /// method requires the `monitoring.dashboards.create` permission on the
     /// specified project. For more information about permissions, see [Cloud
     /// Identity and Access Management](https://cloud.google.com/iam).
-    pub fn create_dashboard(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dashboards_service::CreateDashboard {
+    pub fn create_dashboard(&self) -> super::builder::dashboards_service::CreateDashboard {
         super::builder::dashboards_service::CreateDashboard::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the existing dashboards.
@@ -140,12 +136,8 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.list` permission
     /// on the specified project. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
-    pub fn list_dashboards(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dashboards_service::ListDashboards {
+    pub fn list_dashboards(&self) -> super::builder::dashboards_service::ListDashboards {
         super::builder::dashboards_service::ListDashboards::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Fetches a specific dashboard.
@@ -153,12 +145,8 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.get` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
-    pub fn get_dashboard(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dashboards_service::GetDashboard {
+    pub fn get_dashboard(&self) -> super::builder::dashboards_service::GetDashboard {
         super::builder::dashboards_service::GetDashboard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an existing custom dashboard.
@@ -166,12 +154,8 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.delete` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
-    pub fn delete_dashboard(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dashboards_service::DeleteDashboard {
+    pub fn delete_dashboard(&self) -> super::builder::dashboards_service::DeleteDashboard {
         super::builder::dashboards_service::DeleteDashboard::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Replaces an existing custom dashboard with a new definition.
@@ -179,11 +163,7 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.update` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
-    pub fn update_dashboard(
-        &self,
-        dashboard: impl Into<crate::model::Dashboard>,
-    ) -> super::builder::dashboards_service::UpdateDashboard {
+    pub fn update_dashboard(&self) -> super::builder::dashboards_service::UpdateDashboard {
         super::builder::dashboards_service::UpdateDashboard::new(self.inner.clone())
-            .set_dashboard(dashboard.into())
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/transport.rs
+++ b/src/generated/monitoring/dashboard/v1/src/transport.rs
@@ -158,10 +158,15 @@ impl super::stub::DashboardsService for DashboardsService {
     ) -> Result<gax::response::Response<crate::model::Dashboard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.dashboard
+            let arg = &req
+                .dashboard
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("dashboard"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("dashboard.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/monitoring/dashboard/v1/src/transport.rs
+++ b/src/generated/monitoring/dashboard/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DashboardsService for DashboardsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dashboard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/dashboards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/dashboards", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -69,12 +73,16 @@ impl super::stub::DashboardsService for DashboardsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDashboardsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/dashboards", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/dashboards", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,9 +101,16 @@ impl super::stub::DashboardsService for DashboardsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dashboard>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -112,9 +127,16 @@ impl super::stub::DashboardsService for DashboardsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,18 +157,15 @@ impl super::stub::DashboardsService for DashboardsService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Dashboard>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.dashboard
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("dashboard"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.dashboard
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("dashboard"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/monitoring/metricsscope/v1/src/client.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/client.rs
@@ -120,12 +120,8 @@ impl MetricsScopes {
     }
 
     /// Returns a specific `Metrics Scope`.
-    pub fn get_metrics_scope(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_scopes::GetMetricsScope {
+    pub fn get_metrics_scope(&self) -> super::builder::metrics_scopes::GetMetricsScope {
         super::builder::metrics_scopes::GetMetricsScope::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns a list of every `Metrics Scope` that a specific `MonitoredProject`
@@ -151,10 +147,8 @@ impl MetricsScopes {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_monitored_project(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::metrics_scopes::CreateMonitoredProject {
         super::builder::metrics_scopes::CreateMonitoredProject::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a `MonitoredProject` from the specified `Metrics Scope`.
@@ -170,19 +164,14 @@ impl MetricsScopes {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn delete_monitored_project(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metrics_scopes::DeleteMonitoredProject {
         super::builder::metrics_scopes::DeleteMonitoredProject::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metrics_scopes::GetOperation {
-        super::builder::metrics_scopes::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::metrics_scopes::GetOperation {
+        super::builder::metrics_scopes::GetOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/transport.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/transport.rs
@@ -46,9 +46,16 @@ impl super::stub::MetricsScopes for MetricsScopes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::MetricsScope>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,13 +73,11 @@ impl super::stub::MetricsScopes for MetricsScopes {
     ) -> Result<gax::response::Response<crate::model::ListMetricsScopesByMonitoredProjectResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path =
+            "/v1/locations/global/metricsScopes:listMetricsScopesByMonitoredProject".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                "/v1/locations/global/metricsScopes:listMetricsScopesByMonitoredProject"
-                    .to_string(),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -93,12 +98,16 @@ impl super::stub::MetricsScopes for MetricsScopes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/projects", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/projects", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -115,9 +124,16 @@ impl super::stub::MetricsScopes for MetricsScopes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -134,9 +150,16 @@ impl super::stub::MetricsScopes for MetricsScopes {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/monitoring/v3/src/client.rs
+++ b/src/generated/monitoring/v3/src/client.rs
@@ -129,21 +129,13 @@ impl AlertPolicyService {
     }
 
     /// Lists the existing alerting policies for the workspace.
-    pub fn list_alert_policies(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alert_policy_service::ListAlertPolicies {
+    pub fn list_alert_policies(&self) -> super::builder::alert_policy_service::ListAlertPolicies {
         super::builder::alert_policy_service::ListAlertPolicies::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a single alerting policy.
-    pub fn get_alert_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alert_policy_service::GetAlertPolicy {
+    pub fn get_alert_policy(&self) -> super::builder::alert_policy_service::GetAlertPolicy {
         super::builder::alert_policy_service::GetAlertPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new alerting policy.
@@ -151,12 +143,8 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
-    pub fn create_alert_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alert_policy_service::CreateAlertPolicy {
+    pub fn create_alert_policy(&self) -> super::builder::alert_policy_service::CreateAlertPolicy {
         super::builder::alert_policy_service::CreateAlertPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes an alerting policy.
@@ -164,12 +152,8 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
-    pub fn delete_alert_policy(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::alert_policy_service::DeleteAlertPolicy {
+    pub fn delete_alert_policy(&self) -> super::builder::alert_policy_service::DeleteAlertPolicy {
         super::builder::alert_policy_service::DeleteAlertPolicy::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an alerting policy. You can either replace the entire policy with
@@ -180,12 +164,8 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
-    pub fn update_alert_policy(
-        &self,
-        alert_policy: impl Into<crate::model::AlertPolicy>,
-    ) -> super::builder::alert_policy_service::UpdateAlertPolicy {
+    pub fn update_alert_policy(&self) -> super::builder::alert_policy_service::UpdateAlertPolicy {
         super::builder::alert_policy_service::UpdateAlertPolicy::new(self.inner.clone())
-            .set_alert_policy(alert_policy.into())
     }
 }
 
@@ -301,53 +281,34 @@ impl GroupService {
     }
 
     /// Lists the existing groups.
-    pub fn list_groups(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::group_service::ListGroups {
-        super::builder::group_service::ListGroups::new(self.inner.clone()).set_name(name.into())
+    pub fn list_groups(&self) -> super::builder::group_service::ListGroups {
+        super::builder::group_service::ListGroups::new(self.inner.clone())
     }
 
     /// Gets a single group.
-    pub fn get_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::group_service::GetGroup {
-        super::builder::group_service::GetGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_group(&self) -> super::builder::group_service::GetGroup {
+        super::builder::group_service::GetGroup::new(self.inner.clone())
     }
 
     /// Creates a new group.
-    pub fn create_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::group_service::CreateGroup {
-        super::builder::group_service::CreateGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn create_group(&self) -> super::builder::group_service::CreateGroup {
+        super::builder::group_service::CreateGroup::new(self.inner.clone())
     }
 
     /// Updates an existing group.
     /// You can change any group attributes except `name`.
-    pub fn update_group(
-        &self,
-        group: impl Into<crate::model::Group>,
-    ) -> super::builder::group_service::UpdateGroup {
-        super::builder::group_service::UpdateGroup::new(self.inner.clone()).set_group(group.into())
+    pub fn update_group(&self) -> super::builder::group_service::UpdateGroup {
+        super::builder::group_service::UpdateGroup::new(self.inner.clone())
     }
 
     /// Deletes an existing group.
-    pub fn delete_group(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::group_service::DeleteGroup {
-        super::builder::group_service::DeleteGroup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_group(&self) -> super::builder::group_service::DeleteGroup {
+        super::builder::group_service::DeleteGroup::new(self.inner.clone())
     }
 
     /// Lists the monitored resources that are members of a group.
-    pub fn list_group_members(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::group_service::ListGroupMembers {
+    pub fn list_group_members(&self) -> super::builder::group_service::ListGroupMembers {
         super::builder::group_service::ListGroupMembers::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -455,37 +416,25 @@ impl MetricService {
     /// Lists monitored resource descriptors that match a filter.
     pub fn list_monitored_resource_descriptors(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metric_service::ListMonitoredResourceDescriptors {
         super::builder::metric_service::ListMonitoredResourceDescriptors::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a single monitored resource descriptor.
     pub fn get_monitored_resource_descriptor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metric_service::GetMonitoredResourceDescriptor {
         super::builder::metric_service::GetMonitoredResourceDescriptor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists metric descriptors that match a filter.
-    pub fn list_metric_descriptors(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metric_service::ListMetricDescriptors {
+    pub fn list_metric_descriptors(&self) -> super::builder::metric_service::ListMetricDescriptors {
         super::builder::metric_service::ListMetricDescriptors::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a single metric descriptor.
-    pub fn get_metric_descriptor(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metric_service::GetMetricDescriptor {
+    pub fn get_metric_descriptor(&self) -> super::builder::metric_service::GetMetricDescriptor {
         super::builder::metric_service::GetMetricDescriptor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new metric descriptor.
@@ -496,10 +445,8 @@ impl MetricService {
     /// except that metric labels are never removed.
     pub fn create_metric_descriptor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metric_service::CreateMetricDescriptor {
         super::builder::metric_service::CreateMetricDescriptor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Deletes a metric descriptor. Only user-created
@@ -507,19 +454,13 @@ impl MetricService {
     /// deleted.
     pub fn delete_metric_descriptor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metric_service::DeleteMetricDescriptor {
         super::builder::metric_service::DeleteMetricDescriptor::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists time series that match a filter.
-    pub fn list_time_series(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metric_service::ListTimeSeries {
+    pub fn list_time_series(&self) -> super::builder::metric_service::ListTimeSeries {
         super::builder::metric_service::ListTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates or adds data to one or more time series.
@@ -529,12 +470,8 @@ impl MetricService {
     /// This method does not support
     /// [resource locations constraint of an organization
     /// policy](https://cloud.google.com/resource-manager/docs/organization-policy/defining-locations#setting_the_organization_policy).
-    pub fn create_time_series(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::metric_service::CreateTimeSeries {
+    pub fn create_time_series(&self) -> super::builder::metric_service::CreateTimeSeries {
         super::builder::metric_service::CreateTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates or adds data to one or more service time series. A service time
@@ -550,10 +487,8 @@ impl MetricService {
     /// [google.monitoring.v3.MetricService.CreateTimeSeries]: crate::client::MetricService::create_time_series
     pub fn create_service_time_series(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::metric_service::CreateServiceTimeSeries {
         super::builder::metric_service::CreateServiceTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -664,24 +599,20 @@ impl NotificationChannelService {
     /// makes it possible for new channel types to be dynamically added.
     pub fn list_notification_channel_descriptors(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::ListNotificationChannelDescriptors {
         super::builder::notification_channel_service::ListNotificationChannelDescriptors::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Gets a single channel descriptor. The descriptor indicates which fields
     /// are expected / permitted for a notification channel of the given type.
     pub fn get_notification_channel_descriptor(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::GetNotificationChannelDescriptor {
         super::builder::notification_channel_service::GetNotificationChannelDescriptor::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Lists the notification channels that have been created for the project.
@@ -689,12 +620,10 @@ impl NotificationChannelService {
     /// the `ListNotificationChannelDescriptors` method.
     pub fn list_notification_channels(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::ListNotificationChannels {
         super::builder::notification_channel_service::ListNotificationChannels::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Gets a single notification channel. The channel includes the relevant
@@ -704,12 +633,10 @@ impl NotificationChannelService {
     /// that was supplied in the call to the create method.
     pub fn get_notification_channel(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::GetNotificationChannel {
         super::builder::notification_channel_service::GetNotificationChannel::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Creates a new notification channel, representing a single notification
@@ -721,12 +648,10 @@ impl NotificationChannelService {
     /// UpdateNotificationChannel.
     pub fn create_notification_channel(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::CreateNotificationChannel {
         super::builder::notification_channel_service::CreateNotificationChannel::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Updates a notification channel. Fields not specified in the field mask
@@ -738,12 +663,10 @@ impl NotificationChannelService {
     /// UpdateNotificationChannel.
     pub fn update_notification_channel(
         &self,
-        notification_channel: impl Into<crate::model::NotificationChannel>,
     ) -> super::builder::notification_channel_service::UpdateNotificationChannel {
         super::builder::notification_channel_service::UpdateNotificationChannel::new(
             self.inner.clone(),
         )
-        .set_notification_channel(notification_channel.into())
     }
 
     /// Deletes a notification channel.
@@ -754,24 +677,20 @@ impl NotificationChannelService {
     /// UpdateNotificationChannel.
     pub fn delete_notification_channel(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::DeleteNotificationChannel {
         super::builder::notification_channel_service::DeleteNotificationChannel::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Causes a verification code to be delivered to the channel. The code
     /// can then be supplied in `VerifyNotificationChannel` to verify the channel.
     pub fn send_notification_channel_verification_code(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::SendNotificationChannelVerificationCode {
         super::builder::notification_channel_service::SendNotificationChannelVerificationCode::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Requests a verification code for an already verified channel that can then
@@ -797,12 +716,10 @@ impl NotificationChannelService {
     /// 64 encoded string that has a longer expiration time.
     pub fn get_notification_channel_verification_code(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::GetNotificationChannelVerificationCode {
         super::builder::notification_channel_service::GetNotificationChannelVerificationCode::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// Verifies a `NotificationChannel` by proving receipt of the code
@@ -810,12 +727,10 @@ impl NotificationChannelService {
     /// `SendNotificationChannelVerificationCode`.
     pub fn verify_notification_channel(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::notification_channel_service::VerifyNotificationChannel {
         super::builder::notification_channel_service::VerifyNotificationChannel::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 }
 
@@ -926,12 +841,8 @@ impl QueryService {
     /// see the [MQL deprecation
     /// notice](https://cloud.google.com/stackdriver/docs/deprecations/mql).
     #[deprecated]
-    pub fn query_time_series(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::query_service::QueryTimeSeries {
+    pub fn query_time_series(&self) -> super::builder::query_service::QueryTimeSeries {
         super::builder::query_service::QueryTimeSeries::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1041,103 +952,73 @@ impl ServiceMonitoringService {
     }
 
     /// Create a `Service`.
-    pub fn create_service(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_monitoring_service::CreateService {
+    pub fn create_service(&self) -> super::builder::service_monitoring_service::CreateService {
         super::builder::service_monitoring_service::CreateService::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get the named `Service`.
-    pub fn get_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_monitoring_service::GetService {
+    pub fn get_service(&self) -> super::builder::service_monitoring_service::GetService {
         super::builder::service_monitoring_service::GetService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// List `Service`s for this Metrics Scope.
-    pub fn list_services(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::service_monitoring_service::ListServices {
+    pub fn list_services(&self) -> super::builder::service_monitoring_service::ListServices {
         super::builder::service_monitoring_service::ListServices::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Update this `Service`.
-    pub fn update_service(
-        &self,
-        service: impl Into<crate::model::Service>,
-    ) -> super::builder::service_monitoring_service::UpdateService {
+    pub fn update_service(&self) -> super::builder::service_monitoring_service::UpdateService {
         super::builder::service_monitoring_service::UpdateService::new(self.inner.clone())
-            .set_service(service.into())
     }
 
     /// Soft delete this `Service`.
-    pub fn delete_service(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::service_monitoring_service::DeleteService {
+    pub fn delete_service(&self) -> super::builder::service_monitoring_service::DeleteService {
         super::builder::service_monitoring_service::DeleteService::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Create a `ServiceLevelObjective` for the given `Service`.
     pub fn create_service_level_objective(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::service_monitoring_service::CreateServiceLevelObjective {
         super::builder::service_monitoring_service::CreateServiceLevelObjective::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Get a `ServiceLevelObjective` by name.
     pub fn get_service_level_objective(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::service_monitoring_service::GetServiceLevelObjective {
         super::builder::service_monitoring_service::GetServiceLevelObjective::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 
     /// List the `ServiceLevelObjective`s for the given `Service`.
     pub fn list_service_level_objectives(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::service_monitoring_service::ListServiceLevelObjectives {
         super::builder::service_monitoring_service::ListServiceLevelObjectives::new(
             self.inner.clone(),
         )
-        .set_parent(parent.into())
     }
 
     /// Update the given `ServiceLevelObjective`.
     pub fn update_service_level_objective(
         &self,
-        service_level_objective: impl Into<crate::model::ServiceLevelObjective>,
     ) -> super::builder::service_monitoring_service::UpdateServiceLevelObjective {
         super::builder::service_monitoring_service::UpdateServiceLevelObjective::new(
             self.inner.clone(),
         )
-        .set_service_level_objective(service_level_objective.into())
     }
 
     /// Delete the given `ServiceLevelObjective`.
     pub fn delete_service_level_objective(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::service_monitoring_service::DeleteServiceLevelObjective {
         super::builder::service_monitoring_service::DeleteServiceLevelObjective::new(
             self.inner.clone(),
         )
-        .set_name(name.into())
     }
 }
 
@@ -1246,40 +1127,25 @@ impl SnoozeService {
     /// Creates a `Snooze` that will prevent alerts, which match the provided
     /// criteria, from being opened. The `Snooze` applies for a specific time
     /// interval.
-    pub fn create_snooze(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::snooze_service::CreateSnooze {
+    pub fn create_snooze(&self) -> super::builder::snooze_service::CreateSnooze {
         super::builder::snooze_service::CreateSnooze::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the `Snooze`s associated with a project. Can optionally pass in
     /// `filter`, which specifies predicates to match `Snooze`s.
-    pub fn list_snoozes(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::snooze_service::ListSnoozes {
+    pub fn list_snoozes(&self) -> super::builder::snooze_service::ListSnoozes {
         super::builder::snooze_service::ListSnoozes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Retrieves a `Snooze` by `name`.
-    pub fn get_snooze(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::snooze_service::GetSnooze {
-        super::builder::snooze_service::GetSnooze::new(self.inner.clone()).set_name(name.into())
+    pub fn get_snooze(&self) -> super::builder::snooze_service::GetSnooze {
+        super::builder::snooze_service::GetSnooze::new(self.inner.clone())
     }
 
     /// Updates a `Snooze`, identified by its `name`, with the parameters in the
     /// given `Snooze` object.
-    pub fn update_snooze(
-        &self,
-        snooze: impl Into<crate::model::Snooze>,
-    ) -> super::builder::snooze_service::UpdateSnooze {
+    pub fn update_snooze(&self) -> super::builder::snooze_service::UpdateSnooze {
         super::builder::snooze_service::UpdateSnooze::new(self.inner.clone())
-            .set_snooze(snooze.into())
     }
 }
 
@@ -1396,28 +1262,22 @@ impl UptimeCheckService {
     /// (leaving out any invalid configurations).
     pub fn list_uptime_check_configs(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::uptime_check_service::ListUptimeCheckConfigs {
         super::builder::uptime_check_service::ListUptimeCheckConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a single Uptime check configuration.
     pub fn get_uptime_check_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::uptime_check_service::GetUptimeCheckConfig {
         super::builder::uptime_check_service::GetUptimeCheckConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new Uptime check configuration.
     pub fn create_uptime_check_config(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::uptime_check_service::CreateUptimeCheckConfig {
         super::builder::uptime_check_service::CreateUptimeCheckConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an Uptime check configuration. You can either replace the entire
@@ -1426,10 +1286,8 @@ impl UptimeCheckService {
     /// Returns the updated configuration.
     pub fn update_uptime_check_config(
         &self,
-        uptime_check_config: impl Into<crate::model::UptimeCheckConfig>,
     ) -> super::builder::uptime_check_service::UpdateUptimeCheckConfig {
         super::builder::uptime_check_service::UpdateUptimeCheckConfig::new(self.inner.clone())
-            .set_uptime_check_config(uptime_check_config.into())
     }
 
     /// Deletes an Uptime check configuration. Note that this method will fail
@@ -1437,10 +1295,8 @@ impl UptimeCheckService {
     /// other dependent configs that would be rendered invalid by the deletion.
     pub fn delete_uptime_check_config(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::uptime_check_service::DeleteUptimeCheckConfig {
         super::builder::uptime_check_service::DeleteUptimeCheckConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Returns the list of IP addresses that checkers run from.

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -159,10 +159,15 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
     ) -> Result<gax::response::Response<crate::model::AlertPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.alert_policy
+            let arg = &req
+                .alert_policy
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("alert_policy"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("alert_policy.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -304,10 +309,15 @@ impl super::stub::GroupService for GroupService {
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
         let path = format!("/v3/{}", {
-            &req.group
+            let arg = &req
+                .group
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("group.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -868,10 +878,15 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
     ) -> Result<gax::response::Response<crate::model::NotificationChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.notification_channel
+            let arg = &req
+                .notification_channel
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("notification_channel"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("notification_channel.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1160,10 +1175,15 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.service
+            let arg = &req
+                .service
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("service.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1306,10 +1326,17 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
     ) -> Result<gax::response::Response<crate::model::ServiceLevelObjective>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.service_level_objective
+            let arg = &req
+                .service_level_objective
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("service_level_objective"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing(
+                    "service_level_objective.name",
+                ));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1469,10 +1496,15 @@ impl super::stub::SnoozeService for SnoozeService {
     ) -> Result<gax::response::Response<crate::model::Snooze>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.snooze
+            let arg = &req
+                .snooze
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("snooze"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("snooze.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1602,10 +1634,15 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
     ) -> Result<gax::response::Response<crate::model::UptimeCheckConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v3/{}", {
-            &req.uptime_check_config
+            let arg = &req
+                .uptime_check_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("uptime_check_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("uptime_check_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAlertPoliciesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/alertPolicies", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/alertPolicies", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -72,9 +76,16 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AlertPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -91,12 +102,16 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AlertPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/alertPolicies", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/alertPolicies", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -113,9 +128,16 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -136,18 +158,15 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AlertPolicy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.alert_policy
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("alert_policy"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.alert_policy
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("alert_policy"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -193,9 +212,16 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGroupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/groups", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/groups", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,9 +252,16 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -245,9 +278,16 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/groups", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/groups", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -263,18 +303,15 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Group>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            &req.group
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("group"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PUT,
-                format!(
-                    "/v3/{}",
-                    req.group
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("group"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,9 +327,16 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -314,9 +358,16 @@ impl super::stub::GroupService for GroupService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListGroupMembersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/members", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/members", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -370,12 +421,16 @@ impl super::stub::MetricService for MetricService {
     ) -> Result<gax::response::Response<crate::model::ListMonitoredResourceDescriptorsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/monitoredResourceDescriptors", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/monitoredResourceDescriptors", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -395,9 +450,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::MonitoredResourceDescriptor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -414,12 +476,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListMetricDescriptorsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/metricDescriptors", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/metricDescriptors", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -440,9 +506,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::MetricDescriptor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -459,12 +532,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<api::model::MetricDescriptor>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/metricDescriptors", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/metricDescriptors", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -481,9 +558,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -504,9 +588,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTimeSeriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/timeSeries", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/timeSeries", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -558,12 +649,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/timeSeries", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/timeSeries", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -583,12 +678,16 @@ impl super::stub::MetricService for MetricService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/timeSeries:createService", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/timeSeries:createService", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -632,12 +731,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
     ) -> Result<gax::response::Response<crate::model::ListNotificationChannelDescriptorsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/notificationChannelDescriptors", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/notificationChannelDescriptors", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -656,9 +759,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationChannelDescriptor>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -675,12 +785,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListNotificationChannelsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/notificationChannels", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/notificationChannels", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -701,9 +815,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -720,12 +841,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/notificationChannels", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/notificationChannels", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -742,18 +867,15 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.notification_channel
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("notification_channel"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.notification_channel
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("notification_channel"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -776,9 +898,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -800,12 +929,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:sendVerificationCode", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:sendVerificationCode", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -826,12 +959,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
     ) -> Result<gax::response::Response<crate::model::GetNotificationChannelVerificationCodeResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:getVerificationCode", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}:getVerificationCode", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -846,9 +983,16 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::NotificationChannel>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}:verify", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}:verify", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -886,12 +1030,16 @@ impl super::stub::QueryService for QueryService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryTimeSeriesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/timeSeries:query", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/timeSeries:query", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -929,12 +1077,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/services", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -952,9 +1104,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -971,9 +1130,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServicesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/services", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/services", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -993,18 +1159,15 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Service>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.service
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.service
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1027,9 +1190,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1050,12 +1220,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceLevelObjective>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/serviceLevelObjectives", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/serviceLevelObjectives", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1074,9 +1248,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceLevelObjective>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1094,12 +1275,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListServiceLevelObjectivesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/serviceLevelObjectives", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/serviceLevelObjectives", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1120,18 +1305,15 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ServiceLevelObjective>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.service_level_objective
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("service_level_objective"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.service_level_objective
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("service_level_objective"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1154,9 +1336,16 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1200,9 +1389,16 @@ impl super::stub::SnoozeService for SnoozeService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snooze>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/snoozes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v3/{}/snoozes", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1217,9 +1413,16 @@ impl super::stub::SnoozeService for SnoozeService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSnoozesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/snoozes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}/snoozes", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1239,9 +1442,16 @@ impl super::stub::SnoozeService for SnoozeService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snooze>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1258,18 +1468,15 @@ impl super::stub::SnoozeService for SnoozeService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Snooze>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.snooze
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("snooze"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.snooze
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("snooze"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1313,12 +1520,16 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUptimeCheckConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}/uptimeCheckConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v3/{}/uptimeCheckConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1338,9 +1549,16 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UptimeCheckConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1357,12 +1575,16 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UptimeCheckConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}/uptimeCheckConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v3/{}/uptimeCheckConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1379,18 +1601,15 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::UptimeCheckConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v3/{}", {
+            &req.uptime_check_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("uptime_check_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v3/{}",
-                    req.uptime_check_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("uptime_check_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1413,9 +1632,16 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v3/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v3/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1436,9 +1662,10 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUptimeCheckIpsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v3/uptimeCheckIps".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v3/uptimeCheckIps".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -122,235 +122,135 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
-    pub fn list_locations(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::secret_manager_service::ListLocations {
         super::builder::secret_manager_service::ListLocations::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Gets information about a location.
-    pub fn get_location(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetLocation {
+    pub fn get_location(&self) -> super::builder::secret_manager_service::GetLocation {
         super::builder::secret_manager_service::GetLocation::new(self.inner.clone())
-            .set_project(project.into())
-            .set_location(location.into())
     }
 
     /// Lists Secrets.
-    pub fn list_secrets(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::ListSecrets {
+    pub fn list_secrets(&self) -> super::builder::secret_manager_service::ListSecrets {
         super::builder::secret_manager_service::ListSecrets::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
-    pub fn create_secret(
-        &self,
-        project: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::CreateSecret {
+    pub fn create_secret(&self) -> super::builder::secret_manager_service::CreateSecret {
         super::builder::secret_manager_service::CreateSecret::new(self.inner.clone())
-            .set_project(project.into())
     }
 
     /// Lists Secrets.
     pub fn list_secrets_by_project_and_location(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::ListSecretsByProjectAndLocation {
         super::builder::secret_manager_service::ListSecretsByProjectAndLocation::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
     }
 
     /// Creates a new Secret containing no SecretVersions.
     pub fn create_secret_by_project_and_location(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::CreateSecretByProjectAndLocation {
         super::builder::secret_manager_service::CreateSecretByProjectAndLocation::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
-    pub fn add_secret_version(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::AddSecretVersion {
+    pub fn add_secret_version(&self) -> super::builder::secret_manager_service::AddSecretVersion {
         super::builder::secret_manager_service::AddSecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
     pub fn add_secret_version_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::AddSecretVersionByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::AddSecretVersionByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Gets metadata for a given Secret.
-    pub fn get_secret(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetSecret {
+    pub fn get_secret(&self) -> super::builder::secret_manager_service::GetSecret {
         super::builder::secret_manager_service::GetSecret::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Deletes a Secret.
-    pub fn delete_secret(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::DeleteSecret {
+    pub fn delete_secret(&self) -> super::builder::secret_manager_service::DeleteSecret {
         super::builder::secret_manager_service::DeleteSecret::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Updates metadata of an existing Secret.
-    pub fn update_secret(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::UpdateSecret {
+    pub fn update_secret(&self) -> super::builder::secret_manager_service::UpdateSecret {
         super::builder::secret_manager_service::UpdateSecret::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Gets metadata for a given Secret.
     pub fn get_secret_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::GetSecretByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::GetSecretByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Deletes a Secret.
     pub fn delete_secret_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::DeleteSecretByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::DeleteSecretByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Updates metadata of an existing Secret.
     pub fn update_secret_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::UpdateSecretByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::UpdateSecretByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
     pub fn list_secret_versions(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::ListSecretVersions {
         super::builder::secret_manager_service::ListSecretVersions::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Lists SecretVersions. This call does not return secret
     /// data.
     pub fn list_secret_versions_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::ListSecretVersionsByProjectAndLocationAndSecret
     {
-        super::builder::secret_manager_service::ListSecretVersionsByProjectAndLocationAndSecret::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
+        super::builder::secret_manager_service::ListSecretVersionsByProjectAndLocationAndSecret::new(
+            self.inner.clone(),
+        )
     }
 
     /// Gets metadata for a SecretVersion.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetSecretVersion {
+    pub fn get_secret_version(&self) -> super::builder::secret_manager_service::GetSecretVersion {
         super::builder::secret_manager_service::GetSecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
-            .set_version(version.into())
     }
 
     /// Gets metadata for a SecretVersion.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn get_secret_version_by_project_and_location_and_secret_and_version(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion
+    pub fn get_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
-            .set_version ( version.into() )
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
@@ -359,33 +259,17 @@ impl SecretManagerService {
     /// created SecretVersion.
     pub fn access_secret_version(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::AccessSecretVersion {
         super::builder::secret_manager_service::AccessSecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
-            .set_version(version.into())
     }
 
     /// Accesses a SecretVersion. This call returns the secret data.
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
-    pub fn access_secret_version_by_project_and_location_and_secret_and_version(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
+    pub fn access_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
-            .set_version ( version.into() )
     }
 
     /// Disables a SecretVersion.
@@ -394,33 +278,17 @@ impl SecretManagerService {
     /// DISABLED.
     pub fn disable_secret_version(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::DisableSecretVersion {
         super::builder::secret_manager_service::DisableSecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
-            .set_version(version.into())
     }
 
     /// Disables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
-    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
+    pub fn disable_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
-            .set_version ( version.into() )
     }
 
     /// Enables a SecretVersion.
@@ -429,33 +297,17 @@ impl SecretManagerService {
     /// ENABLED.
     pub fn enable_secret_version(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::EnableSecretVersion {
         super::builder::secret_manager_service::EnableSecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
-            .set_version(version.into())
     }
 
     /// Enables a SecretVersion.
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
-    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
+    pub fn enable_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
-            .set_version ( version.into() )
     }
 
     /// Destroys a SecretVersion.
@@ -465,14 +317,8 @@ impl SecretManagerService {
     /// secret data.
     pub fn destroy_secret_version(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::DestroySecretVersion {
         super::builder::secret_manager_service::DestroySecretVersion::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
-            .set_version(version.into())
     }
 
     /// Destroys a SecretVersion.
@@ -480,19 +326,9 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
-    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(
-        &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-        version: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
+    pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
-            .set_version ( version.into() )
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -500,14 +336,8 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
-    pub fn set_iam_policy(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::secret_manager_service::SetIamPolicy {
         super::builder::secret_manager_service::SetIamPolicy::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Sets the access control policy on the specified secret. Replaces any
@@ -517,44 +347,26 @@ impl SecretManagerService {
     /// to the policy set on the associated Secret.
     pub fn set_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::SetIamPolicyByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::SetIamPolicyByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
-    pub fn get_iam_policy(
-        &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
-    ) -> super::builder::secret_manager_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::secret_manager_service::GetIamPolicy {
         super::builder::secret_manager_service::GetIamPolicy::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
     pub fn get_iam_policy_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::GetIamPolicyByProjectAndLocationAndSecret {
         super::builder::secret_manager_service::GetIamPolicyByProjectAndLocationAndSecret::new(
             self.inner.clone(),
         )
-        .set_project(project.into())
-        .set_location(location.into())
-        .set_secret(secret.into())
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -566,12 +378,8 @@ impl SecretManagerService {
     /// may "fail open" without warning.
     pub fn test_iam_permissions(
         &self,
-        project: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::TestIamPermissions {
         super::builder::secret_manager_service::TestIamPermissions::new(self.inner.clone())
-            .set_project(project.into())
-            .set_secret(secret.into())
     }
 
     /// Returns permissions that a caller has for the specified secret.
@@ -583,14 +391,10 @@ impl SecretManagerService {
     /// may "fail open" without warning.
     pub fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
-        project: impl Into<std::string::String>,
-        location: impl Into<std::string::String>,
-        secret: impl Into<std::string::String>,
     ) -> super::builder::secret_manager_service::TestIamPermissionsByProjectAndLocationAndSecret
     {
-        super::builder::secret_manager_service::TestIamPermissionsByProjectAndLocationAndSecret::new(self.inner.clone())
-            .set_project ( project.into() )
-            .set_location ( location.into() )
-            .set_secret ( secret.into() )
+        super::builder::secret_manager_service::TestIamPermissionsByProjectAndLocationAndSecret::new(
+            self.inner.clone(),
+        )
     }
 }

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/locations", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/locations", req.project),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -80,12 +84,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/locations/{}", req.project, req.location),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -102,12 +120,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/secrets", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/secrets", req.project),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -136,12 +158,16 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/secrets", {
+            let arg = &req.project;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/secrets", req.project),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -159,15 +185,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets",
-                    req.project, req.location
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -196,15 +233,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets",
-                    req.project, req.location
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -222,15 +270,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}:addVersion",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}:addVersion",
-                    req.project, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -245,15 +304,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}:addVersion",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}:addVersion",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -268,12 +345,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -290,12 +381,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Empty>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -316,12 +421,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!("/v1/projects/{}/secrets/{}", req.project, req.secret),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -343,15 +462,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -368,15 +505,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Empty>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::DELETE,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -397,15 +552,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Secret>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -427,15 +600,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions",
-                    req.project, req.secret
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -464,15 +648,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSecretVersionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -501,15 +703,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions/{}",
-                    req.project, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -526,15 +746,40 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions/{}",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions/{}",
-                    req.project, req.location, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -551,15 +796,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessSecretVersionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions/{}:access",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions/{}:access",
-                    req.project, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -576,15 +839,40 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AccessSecretVersionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:access",
-                    req.project, req.location, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -601,15 +889,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions/{}:disable",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions/{}:disable",
-                    req.project, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -624,15 +930,40 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:disable",
-                    req.project, req.location, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -647,15 +978,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions/{}:enable",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions/{}:enable",
-                    req.project, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -670,15 +1019,40 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:enable",
-                    req.project, req.location, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -693,15 +1067,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}/versions/{}:destroy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}/versions/{}:destroy",
-                    req.project, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -716,15 +1108,40 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SecretVersion>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+            {
+                let arg = &req.version;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("version"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}/versions/{}:destroy",
-                    req.project, req.location, req.secret, req.version
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -739,15 +1156,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}:setIamPolicy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}:setIamPolicy",
-                    req.project, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -762,15 +1190,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}:setIamPolicy",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -785,15 +1231,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}:getIamPolicy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/secrets/{}:getIamPolicy",
-                    req.project, req.secret
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -816,15 +1273,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}:getIamPolicy",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -847,15 +1322,26 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/secrets/{}:testIamPermissions",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/secrets/{}:testIamPermissions",
-                    req.project, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",
@@ -870,15 +1356,33 @@ impl super::stub::SecretManagerService for SecretManagerService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!(
+            "/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions",
+            {
+                let arg = &req.project;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("project"));
+                }
+                arg
+            },
+            {
+                let arg = &req.location;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("location"));
+                }
+                arg
+            },
+            {
+                let arg = &req.secret;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("secret"));
+                }
+                arg
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!(
-                    "/v1/projects/{}/locations/{}/secrets/{}:testIamPermissions",
-                    req.project, req.location, req.secret
-                ),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/privacy/dlp/v2/src/client.rs
+++ b/src/generated/privacy/dlp/v2/src/client.rs
@@ -133,12 +133,8 @@ impl DlpService {
     /// <https://cloud.google.com/sensitive-data-protection/docs/inspecting-images>
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/inspecting-text>,
-    pub fn inspect_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::InspectContent {
+    pub fn inspect_content(&self) -> super::builder::dlp_service::InspectContent {
         super::builder::dlp_service::InspectContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Redacts potentially sensitive info from an image.
@@ -153,11 +149,8 @@ impl DlpService {
     ///
     /// Only the first frame of each multiframe image is redacted. Metadata and
     /// other frames are omitted in the response.
-    pub fn redact_image(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::RedactImage {
-        super::builder::dlp_service::RedactImage::new(self.inner.clone()).set_parent(parent.into())
+    pub fn redact_image(&self) -> super::builder::dlp_service::RedactImage {
+        super::builder::dlp_service::RedactImage::new(self.inner.clone())
     }
 
     /// De-identifies potentially sensitive info from a ContentItem.
@@ -169,24 +162,16 @@ impl DlpService {
     /// When no InfoTypes or CustomInfoTypes are specified in this request, the
     /// system will automatically choose what detectors to run. By default this may
     /// be all types, but may change over time as detectors are updated.
-    pub fn deidentify_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeidentifyContent {
+    pub fn deidentify_content(&self) -> super::builder::dlp_service::DeidentifyContent {
         super::builder::dlp_service::DeidentifyContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Re-identifies content that has been de-identified.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/pseudonymization#re-identification_in_free_text_code_example>
     /// to learn more.
-    pub fn reidentify_content(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ReidentifyContent {
+    pub fn reidentify_content(&self) -> super::builder::dlp_service::ReidentifyContent {
         super::builder::dlp_service::ReidentifyContent::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Returns a list of the sensitive information types that the DLP API
@@ -202,60 +187,40 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
-    pub fn create_inspect_template(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateInspectTemplate {
+    pub fn create_inspect_template(&self) -> super::builder::dlp_service::CreateInspectTemplate {
         super::builder::dlp_service::CreateInspectTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the InspectTemplate.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
-    pub fn update_inspect_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::UpdateInspectTemplate {
+    pub fn update_inspect_template(&self) -> super::builder::dlp_service::UpdateInspectTemplate {
         super::builder::dlp_service::UpdateInspectTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets an InspectTemplate.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
-    pub fn get_inspect_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetInspectTemplate {
+    pub fn get_inspect_template(&self) -> super::builder::dlp_service::GetInspectTemplate {
         super::builder::dlp_service::GetInspectTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists InspectTemplates.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
-    pub fn list_inspect_templates(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListInspectTemplates {
+    pub fn list_inspect_templates(&self) -> super::builder::dlp_service::ListInspectTemplates {
         super::builder::dlp_service::ListInspectTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an InspectTemplate.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
-    pub fn delete_inspect_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteInspectTemplate {
+    pub fn delete_inspect_template(&self) -> super::builder::dlp_service::DeleteInspectTemplate {
         super::builder::dlp_service::DeleteInspectTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a DeidentifyTemplate for reusing frequently used configuration
@@ -265,10 +230,8 @@ impl DlpService {
     /// to learn more.
     pub fn create_deidentify_template(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::CreateDeidentifyTemplate {
         super::builder::dlp_service::CreateDeidentifyTemplate::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the DeidentifyTemplate.
@@ -277,22 +240,16 @@ impl DlpService {
     /// to learn more.
     pub fn update_deidentify_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::UpdateDeidentifyTemplate {
         super::builder::dlp_service::UpdateDeidentifyTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a DeidentifyTemplate.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates-deid>
     /// to learn more.
-    pub fn get_deidentify_template(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetDeidentifyTemplate {
+    pub fn get_deidentify_template(&self) -> super::builder::dlp_service::GetDeidentifyTemplate {
         super::builder::dlp_service::GetDeidentifyTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists DeidentifyTemplates.
@@ -301,10 +258,8 @@ impl DlpService {
     /// to learn more.
     pub fn list_deidentify_templates(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::ListDeidentifyTemplates {
         super::builder::dlp_service::ListDeidentifyTemplates::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a DeidentifyTemplate.
@@ -313,10 +268,8 @@ impl DlpService {
     /// to learn more.
     pub fn delete_deidentify_template(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::DeleteDeidentifyTemplate {
         super::builder::dlp_service::DeleteDeidentifyTemplate::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a job trigger to run DLP actions such as scanning storage for
@@ -324,23 +277,16 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
-    pub fn create_job_trigger(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateJobTrigger {
+    pub fn create_job_trigger(&self) -> super::builder::dlp_service::CreateJobTrigger {
         super::builder::dlp_service::CreateJobTrigger::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a job trigger.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
-    pub fn update_job_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::UpdateJobTrigger {
-        super::builder::dlp_service::UpdateJobTrigger::new(self.inner.clone()).set_name(name.into())
+    pub fn update_job_trigger(&self) -> super::builder::dlp_service::UpdateJobTrigger {
+        super::builder::dlp_service::UpdateJobTrigger::new(self.inner.clone())
     }
 
     /// Inspect hybrid content and store findings to a trigger. The inspection
@@ -348,99 +294,63 @@ impl DlpService {
     /// jobs within the trigger.
     pub fn hybrid_inspect_job_trigger(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::HybridInspectJobTrigger {
         super::builder::dlp_service::HybridInspectJobTrigger::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a job trigger.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
-    pub fn get_job_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetJobTrigger {
-        super::builder::dlp_service::GetJobTrigger::new(self.inner.clone()).set_name(name.into())
+    pub fn get_job_trigger(&self) -> super::builder::dlp_service::GetJobTrigger {
+        super::builder::dlp_service::GetJobTrigger::new(self.inner.clone())
     }
 
     /// Lists job triggers.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
-    pub fn list_job_triggers(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListJobTriggers {
+    pub fn list_job_triggers(&self) -> super::builder::dlp_service::ListJobTriggers {
         super::builder::dlp_service::ListJobTriggers::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a job trigger.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
-    pub fn delete_job_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteJobTrigger {
-        super::builder::dlp_service::DeleteJobTrigger::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_job_trigger(&self) -> super::builder::dlp_service::DeleteJobTrigger {
+        super::builder::dlp_service::DeleteJobTrigger::new(self.inner.clone())
     }
 
     /// Activate a job trigger. Causes the immediate execute of a trigger
     /// instead of waiting on the trigger event to occur.
-    pub fn activate_job_trigger(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ActivateJobTrigger {
+    pub fn activate_job_trigger(&self) -> super::builder::dlp_service::ActivateJobTrigger {
         super::builder::dlp_service::ActivateJobTrigger::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a config for discovery to scan and profile storage.
-    pub fn create_discovery_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateDiscoveryConfig {
+    pub fn create_discovery_config(&self) -> super::builder::dlp_service::CreateDiscoveryConfig {
         super::builder::dlp_service::CreateDiscoveryConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates a discovery configuration.
-    pub fn update_discovery_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::UpdateDiscoveryConfig {
+    pub fn update_discovery_config(&self) -> super::builder::dlp_service::UpdateDiscoveryConfig {
         super::builder::dlp_service::UpdateDiscoveryConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a discovery configuration.
-    pub fn get_discovery_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetDiscoveryConfig {
+    pub fn get_discovery_config(&self) -> super::builder::dlp_service::GetDiscoveryConfig {
         super::builder::dlp_service::GetDiscoveryConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists discovery configurations.
-    pub fn list_discovery_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListDiscoveryConfigs {
+    pub fn list_discovery_configs(&self) -> super::builder::dlp_service::ListDiscoveryConfigs {
         super::builder::dlp_service::ListDiscoveryConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a discovery configuration.
-    pub fn delete_discovery_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteDiscoveryConfig {
+    pub fn delete_discovery_config(&self) -> super::builder::dlp_service::DeleteDiscoveryConfig {
         super::builder::dlp_service::DeleteDiscoveryConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates a new job to inspect storage or calculate risk metrics.
@@ -453,11 +363,8 @@ impl DlpService {
     /// When no InfoTypes or CustomInfoTypes are specified in inspect jobs, the
     /// system will automatically choose what detectors to run. By default this may
     /// be all types, but may change over time as detectors are updated.
-    pub fn create_dlp_job(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateDlpJob {
-        super::builder::dlp_service::CreateDlpJob::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_dlp_job(&self) -> super::builder::dlp_service::CreateDlpJob {
+        super::builder::dlp_service::CreateDlpJob::new(self.inner.clone())
     }
 
     /// Lists DlpJobs that match the specified filter in the request.
@@ -466,11 +373,8 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
-    pub fn list_dlp_jobs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListDlpJobs {
-        super::builder::dlp_service::ListDlpJobs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_dlp_jobs(&self) -> super::builder::dlp_service::ListDlpJobs {
+        super::builder::dlp_service::ListDlpJobs::new(self.inner.clone())
     }
 
     /// Gets the latest state of a long-running DlpJob.
@@ -479,11 +383,8 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
-    pub fn get_dlp_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetDlpJob {
-        super::builder::dlp_service::GetDlpJob::new(self.inner.clone()).set_name(name.into())
+    pub fn get_dlp_job(&self) -> super::builder::dlp_service::GetDlpJob {
+        super::builder::dlp_service::GetDlpJob::new(self.inner.clone())
     }
 
     /// Deletes a long-running DlpJob. This method indicates that the client is
@@ -494,11 +395,8 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
-    pub fn delete_dlp_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteDlpJob {
-        super::builder::dlp_service::DeleteDlpJob::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_dlp_job(&self) -> super::builder::dlp_service::DeleteDlpJob {
+        super::builder::dlp_service::DeleteDlpJob::new(self.inner.clone())
     }
 
     /// Starts asynchronous cancellation on a long-running DlpJob. The server
@@ -509,23 +407,16 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
-    pub fn cancel_dlp_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CancelDlpJob {
-        super::builder::dlp_service::CancelDlpJob::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_dlp_job(&self) -> super::builder::dlp_service::CancelDlpJob {
+        super::builder::dlp_service::CancelDlpJob::new(self.inner.clone())
     }
 
     /// Creates a pre-built stored infoType to be used for inspection.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
-    pub fn create_stored_info_type(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateStoredInfoType {
+    pub fn create_stored_info_type(&self) -> super::builder::dlp_service::CreateStoredInfoType {
         super::builder::dlp_service::CreateStoredInfoType::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates the stored infoType by creating a new version. The existing version
@@ -533,211 +424,135 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
-    pub fn update_stored_info_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::UpdateStoredInfoType {
+    pub fn update_stored_info_type(&self) -> super::builder::dlp_service::UpdateStoredInfoType {
         super::builder::dlp_service::UpdateStoredInfoType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a stored infoType.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
-    pub fn get_stored_info_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetStoredInfoType {
+    pub fn get_stored_info_type(&self) -> super::builder::dlp_service::GetStoredInfoType {
         super::builder::dlp_service::GetStoredInfoType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists stored infoTypes.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
-    pub fn list_stored_info_types(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListStoredInfoTypes {
+    pub fn list_stored_info_types(&self) -> super::builder::dlp_service::ListStoredInfoTypes {
         super::builder::dlp_service::ListStoredInfoTypes::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes a stored infoType.
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
-    pub fn delete_stored_info_type(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteStoredInfoType {
+    pub fn delete_stored_info_type(&self) -> super::builder::dlp_service::DeleteStoredInfoType {
         super::builder::dlp_service::DeleteStoredInfoType::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists project data profiles for an organization.
     pub fn list_project_data_profiles(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::ListProjectDataProfiles {
         super::builder::dlp_service::ListProjectDataProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists table data profiles for an organization.
-    pub fn list_table_data_profiles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListTableDataProfiles {
+    pub fn list_table_data_profiles(&self) -> super::builder::dlp_service::ListTableDataProfiles {
         super::builder::dlp_service::ListTableDataProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists column data profiles for an organization.
-    pub fn list_column_data_profiles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListColumnDataProfiles {
+    pub fn list_column_data_profiles(&self) -> super::builder::dlp_service::ListColumnDataProfiles {
         super::builder::dlp_service::ListColumnDataProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a project data profile.
-    pub fn get_project_data_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetProjectDataProfile {
+    pub fn get_project_data_profile(&self) -> super::builder::dlp_service::GetProjectDataProfile {
         super::builder::dlp_service::GetProjectDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists file store data profiles for an organization.
     pub fn list_file_store_data_profiles(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::ListFileStoreDataProfiles {
         super::builder::dlp_service::ListFileStoreDataProfiles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets a file store data profile.
     pub fn get_file_store_data_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::GetFileStoreDataProfile {
         super::builder::dlp_service::GetFileStoreDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Delete a FileStoreDataProfile. Will not prevent the profile from being
     /// regenerated if the resource is still included in a discovery configuration.
     pub fn delete_file_store_data_profile(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::dlp_service::DeleteFileStoreDataProfile {
         super::builder::dlp_service::DeleteFileStoreDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a table data profile.
-    pub fn get_table_data_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetTableDataProfile {
+    pub fn get_table_data_profile(&self) -> super::builder::dlp_service::GetTableDataProfile {
         super::builder::dlp_service::GetTableDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Gets a column data profile.
-    pub fn get_column_data_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetColumnDataProfile {
+    pub fn get_column_data_profile(&self) -> super::builder::dlp_service::GetColumnDataProfile {
         super::builder::dlp_service::GetColumnDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Delete a TableDataProfile. Will not prevent the profile from being
     /// regenerated if the table is still included in a discovery configuration.
-    pub fn delete_table_data_profile(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteTableDataProfile {
+    pub fn delete_table_data_profile(&self) -> super::builder::dlp_service::DeleteTableDataProfile {
         super::builder::dlp_service::DeleteTableDataProfile::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Inspect hybrid content and store findings to a job.
     /// To review the findings, inspect the job. Inspection will occur
     /// asynchronously.
-    pub fn hybrid_inspect_dlp_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::HybridInspectDlpJob {
+    pub fn hybrid_inspect_dlp_job(&self) -> super::builder::dlp_service::HybridInspectDlpJob {
         super::builder::dlp_service::HybridInspectDlpJob::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Finish a running hybrid DlpJob. Triggers the finalization steps and running
     /// of any enabled actions that have not yet run.
-    pub fn finish_dlp_job(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::FinishDlpJob {
-        super::builder::dlp_service::FinishDlpJob::new(self.inner.clone()).set_name(name.into())
+    pub fn finish_dlp_job(&self) -> super::builder::dlp_service::FinishDlpJob {
+        super::builder::dlp_service::FinishDlpJob::new(self.inner.clone())
     }
 
     /// Create a Connection to an external data source.
-    pub fn create_connection(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::CreateConnection {
+    pub fn create_connection(&self) -> super::builder::dlp_service::CreateConnection {
         super::builder::dlp_service::CreateConnection::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Get a Connection by name.
-    pub fn get_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::GetConnection {
-        super::builder::dlp_service::GetConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn get_connection(&self) -> super::builder::dlp_service::GetConnection {
+        super::builder::dlp_service::GetConnection::new(self.inner.clone())
     }
 
     /// Lists Connections in a parent. Use SearchConnections to see all connections
     /// within an organization.
-    pub fn list_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::ListConnections {
+    pub fn list_connections(&self) -> super::builder::dlp_service::ListConnections {
         super::builder::dlp_service::ListConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Searches for Connections in a parent.
-    pub fn search_connections(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::SearchConnections {
+    pub fn search_connections(&self) -> super::builder::dlp_service::SearchConnections {
         super::builder::dlp_service::SearchConnections::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Delete a Connection.
-    pub fn delete_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::DeleteConnection {
-        super::builder::dlp_service::DeleteConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_connection(&self) -> super::builder::dlp_service::DeleteConnection {
+        super::builder::dlp_service::DeleteConnection::new(self.inner.clone())
     }
 
     /// Update a Connection.
-    pub fn update_connection(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::dlp_service::UpdateConnection {
-        super::builder::dlp_service::UpdateConnection::new(self.inner.clone()).set_name(name.into())
+    pub fn update_connection(&self) -> super::builder::dlp_service::UpdateConnection {
+        super::builder::dlp_service::UpdateConnection::new(self.inner.clone())
     }
 }

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InspectContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/content:inspect", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/content:inspect", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -66,12 +70,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RedactImageResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/image:redact", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/image:redact", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -86,12 +94,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeidentifyContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/content:deidentify", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/content:deidentify", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -106,12 +118,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReidentifyContentResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/content:reidentify", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/content:reidentify", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -126,9 +142,10 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInfoTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v2/infoTypes".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v2/infoTypes".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -149,12 +166,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InspectTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/inspectTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/inspectTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -169,9 +190,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InspectTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -186,9 +214,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InspectTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -205,12 +240,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInspectTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/inspectTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/inspectTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,9 +270,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,12 +300,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeidentifyTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/deidentifyTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/deidentifyTemplates", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -274,9 +324,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeidentifyTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -291,9 +348,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DeidentifyTemplate>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,12 +374,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDeidentifyTemplatesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/deidentifyTemplates", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/deidentifyTemplates", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -336,9 +404,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -359,12 +434,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/jobTriggers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/jobTriggers", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -379,9 +458,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,12 +482,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HybridInspectResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:hybridInspect", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:hybridInspect", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -416,9 +506,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::JobTrigger>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -435,12 +532,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListJobTriggersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/jobTriggers", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/jobTriggers", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -463,9 +564,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -486,9 +594,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DlpJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:activate", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:activate", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -503,12 +618,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoveryConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/discoveryConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/discoveryConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -523,9 +642,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoveryConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -540,9 +666,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DiscoveryConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -559,12 +692,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDiscoveryConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/discoveryConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/discoveryConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -584,9 +721,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -607,9 +751,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DlpJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/dlpJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}/dlpJobs", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -624,9 +775,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDlpJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/dlpJobs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}/dlpJobs", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -649,9 +807,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::DlpJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -668,9 +833,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -691,9 +863,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -713,12 +892,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StoredInfoType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/storedInfoTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/storedInfoTypes", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -733,9 +916,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StoredInfoType>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -750,9 +940,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StoredInfoType>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -769,12 +966,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListStoredInfoTypesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/storedInfoTypes", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/storedInfoTypes", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,9 +996,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -818,12 +1026,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListProjectDataProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/projectDataProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/projectDataProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -844,12 +1056,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTableDataProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/tableDataProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/tableDataProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -870,12 +1086,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListColumnDataProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/columnDataProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/columnDataProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -896,9 +1116,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ProjectDataProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -915,12 +1142,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListFileStoreDataProfilesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/fileStoreDataProfiles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/fileStoreDataProfiles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -941,9 +1172,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FileStoreDataProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -960,9 +1198,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -983,9 +1228,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TableDataProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1002,9 +1254,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ColumnDataProfile>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1021,9 +1280,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1044,12 +1310,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::HybridInspectResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:hybridInspect", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}:hybridInspect", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1064,9 +1334,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}:finish", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v2/{}:finish", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1086,12 +1363,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v2/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1106,9 +1387,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1125,12 +1413,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/connections", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/connections", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1150,12 +1442,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SearchConnectionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}/connections:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v2/{}/connections:search", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1175,9 +1471,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1198,9 +1501,16 @@ impl super::stub::DlpService for DlpService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Connection>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v2/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v2/{}", req.name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -142,30 +142,20 @@ impl Compliance {
     /// This method echoes the ComplianceData request. This method exercises
     /// sending some parameters as "simple" path variables (i.e., of the form
     /// "/bar/{foo}" rather than "/{foo=bar/*}"), and the rest as query parameters.
-    pub fn repeat_data_simple_path(
-        &self,
-        info: impl Into<crate::model::ComplianceData>,
-    ) -> super::builder::compliance::RepeatDataSimplePath {
+    pub fn repeat_data_simple_path(&self) -> super::builder::compliance::RepeatDataSimplePath {
         super::builder::compliance::RepeatDataSimplePath::new(self.inner.clone())
-            .set_info(info.into())
     }
 
     /// Same as RepeatDataSimplePath, but with a path resource.
-    pub fn repeat_data_path_resource(
-        &self,
-        info: impl Into<crate::model::ComplianceData>,
-    ) -> super::builder::compliance::RepeatDataPathResource {
+    pub fn repeat_data_path_resource(&self) -> super::builder::compliance::RepeatDataPathResource {
         super::builder::compliance::RepeatDataPathResource::new(self.inner.clone())
-            .set_info(info.into())
     }
 
     /// Same as RepeatDataSimplePath, but with a trailing resource.
     pub fn repeat_data_path_trailing_resource(
         &self,
-        info: impl Into<crate::model::ComplianceData>,
     ) -> super::builder::compliance::RepeatDataPathTrailingResource {
         super::builder::compliance::RepeatDataPathTrailingResource::new(self.inner.clone())
-            .set_info(info.into())
     }
 
     /// This method echoes the ComplianceData request, using the HTTP PUT method.
@@ -201,54 +191,36 @@ impl Compliance {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::compliance::ListLocations {
-        super::builder::compliance::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::compliance::ListLocations {
+        super::builder::compliance::ListLocations::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::compliance::GetLocation {
-        super::builder::compliance::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::compliance::GetLocation {
+        super::builder::compliance::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::compliance::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::compliance::SetIamPolicy {
         super::builder::compliance::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::compliance::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::compliance::GetIamPolicy {
         super::builder::compliance::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::compliance::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::compliance::TestIamPermissions {
         super::builder::compliance::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -261,31 +233,22 @@ impl Compliance {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::compliance::GetOperation {
-        super::builder::compliance::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::compliance::GetOperation {
+        super::builder::compliance::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::compliance::DeleteOperation {
-        super::builder::compliance::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::compliance::DeleteOperation {
+        super::builder::compliance::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::compliance::CancelOperation {
-        super::builder::compliance::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::compliance::CancelOperation {
+        super::builder::compliance::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -467,52 +430,36 @@ impl Echo {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::echo::ListLocations {
-        super::builder::echo::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::echo::ListLocations {
+        super::builder::echo::ListLocations::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::echo::GetLocation {
-        super::builder::echo::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::echo::GetLocation {
+        super::builder::echo::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::echo::SetIamPolicy {
-        super::builder::echo::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::echo::SetIamPolicy {
+        super::builder::echo::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::echo::GetIamPolicy {
-        super::builder::echo::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::echo::GetIamPolicy {
+        super::builder::echo::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::echo::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::echo::TestIamPermissions {
         super::builder::echo::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -525,31 +472,22 @@ impl Echo {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::echo::GetOperation {
-        super::builder::echo::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::echo::GetOperation {
+        super::builder::echo::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::echo::DeleteOperation {
-        super::builder::echo::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::echo::DeleteOperation {
+        super::builder::echo::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::echo::CancelOperation {
-        super::builder::echo::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::echo::CancelOperation {
+        super::builder::echo::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -659,27 +597,18 @@ impl Identity {
     }
 
     /// Retrieves the User with the given uri.
-    pub fn get_user(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::GetUser {
-        super::builder::identity::GetUser::new(self.inner.clone()).set_name(name.into())
+    pub fn get_user(&self) -> super::builder::identity::GetUser {
+        super::builder::identity::GetUser::new(self.inner.clone())
     }
 
     /// Updates a user.
-    pub fn update_user(
-        &self,
-        user: impl Into<crate::model::User>,
-    ) -> super::builder::identity::UpdateUser {
-        super::builder::identity::UpdateUser::new(self.inner.clone()).set_user(user.into())
+    pub fn update_user(&self) -> super::builder::identity::UpdateUser {
+        super::builder::identity::UpdateUser::new(self.inner.clone())
     }
 
     /// Deletes a user, their profile, and all of their authored messages.
-    pub fn delete_user(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::DeleteUser {
-        super::builder::identity::DeleteUser::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_user(&self) -> super::builder::identity::DeleteUser {
+        super::builder::identity::DeleteUser::new(self.inner.clone())
     }
 
     /// Lists all users.
@@ -690,54 +619,36 @@ impl Identity {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::ListLocations {
-        super::builder::identity::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::identity::ListLocations {
+        super::builder::identity::ListLocations::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::GetLocation {
-        super::builder::identity::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::identity::GetLocation {
+        super::builder::identity::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::identity::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::identity::SetIamPolicy {
         super::builder::identity::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::identity::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::identity::GetIamPolicy {
         super::builder::identity::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::identity::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::identity::TestIamPermissions {
         super::builder::identity::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -750,31 +661,22 @@ impl Identity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::GetOperation {
-        super::builder::identity::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::identity::GetOperation {
+        super::builder::identity::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::DeleteOperation {
-        super::builder::identity::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::identity::DeleteOperation {
+        super::builder::identity::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::identity::CancelOperation {
-        super::builder::identity::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::identity::CancelOperation {
+        super::builder::identity::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -887,27 +789,18 @@ impl Messaging {
     }
 
     /// Retrieves the Room with the given resource name.
-    pub fn get_room(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::GetRoom {
-        super::builder::messaging::GetRoom::new(self.inner.clone()).set_name(name.into())
+    pub fn get_room(&self) -> super::builder::messaging::GetRoom {
+        super::builder::messaging::GetRoom::new(self.inner.clone())
     }
 
     /// Updates a room.
-    pub fn update_room(
-        &self,
-        room: impl Into<crate::model::Room>,
-    ) -> super::builder::messaging::UpdateRoom {
-        super::builder::messaging::UpdateRoom::new(self.inner.clone()).set_room(room.into())
+    pub fn update_room(&self) -> super::builder::messaging::UpdateRoom {
+        super::builder::messaging::UpdateRoom::new(self.inner.clone())
     }
 
     /// Deletes a room and all of its blurbs.
-    pub fn delete_room(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::DeleteRoom {
-        super::builder::messaging::DeleteRoom::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_room(&self) -> super::builder::messaging::DeleteRoom {
+        super::builder::messaging::DeleteRoom::new(self.inner.clone())
     }
 
     /// Lists all chat rooms.
@@ -918,44 +811,29 @@ impl Messaging {
     /// Creates a blurb. If the parent is a room, the blurb is understood to be a
     /// message in that room. If the parent is a profile, the blurb is understood
     /// to be a post on the profile.
-    pub fn create_blurb(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::messaging::CreateBlurb {
-        super::builder::messaging::CreateBlurb::new(self.inner.clone()).set_parent(parent.into())
+    pub fn create_blurb(&self) -> super::builder::messaging::CreateBlurb {
+        super::builder::messaging::CreateBlurb::new(self.inner.clone())
     }
 
     /// Retrieves the Blurb with the given resource name.
-    pub fn get_blurb(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::GetBlurb {
-        super::builder::messaging::GetBlurb::new(self.inner.clone()).set_name(name.into())
+    pub fn get_blurb(&self) -> super::builder::messaging::GetBlurb {
+        super::builder::messaging::GetBlurb::new(self.inner.clone())
     }
 
     /// Updates a blurb.
-    pub fn update_blurb(
-        &self,
-        blurb: impl Into<crate::model::Blurb>,
-    ) -> super::builder::messaging::UpdateBlurb {
-        super::builder::messaging::UpdateBlurb::new(self.inner.clone()).set_blurb(blurb.into())
+    pub fn update_blurb(&self) -> super::builder::messaging::UpdateBlurb {
+        super::builder::messaging::UpdateBlurb::new(self.inner.clone())
     }
 
     /// Deletes a blurb.
-    pub fn delete_blurb(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::DeleteBlurb {
-        super::builder::messaging::DeleteBlurb::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_blurb(&self) -> super::builder::messaging::DeleteBlurb {
+        super::builder::messaging::DeleteBlurb::new(self.inner.clone())
     }
 
     /// Lists blurbs for a specific chat room or user profile depending on the
     /// parent resource name.
-    pub fn list_blurbs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::messaging::ListBlurbs {
-        super::builder::messaging::ListBlurbs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_blurbs(&self) -> super::builder::messaging::ListBlurbs {
+        super::builder::messaging::ListBlurbs::new(self.inner.clone())
     }
 
     /// This method searches through all blurbs across all rooms and profiles
@@ -971,64 +849,43 @@ impl Messaging {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn search_blurbs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::messaging::SearchBlurbs {
-        super::builder::messaging::SearchBlurbs::new(self.inner.clone()).set_parent(parent.into())
+    pub fn search_blurbs(&self) -> super::builder::messaging::SearchBlurbs {
+        super::builder::messaging::SearchBlurbs::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::ListLocations {
-        super::builder::messaging::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::messaging::ListLocations {
+        super::builder::messaging::ListLocations::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::GetLocation {
-        super::builder::messaging::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::messaging::GetLocation {
+        super::builder::messaging::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::messaging::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::messaging::SetIamPolicy {
         super::builder::messaging::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::messaging::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::messaging::GetIamPolicy {
         super::builder::messaging::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::messaging::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::messaging::TestIamPermissions {
         super::builder::messaging::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1041,31 +898,22 @@ impl Messaging {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::GetOperation {
-        super::builder::messaging::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::messaging::GetOperation {
+        super::builder::messaging::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::DeleteOperation {
-        super::builder::messaging::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::messaging::DeleteOperation {
+        super::builder::messaging::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::messaging::CancelOperation {
-        super::builder::messaging::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::messaging::CancelOperation {
+        super::builder::messaging::CancelOperation::new(self.inner.clone())
     }
 }
 
@@ -1183,84 +1031,55 @@ impl SequenceService {
     }
 
     /// Retrieves a sequence.
-    pub fn get_sequence_report(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::GetSequenceReport {
+    pub fn get_sequence_report(&self) -> super::builder::sequence_service::GetSequenceReport {
         super::builder::sequence_service::GetSequenceReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Retrieves a sequence.
     pub fn get_streaming_sequence_report(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::sequence_service::GetStreamingSequenceReport {
         super::builder::sequence_service::GetStreamingSequenceReport::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Attempts a sequence.
-    pub fn attempt_sequence(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::AttemptSequence {
+    pub fn attempt_sequence(&self) -> super::builder::sequence_service::AttemptSequence {
         super::builder::sequence_service::AttemptSequence::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::ListLocations {
+    pub fn list_locations(&self) -> super::builder::sequence_service::ListLocations {
         super::builder::sequence_service::ListLocations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::GetLocation {
-        super::builder::sequence_service::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::sequence_service::GetLocation {
+        super::builder::sequence_service::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::sequence_service::SetIamPolicy {
         super::builder::sequence_service::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::sequence_service::GetIamPolicy {
         super::builder::sequence_service::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::sequence_service::TestIamPermissions {
         super::builder::sequence_service::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1273,34 +1092,22 @@ impl SequenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::sequence_service::GetOperation {
         super::builder::sequence_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::sequence_service::DeleteOperation {
         super::builder::sequence_service::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::sequence_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::sequence_service::CancelOperation {
         super::builder::sequence_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }
 
@@ -1421,11 +1228,8 @@ impl Testing {
     }
 
     /// Gets a testing session.
-    pub fn get_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::GetSession {
-        super::builder::testing::GetSession::new(self.inner.clone()).set_name(name.into())
+    pub fn get_session(&self) -> super::builder::testing::GetSession {
+        super::builder::testing::GetSession::new(self.inner.clone())
     }
 
     /// Lists the current test sessions.
@@ -1434,29 +1238,20 @@ impl Testing {
     }
 
     /// Delete a test session.
-    pub fn delete_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::DeleteSession {
-        super::builder::testing::DeleteSession::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_session(&self) -> super::builder::testing::DeleteSession {
+        super::builder::testing::DeleteSession::new(self.inner.clone())
     }
 
     /// Report on the status of a session.
     /// This generates a report detailing which tests have been completed,
     /// and an overall rollup.
-    pub fn report_session(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::ReportSession {
-        super::builder::testing::ReportSession::new(self.inner.clone()).set_name(name.into())
+    pub fn report_session(&self) -> super::builder::testing::ReportSession {
+        super::builder::testing::ReportSession::new(self.inner.clone())
     }
 
     /// List the tests of a sessesion.
-    pub fn list_tests(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::testing::ListTests {
-        super::builder::testing::ListTests::new(self.inner.clone()).set_parent(parent.into())
+    pub fn list_tests(&self) -> super::builder::testing::ListTests {
+        super::builder::testing::ListTests::new(self.inner.clone())
     }
 
     /// Explicitly decline to implement a test.
@@ -1465,73 +1260,51 @@ impl Testing {
     /// attempting to do the test will error.
     ///
     /// This method will error if attempting to delete a required test.
-    pub fn delete_test(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::DeleteTest {
-        super::builder::testing::DeleteTest::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_test(&self) -> super::builder::testing::DeleteTest {
+        super::builder::testing::DeleteTest::new(self.inner.clone())
     }
 
     /// Register a response to a test.
     ///
     /// In cases where a test involves registering a final answer at the
     /// end of the test, this method provides the means to do so.
-    pub fn verify_test(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::VerifyTest {
-        super::builder::testing::VerifyTest::new(self.inner.clone()).set_name(name.into())
+    pub fn verify_test(&self) -> super::builder::testing::VerifyTest {
+        super::builder::testing::VerifyTest::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn list_locations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::ListLocations {
-        super::builder::testing::ListLocations::new(self.inner.clone()).set_name(name.into())
+    pub fn list_locations(&self) -> super::builder::testing::ListLocations {
+        super::builder::testing::ListLocations::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
-    pub fn get_location(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::GetLocation {
-        super::builder::testing::GetLocation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_location(&self) -> super::builder::testing::GetLocation {
+        super::builder::testing::GetLocation::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::testing::SetIamPolicy {
-        super::builder::testing::SetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn set_iam_policy(&self) -> super::builder::testing::SetIamPolicy {
+        super::builder::testing::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::testing::GetIamPolicy {
-        super::builder::testing::GetIamPolicy::new(self.inner.clone()).set_resource(resource.into())
+    pub fn get_iam_policy(&self) -> super::builder::testing::GetIamPolicy {
+        super::builder::testing::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::testing::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::testing::TestIamPermissions {
         super::builder::testing::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
@@ -1544,30 +1317,21 @@ impl Testing {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::GetOperation {
-        super::builder::testing::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::testing::GetOperation {
+        super::builder::testing::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::DeleteOperation {
-        super::builder::testing::DeleteOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_operation(&self) -> super::builder::testing::DeleteOperation {
+        super::builder::testing::DeleteOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::testing::CancelOperation {
-        super::builder::testing::CancelOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn cancel_operation(&self) -> super::builder::testing::CancelOperation {
+        super::builder::testing::CancelOperation::new(self.inner.clone())
     }
 }

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -46,9 +46,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/repeat:body".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/repeat:body".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -63,12 +64,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/repeat:bodyinfo".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/repeat:bodyinfo".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -103,9 +102,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/repeat:query".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/repeat:query".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -152,34 +152,42 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1beta1/repeat/{}/{}/{}/{}/{}:simplepath",
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_string
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_int32
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_double
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_bool
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_kingdom
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1beta1/repeat/{}/{}/{}/{}/{}:simplepath",
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_string,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_int32,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_double,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_bool,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_kingdom
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -226,29 +234,33 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1beta1/repeat/{}/{}/bool/{}:pathresource",
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_string
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_child
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
+                    .f_string
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_bool
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1beta1/repeat/{}/{}/bool/{}:pathresource",
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_string,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_child
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                        .f_string,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_bool
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -295,25 +307,27 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!(
+            "/v1beta1/repeat/{}/{}:pathtrailingresource",
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_string
+            },
+            {
+                &req.info
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("info"))?
+                    .f_child
+                    .as_ref()
+                    .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
+                    .f_string
+            },
+        );
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!(
-                    "/v1beta1/repeat/{}/{}:pathtrailingresource",
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_string,
-                    req.info
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                        .f_child
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                        .f_string
-                ),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -360,9 +374,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/repeat:bodyput".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::PUT, "/v1beta1/repeat:bodyput".to_string())
+            .builder(reqwest::Method::PUT, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,12 +392,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RepeatResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/repeat:bodypatch".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                "/v1beta1/repeat:bodypatch".to_string(),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -397,9 +410,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/compliance/enum".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/compliance/enum".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -417,12 +431,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EnumResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/compliance/enum".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/compliance/enum".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -450,12 +462,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -475,9 +491,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -494,12 +517,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -514,12 +541,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -546,12 +577,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -566,9 +601,10 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -589,9 +625,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -608,9 +651,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -631,12 +681,16 @@ impl super::stub::Compliance for Compliance {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -678,9 +732,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:echo".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/echo:echo".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -695,12 +750,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::EchoErrorDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:error-details".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/echo:error-details".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -715,12 +768,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::FailEchoWithDetailsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:failWithDetails".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/echo:failWithDetails".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -735,12 +786,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:pagedExpand".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/echo:pagedExpand".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -755,12 +804,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:pagedExpandLegacy".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/echo:pagedExpandLegacy".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -775,12 +822,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PagedExpandLegacyMappedResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:pagedExpandLegacyMapped".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/echo:pagedExpandLegacyMapped".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -795,9 +840,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:wait".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/echo:wait".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -812,9 +858,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BlockResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/echo:block".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/echo:block".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -829,12 +876,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -854,9 +905,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -873,12 +931,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -893,12 +955,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -925,12 +991,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -945,9 +1015,10 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -968,9 +1039,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -987,9 +1065,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1010,12 +1095,16 @@ impl super::stub::Echo for Echo {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1073,9 +1162,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/users".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/users".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1090,9 +1180,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1109,18 +1206,15 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}", {
+            &req.user
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("user"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1beta1/{}",
-                    req.user
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("user"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1141,9 +1235,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1164,9 +1265,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListUsersResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/users".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/users".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1185,12 +1287,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1210,9 +1316,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1229,12 +1342,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1249,12 +1366,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1281,12 +1402,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1301,9 +1426,10 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1324,9 +1450,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1343,9 +1476,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1366,12 +1506,16 @@ impl super::stub::Identity for Identity {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1415,9 +1559,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/rooms".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/rooms".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1432,9 +1577,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1451,18 +1603,15 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}", {
+            &req.room
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("room"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1beta1/{}",
-                    req.room
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("room"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1483,9 +1632,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1506,9 +1662,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListRoomsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/rooms".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/rooms".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1527,12 +1684,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}/blurbs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}/blurbs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1547,9 +1708,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1566,18 +1734,15 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}", {
+            &req.blurb
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("blurb"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1beta1/{}",
-                    req.blurb
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("blurb"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1598,9 +1763,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1621,12 +1793,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBlurbsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/blurbs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/blurbs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1645,12 +1821,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}/blurbs:search", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}/blurbs:search", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1665,12 +1845,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1690,9 +1874,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1709,12 +1900,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1729,12 +1924,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1761,12 +1960,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1781,9 +1984,10 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1804,9 +2008,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1823,9 +2034,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1846,12 +2064,16 @@ impl super::stub::Messaging for Messaging {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1909,9 +2131,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Sequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/sequences".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/sequences".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1928,12 +2151,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequence>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/streamingSequences".to_string();
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                "/v1beta1/streamingSequences".to_string(),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1950,9 +2171,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::SequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1969,9 +2197,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StreamingSequenceReport>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -1988,9 +2223,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2010,12 +2252,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2035,9 +2281,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2054,12 +2307,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2074,12 +2331,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2106,12 +2367,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2126,9 +2391,10 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2149,9 +2415,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2168,9 +2441,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2191,12 +2471,16 @@ impl super::stub::SequenceService for SequenceService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2240,9 +2524,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1beta1/sessions".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1beta1/sessions".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2259,9 +2544,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Session>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2278,9 +2570,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListSessionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/sessions".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/sessions".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2299,9 +2592,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2322,12 +2622,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ReportSessionResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:report", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:report", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2344,12 +2648,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTestsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/tests", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/tests", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2368,9 +2676,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2391,12 +2706,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::VerifyTestResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:check", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:check", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2418,12 +2737,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::ListLocationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}/locations", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}/locations", req.name),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2443,9 +2766,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<location::model::Location>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2462,12 +2792,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2482,12 +2816,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1beta1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2514,12 +2852,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2534,9 +2876,10 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1beta1/operations".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1beta1/operations".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2557,9 +2900,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2576,9 +2926,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1beta1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1beta1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -2599,12 +2956,16 @@ impl super::stub::Testing for Testing {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1beta1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1beta1/{}:cancel", req.name),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -155,10 +155,15 @@ impl super::stub::Compliance for Compliance {
         let path = format!(
             "/v1beta1/repeat/{}/{}/{}/{}/{}:simplepath",
             {
-                &req.info
+                let arg = &req
+                    .info
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string
+                    .f_string;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("info.f_string"));
+                }
+                arg
             },
             {
                 &req.info
@@ -237,19 +242,29 @@ impl super::stub::Compliance for Compliance {
         let path = format!(
             "/v1beta1/repeat/{}/{}/bool/{}:pathresource",
             {
-                &req.info
+                let arg = &req
+                    .info
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string
+                    .f_string;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("info.f_string"));
+                }
+                arg
             },
             {
-                &req.info
+                let arg = &req
+                    .info
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("info"))?
                     .f_child
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                    .f_string
+                    .f_string;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("info.f_child.f_string"));
+                }
+                arg
             },
             {
                 &req.info
@@ -310,19 +325,29 @@ impl super::stub::Compliance for Compliance {
         let path = format!(
             "/v1beta1/repeat/{}/{}:pathtrailingresource",
             {
-                &req.info
+                let arg = &req
+                    .info
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("info"))?
-                    .f_string
+                    .f_string;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("info.f_string"));
+                }
+                arg
             },
             {
-                &req.info
+                let arg = &req
+                    .info
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("info"))?
                     .f_child
                     .as_ref()
                     .ok_or_else(|| gaxi::path_parameter::missing("f_child"))?
-                    .f_string
+                    .f_string;
+                if arg.is_empty() {
+                    return Err(gaxi::path_parameter::missing("info.f_child.f_string"));
+                }
+                arg
             },
         );
         let builder = self
@@ -1207,10 +1232,15 @@ impl super::stub::Identity for Identity {
     ) -> Result<gax::response::Response<crate::model::User>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1beta1/{}", {
-            &req.user
+            let arg = &req
+                .user
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("user"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("user.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1604,10 +1634,15 @@ impl super::stub::Messaging for Messaging {
     ) -> Result<gax::response::Response<crate::model::Room>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1beta1/{}", {
-            &req.room
+            let arg = &req
+                .room
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("room"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("room.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -1735,10 +1770,15 @@ impl super::stub::Messaging for Messaging {
     ) -> Result<gax::response::Response<crate::model::Blurb>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1beta1/{}", {
-            &req.blurb
+            let arg = &req
+                .blurb
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("blurb"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("blurb.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/spanner/admin/database/v1/src/client.rs
+++ b/src/generated/spanner/admin/database/v1/src/client.rs
@@ -126,12 +126,8 @@ impl DatabaseAdmin {
     }
 
     /// Lists Cloud Spanner databases.
-    pub fn list_databases(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListDatabases {
+    pub fn list_databases(&self) -> super::builder::database_admin::ListDatabases {
         super::builder::database_admin::ListDatabases::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -158,20 +154,13 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_database(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::CreateDatabase {
+    pub fn create_database(&self) -> super::builder::database_admin::CreateDatabase {
         super::builder::database_admin::CreateDatabase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets the state of a Cloud Spanner database.
-    pub fn get_database(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetDatabase {
-        super::builder::database_admin::GetDatabase::new(self.inner.clone()).set_name(name.into())
+    pub fn get_database(&self) -> super::builder::database_admin::GetDatabase {
+        super::builder::database_admin::GetDatabase::new(self.inner.clone())
     }
 
     /// Updates a Cloud Spanner database. The returned
@@ -228,12 +217,8 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_database(
-        &self,
-        database: impl Into<crate::model::Database>,
-    ) -> super::builder::database_admin::UpdateDatabase {
+    pub fn update_database(&self) -> super::builder::database_admin::UpdateDatabase {
         super::builder::database_admin::UpdateDatabase::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Updates the schema of a Cloud Spanner database by
@@ -258,12 +243,8 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_database_ddl(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::UpdateDatabaseDdl {
+    pub fn update_database_ddl(&self) -> super::builder::database_admin::UpdateDatabaseDdl {
         super::builder::database_admin::UpdateDatabaseDdl::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Drops (aka deletes) a Cloud Spanner database.
@@ -271,12 +252,8 @@ impl DatabaseAdmin {
     /// `expire_time`.
     /// Note: Cloud Spanner might continue to accept requests for a few seconds
     /// after the database has been deleted.
-    pub fn drop_database(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::DropDatabase {
+    pub fn drop_database(&self) -> super::builder::database_admin::DropDatabase {
         super::builder::database_admin::DropDatabase::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -284,12 +261,8 @@ impl DatabaseAdmin {
     /// be queried using the [Operations][google.longrunning.Operations] API.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_database_ddl(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetDatabaseDdl {
+    pub fn get_database_ddl(&self) -> super::builder::database_admin::GetDatabaseDdl {
         super::builder::database_admin::GetDatabaseDdl::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Sets the access control policy on a database or backup resource.
@@ -301,12 +274,8 @@ impl DatabaseAdmin {
     /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.SetIamPolicyRequest.resource]: iam_v1::model::SetIamPolicyRequest::resource
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::database_admin::SetIamPolicy {
         super::builder::database_admin::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for a database or backup resource.
@@ -319,12 +288,8 @@ impl DatabaseAdmin {
     /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.GetIamPolicyRequest.resource]: iam_v1::model::GetIamPolicyRequest::resource
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::database_admin::GetIamPolicy {
         super::builder::database_admin::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that the caller has on the specified database or backup
@@ -337,12 +302,8 @@ impl DatabaseAdmin {
     /// Calling this method on a backup that does not exist will
     /// result in a NOT_FOUND error if the user has
     /// `spanner.backups.list` permission on the containing instance.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::database_admin::TestIamPermissions {
         super::builder::database_admin::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Starts creating a new Cloud Spanner Backup.
@@ -373,12 +334,8 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::CreateBackup {
+    pub fn create_backup(&self) -> super::builder::database_admin::CreateBackup {
         super::builder::database_admin::CreateBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Starts copying a Cloud Spanner Backup.
@@ -410,57 +367,39 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn copy_backup(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::CopyBackup {
+    pub fn copy_backup(&self) -> super::builder::database_admin::CopyBackup {
         super::builder::database_admin::CopyBackup::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets metadata on a pending or completed
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
-    pub fn get_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetBackup {
-        super::builder::database_admin::GetBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn get_backup(&self) -> super::builder::database_admin::GetBackup {
+        super::builder::database_admin::GetBackup::new(self.inner.clone())
     }
 
     /// Updates a pending or completed
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
-    pub fn update_backup(
-        &self,
-        backup: impl Into<crate::model::Backup>,
-    ) -> super::builder::database_admin::UpdateBackup {
+    pub fn update_backup(&self) -> super::builder::database_admin::UpdateBackup {
         super::builder::database_admin::UpdateBackup::new(self.inner.clone())
-            .set_backup(backup.into())
     }
 
     /// Deletes a pending or completed
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
-    pub fn delete_backup(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::DeleteBackup {
-        super::builder::database_admin::DeleteBackup::new(self.inner.clone()).set_name(name.into())
+    pub fn delete_backup(&self) -> super::builder::database_admin::DeleteBackup {
+        super::builder::database_admin::DeleteBackup::new(self.inner.clone())
     }
 
     /// Lists completed and pending backups.
     /// Backups returned are ordered by `create_time` in descending order,
     /// starting from the most recent `create_time`.
-    pub fn list_backups(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListBackups {
+    pub fn list_backups(&self) -> super::builder::database_admin::ListBackups {
         super::builder::database_admin::ListBackups::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Create a new database by restoring from a completed backup. The new
@@ -496,12 +435,8 @@ impl DatabaseAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn restore_database(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::RestoreDatabase {
+    pub fn restore_database(&self) -> super::builder::database_admin::RestoreDatabase {
         super::builder::database_admin::RestoreDatabase::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -517,10 +452,8 @@ impl DatabaseAdmin {
     /// [google.longrunning.Operation.metadata]: longrunning::model::Operation::metadata
     pub fn list_database_operations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::database_admin::ListDatabaseOperations {
         super::builder::database_admin::ListDatabaseOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -536,117 +469,70 @@ impl DatabaseAdmin {
     ///
     /// [google.longrunning.Operation]: longrunning::model::Operation
     /// [google.longrunning.Operation.metadata]: longrunning::model::Operation::metadata
-    pub fn list_backup_operations(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListBackupOperations {
+    pub fn list_backup_operations(&self) -> super::builder::database_admin::ListBackupOperations {
         super::builder::database_admin::ListBackupOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists Cloud Spanner database roles.
-    pub fn list_database_roles(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListDatabaseRoles {
+    pub fn list_database_roles(&self) -> super::builder::database_admin::ListDatabaseRoles {
         super::builder::database_admin::ListDatabaseRoles::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Adds split points to specified tables, indexes of a database.
-    pub fn add_split_points(
-        &self,
-        database: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::AddSplitPoints {
+    pub fn add_split_points(&self) -> super::builder::database_admin::AddSplitPoints {
         super::builder::database_admin::AddSplitPoints::new(self.inner.clone())
-            .set_database(database.into())
     }
 
     /// Creates a new backup schedule.
-    pub fn create_backup_schedule(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::CreateBackupSchedule {
+    pub fn create_backup_schedule(&self) -> super::builder::database_admin::CreateBackupSchedule {
         super::builder::database_admin::CreateBackupSchedule::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets backup schedule for the input schedule name.
-    pub fn get_backup_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetBackupSchedule {
+    pub fn get_backup_schedule(&self) -> super::builder::database_admin::GetBackupSchedule {
         super::builder::database_admin::GetBackupSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates a backup schedule.
-    pub fn update_backup_schedule(
-        &self,
-        backup_schedule: impl Into<crate::model::BackupSchedule>,
-    ) -> super::builder::database_admin::UpdateBackupSchedule {
+    pub fn update_backup_schedule(&self) -> super::builder::database_admin::UpdateBackupSchedule {
         super::builder::database_admin::UpdateBackupSchedule::new(self.inner.clone())
-            .set_backup_schedule(backup_schedule.into())
     }
 
     /// Deletes a backup schedule.
-    pub fn delete_backup_schedule(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::DeleteBackupSchedule {
+    pub fn delete_backup_schedule(&self) -> super::builder::database_admin::DeleteBackupSchedule {
         super::builder::database_admin::DeleteBackupSchedule::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists all the backup schedules for the database.
-    pub fn list_backup_schedules(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListBackupSchedules {
+    pub fn list_backup_schedules(&self) -> super::builder::database_admin::ListBackupSchedules {
         super::builder::database_admin::ListBackupSchedules::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::database_admin::ListOperations {
         super::builder::database_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::GetOperation {
-        super::builder::database_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::database_admin::GetOperation {
+        super::builder::database_admin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::database_admin::DeleteOperation {
         super::builder::database_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::database_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::database_admin::CancelOperation {
         super::builder::database_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -125,10 +125,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.database
+            let arg = &req
+                .database
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("database"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -393,10 +398,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup
+            let arg = &req
+                .backup
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -668,10 +678,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.backup_schedule
+            let arg = &req
+                .backup_schedule
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("backup_schedule.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatabasesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/databases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/databases", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,12 +74,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/databases", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/databases", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -90,9 +98,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Database>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -109,18 +124,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.database
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("database"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.database
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("database"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -143,9 +155,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/ddl", {
+            let arg = &req.database;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}/ddl", req.database))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,9 +179,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.database;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.database))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -183,9 +209,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GetDatabaseDdlResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/ddl", {
+            let arg = &req.database;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/ddl", req.database))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -202,12 +235,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -222,12 +259,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -242,12 +283,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -262,9 +307,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -290,12 +342,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backups:copy", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backups:copy", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -310,9 +366,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -329,18 +392,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Backup>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -361,9 +421,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -384,9 +451,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backups", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}/backups", req.parent))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -406,12 +480,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/databases:restore", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/databases:restore", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -426,12 +504,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatabaseOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/databaseOperations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/databaseOperations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -451,12 +533,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupOperations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupOperations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -476,12 +562,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDatabaseRolesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/databaseRoles", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/databaseRoles", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -500,12 +590,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AddSplitPointsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:addSplitPoints", {
+            let arg = &req.database;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("database"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:addSplitPoints", req.database),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -520,12 +614,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/backupSchedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/backupSchedules", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -543,9 +641,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -562,18 +667,15 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BackupSchedule>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.backup_schedule
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.backup_schedule
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("backup_schedule"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -596,9 +698,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -619,12 +728,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBackupSchedulesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/backupSchedules", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/backupSchedules", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -643,9 +756,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -665,9 +785,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -684,9 +811,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -707,9 +841,16 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/spanner/admin/instance/v1/src/client.rs
+++ b/src/generated/spanner/admin/instance/v1/src/client.rs
@@ -142,21 +142,13 @@ impl InstanceAdmin {
     ///
     /// Returns both Google-managed configurations and user-managed
     /// configurations.
-    pub fn list_instance_configs(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::ListInstanceConfigs {
+    pub fn list_instance_configs(&self) -> super::builder::instance_admin::ListInstanceConfigs {
         super::builder::instance_admin::ListInstanceConfigs::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a particular instance configuration.
-    pub fn get_instance_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::GetInstanceConfig {
+    pub fn get_instance_config(&self) -> super::builder::instance_admin::GetInstanceConfig {
         super::builder::instance_admin::GetInstanceConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an instance configuration and begins preparing it to be used. The
@@ -215,12 +207,8 @@ impl InstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance_config(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::CreateInstanceConfig {
+    pub fn create_instance_config(&self) -> super::builder::instance_admin::CreateInstanceConfig {
         super::builder::instance_admin::CreateInstanceConfig::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an instance configuration. The returned
@@ -283,12 +271,8 @@ impl InstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance_config(
-        &self,
-        instance_config: impl Into<crate::model::InstanceConfig>,
-    ) -> super::builder::instance_admin::UpdateInstanceConfig {
+    pub fn update_instance_config(&self) -> super::builder::instance_admin::UpdateInstanceConfig {
         super::builder::instance_admin::UpdateInstanceConfig::new(self.inner.clone())
-            .set_instance_config(instance_config.into())
     }
 
     /// Deletes the instance configuration. Deletion is only allowed when no
@@ -301,12 +285,8 @@ impl InstanceAdmin {
     /// the resource [name][google.spanner.admin.instance.v1.InstanceConfig.name].
     ///
     /// [google.spanner.admin.instance.v1.InstanceConfig.name]: crate::model::InstanceConfig::name
-    pub fn delete_instance_config(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::DeleteInstanceConfig {
+    pub fn delete_instance_config(&self) -> super::builder::instance_admin::DeleteInstanceConfig {
         super::builder::instance_admin::DeleteInstanceConfig::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists the user-managed instance configuration long-running
@@ -322,36 +302,25 @@ impl InstanceAdmin {
     /// from the most recently started operation.
     pub fn list_instance_config_operations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::instance_admin::ListInstanceConfigOperations {
         super::builder::instance_admin::ListInstanceConfigOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all instances in the given project.
-    pub fn list_instances(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::ListInstances {
+    pub fn list_instances(&self) -> super::builder::instance_admin::ListInstances {
         super::builder::instance_admin::ListInstances::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Lists all instance partitions for the given instance.
     pub fn list_instance_partitions(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::instance_admin::ListInstancePartitions {
         super::builder::instance_admin::ListInstancePartitions::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Gets information about a particular instance.
-    pub fn get_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::GetInstance {
-        super::builder::instance_admin::GetInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn get_instance(&self) -> super::builder::instance_admin::GetInstance {
+        super::builder::instance_admin::GetInstance::new(self.inner.clone())
     }
 
     /// Creates an instance and begins preparing it to begin serving. The
@@ -401,12 +370,8 @@ impl InstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn create_instance(
-        &self,
-        parent: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::CreateInstance {
+    pub fn create_instance(&self) -> super::builder::instance_admin::CreateInstance {
         super::builder::instance_admin::CreateInstance::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Updates an instance, and begins allocating or releasing resources
@@ -463,12 +428,8 @@ impl InstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn update_instance(
-        &self,
-        instance: impl Into<crate::model::Instance>,
-    ) -> super::builder::instance_admin::UpdateInstance {
+    pub fn update_instance(&self) -> super::builder::instance_admin::UpdateInstance {
         super::builder::instance_admin::UpdateInstance::new(self.inner.clone())
-            .set_instance(instance.into())
     }
 
     /// Deletes an instance.
@@ -482,12 +443,8 @@ impl InstanceAdmin {
     /// * The instance and *all of its databases* immediately and
     ///   irrevocably disappear from the API. All data in the databases
     ///   is permanently deleted.
-    pub fn delete_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::DeleteInstance {
+    pub fn delete_instance(&self) -> super::builder::instance_admin::DeleteInstance {
         super::builder::instance_admin::DeleteInstance::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Sets the access control policy on an instance resource. Replaces any
@@ -497,12 +454,8 @@ impl InstanceAdmin {
     /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.SetIamPolicyRequest.resource]: iam_v1::model::SetIamPolicyRequest::resource
-    pub fn set_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::SetIamPolicy {
+    pub fn set_iam_policy(&self) -> super::builder::instance_admin::SetIamPolicy {
         super::builder::instance_admin::SetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets the access control policy for an instance resource. Returns an empty
@@ -512,12 +465,8 @@ impl InstanceAdmin {
     /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.GetIamPolicyRequest.resource]: iam_v1::model::GetIamPolicyRequest::resource
-    pub fn get_iam_policy(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::GetIamPolicy {
+    pub fn get_iam_policy(&self) -> super::builder::instance_admin::GetIamPolicy {
         super::builder::instance_admin::GetIamPolicy::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Returns permissions that the caller has on the specified instance resource.
@@ -526,21 +475,13 @@ impl InstanceAdmin {
     /// result in a NOT_FOUND error if the user has `spanner.instances.list`
     /// permission on the containing Google Cloud Project. Otherwise returns an
     /// empty set of permissions.
-    pub fn test_iam_permissions(
-        &self,
-        resource: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::TestIamPermissions {
+    pub fn test_iam_permissions(&self) -> super::builder::instance_admin::TestIamPermissions {
         super::builder::instance_admin::TestIamPermissions::new(self.inner.clone())
-            .set_resource(resource.into())
     }
 
     /// Gets information about a particular instance partition.
-    pub fn get_instance_partition(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::GetInstancePartition {
+    pub fn get_instance_partition(&self) -> super::builder::instance_admin::GetInstancePartition {
         super::builder::instance_admin::GetInstancePartition::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Creates an instance partition and begins preparing it to be used. The
@@ -595,10 +536,8 @@ impl InstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn create_instance_partition(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::instance_admin::CreateInstancePartition {
         super::builder::instance_admin::CreateInstancePartition::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Deletes an existing instance partition. Requires that the
@@ -612,10 +551,8 @@ impl InstanceAdmin {
     /// [google.spanner.admin.instance.v1.InstancePartition.name]: crate::model::InstancePartition::name
     pub fn delete_instance_partition(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::instance_admin::DeleteInstancePartition {
         super::builder::instance_admin::DeleteInstancePartition::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Updates an instance partition, and begins allocating or releasing resources
@@ -678,10 +615,8 @@ impl InstanceAdmin {
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     pub fn update_instance_partition(
         &self,
-        instance_partition: impl Into<crate::model::InstancePartition>,
     ) -> super::builder::instance_admin::UpdateInstancePartition {
         super::builder::instance_admin::UpdateInstancePartition::new(self.inner.clone())
-            .set_instance_partition(instance_partition.into())
     }
 
     /// Lists instance partition long-running operations in the given instance.
@@ -702,10 +637,8 @@ impl InstanceAdmin {
     /// [google.spanner.admin.instance.v1.ListInstancePartitionOperationsRequest.parent]: crate::model::ListInstancePartitionOperationsRequest::parent
     pub fn list_instance_partition_operations(
         &self,
-        parent: impl Into<std::string::String>,
     ) -> super::builder::instance_admin::ListInstancePartitionOperations {
         super::builder::instance_admin::ListInstancePartitionOperations::new(self.inner.clone())
-            .set_parent(parent.into())
     }
 
     /// Moves an instance to the target instance configuration. You can use the
@@ -785,53 +718,35 @@ impl InstanceAdmin {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn move_instance(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::MoveInstance {
-        super::builder::instance_admin::MoveInstance::new(self.inner.clone()).set_name(name.into())
+    pub fn move_instance(&self) -> super::builder::instance_admin::MoveInstance {
+        super::builder::instance_admin::MoveInstance::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::ListOperations {
+    pub fn list_operations(&self) -> super::builder::instance_admin::ListOperations {
         super::builder::instance_admin::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::GetOperation {
-        super::builder::instance_admin::GetOperation::new(self.inner.clone()).set_name(name.into())
+    pub fn get_operation(&self) -> super::builder::instance_admin::GetOperation {
+        super::builder::instance_admin::GetOperation::new(self.inner.clone())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn delete_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::DeleteOperation {
+    pub fn delete_operation(&self) -> super::builder::instance_admin::DeleteOperation {
         super::builder::instance_admin::DeleteOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::instance_admin::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::instance_admin::CancelOperation {
         super::builder::instance_admin::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -125,10 +125,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance_config
+            let arg = &req
+                .instance_config
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance_config"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance_config.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -342,10 +347,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance
+            let arg = &req
+                .instance
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance.name"));
+            }
+            arg
         },);
         let builder = self
             .inner
@@ -548,10 +558,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.instance_partition
+            let arg = &req
+                .instance_partition
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("instance_partition"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("instance_partition.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstanceConfigsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instanceConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instanceConfigs", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -70,9 +74,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstanceConfig>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -89,12 +100,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instanceConfigs", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instanceConfigs", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -109,18 +124,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance_config
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance_config"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance_config
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance_config"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -135,9 +147,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -160,12 +179,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstanceConfigOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instanceConfigOperations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instanceConfigOperations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -185,12 +208,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancesResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -220,12 +247,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListInstancePartitionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instancePartitions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instancePartitions", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,9 +285,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Instance>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -279,12 +317,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instances", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instances", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -299,18 +341,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -325,9 +364,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -348,12 +394,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:setIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:setIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -368,12 +418,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::Policy>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:getIamPolicy", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:getIamPolicy", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -388,12 +442,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<iam_v1::model::TestIamPermissionsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:testIamPermissions", {
+            let arg = &req.resource;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("resource"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}:testIamPermissions", req.resource),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -408,9 +466,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::InstancePartition>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -427,12 +492,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}/instancePartitions", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/{}/instancePartitions", req.parent),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -447,9 +516,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -471,18 +547,15 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.instance_partition
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("instance_partition"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.instance_partition
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("instance_partition"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -498,12 +571,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
     ) -> Result<gax::response::Response<crate::model::ListInstancePartitionOperationsResponse>>
     {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}/instancePartitionOperations", {
+            let arg = &req.parent;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("parent"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/{}/instancePartitionOperations", req.parent),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -533,9 +610,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:move", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:move", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -550,9 +634,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -572,9 +663,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -591,9 +689,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -614,9 +719,16 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/generated/storagetransfer/v1/src/client.rs
+++ b/src/generated/storagetransfer/v1/src/client.rs
@@ -132,10 +132,8 @@ impl StorageTransferService {
     /// only be used by Storage Transfer Service.
     pub fn get_google_service_account(
         &self,
-        project_id: impl Into<std::string::String>,
     ) -> super::builder::storage_transfer_service::GetGoogleServiceAccount {
         super::builder::storage_transfer_service::GetGoogleServiceAccount::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Creates a transfer job that runs periodically.
@@ -160,19 +158,13 @@ impl StorageTransferService {
     /// [google.storagetransfer.v1.TransferJob.status]: crate::model::TransferJob::status
     pub fn update_transfer_job(
         &self,
-        job_name: impl Into<std::string::String>,
     ) -> super::builder::storage_transfer_service::UpdateTransferJob {
         super::builder::storage_transfer_service::UpdateTransferJob::new(self.inner.clone())
-            .set_job_name(job_name.into())
     }
 
     /// Gets a transfer job.
-    pub fn get_transfer_job(
-        &self,
-        job_name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::GetTransferJob {
+    pub fn get_transfer_job(&self) -> super::builder::storage_transfer_service::GetTransferJob {
         super::builder::storage_transfer_service::GetTransferJob::new(self.inner.clone())
-            .set_job_name(job_name.into())
     }
 
     /// Lists transfer jobs.
@@ -183,19 +175,15 @@ impl StorageTransferService {
     /// Pauses a transfer operation.
     pub fn pause_transfer_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::storage_transfer_service::PauseTransferOperation {
         super::builder::storage_transfer_service::PauseTransferOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Resumes a transfer operation that is paused.
     pub fn resume_transfer_operation(
         &self,
-        name: impl Into<std::string::String>,
     ) -> super::builder::storage_transfer_service::ResumeTransferOperation {
         super::builder::storage_transfer_service::ResumeTransferOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Starts a new operation for the specified transfer job.
@@ -212,12 +200,8 @@ impl StorageTransferService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
-    pub fn run_transfer_job(
-        &self,
-        job_name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::RunTransferJob {
+    pub fn run_transfer_job(&self) -> super::builder::storage_transfer_service::RunTransferJob {
         super::builder::storage_transfer_service::RunTransferJob::new(self.inner.clone())
-            .set_job_name(job_name.into())
     }
 
     /// Deletes a transfer job. Deleting a transfer job sets its status to
@@ -226,76 +210,46 @@ impl StorageTransferService {
     /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
     pub fn delete_transfer_job(
         &self,
-        job_name: impl Into<std::string::String>,
     ) -> super::builder::storage_transfer_service::DeleteTransferJob {
         super::builder::storage_transfer_service::DeleteTransferJob::new(self.inner.clone())
-            .set_job_name(job_name.into())
     }
 
     /// Creates an agent pool resource.
-    pub fn create_agent_pool(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::CreateAgentPool {
+    pub fn create_agent_pool(&self) -> super::builder::storage_transfer_service::CreateAgentPool {
         super::builder::storage_transfer_service::CreateAgentPool::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Updates an existing agent pool resource.
-    pub fn update_agent_pool(
-        &self,
-        agent_pool: impl Into<crate::model::AgentPool>,
-    ) -> super::builder::storage_transfer_service::UpdateAgentPool {
+    pub fn update_agent_pool(&self) -> super::builder::storage_transfer_service::UpdateAgentPool {
         super::builder::storage_transfer_service::UpdateAgentPool::new(self.inner.clone())
-            .set_agent_pool(agent_pool.into())
     }
 
     /// Gets an agent pool.
-    pub fn get_agent_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::GetAgentPool {
+    pub fn get_agent_pool(&self) -> super::builder::storage_transfer_service::GetAgentPool {
         super::builder::storage_transfer_service::GetAgentPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists agent pools.
-    pub fn list_agent_pools(
-        &self,
-        project_id: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::ListAgentPools {
+    pub fn list_agent_pools(&self) -> super::builder::storage_transfer_service::ListAgentPools {
         super::builder::storage_transfer_service::ListAgentPools::new(self.inner.clone())
-            .set_project_id(project_id.into())
     }
 
     /// Deletes an agent pool.
-    pub fn delete_agent_pool(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::DeleteAgentPool {
+    pub fn delete_agent_pool(&self) -> super::builder::storage_transfer_service::DeleteAgentPool {
         super::builder::storage_transfer_service::DeleteAgentPool::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Lists transfer operations. Operations are ordered by their creation
     /// time in reverse chronological order.
-    pub fn list_operations(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::ListOperations {
+    pub fn list_operations(&self) -> super::builder::storage_transfer_service::ListOperations {
         super::builder::storage_transfer_service::ListOperations::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
-    pub fn get_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::GetOperation {
+    pub fn get_operation(&self) -> super::builder::storage_transfer_service::GetOperation {
         super::builder::storage_transfer_service::GetOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 
     /// Cancels a transfer. Use
@@ -319,11 +273,7 @@ impl StorageTransferService {
     /// before you canceled the job, tomorrow's transfer operation will
     /// compute a new delta with the five files that were not copied today
     /// plus any new files discovered tomorrow.
-    pub fn cancel_operation(
-        &self,
-        name: impl Into<std::string::String>,
-    ) -> super::builder::storage_transfer_service::CancelOperation {
+    pub fn cancel_operation(&self) -> super::builder::storage_transfer_service::CancelOperation {
         super::builder::storage_transfer_service::CancelOperation::new(self.inner.clone())
-            .set_name(name.into())
     }
 }

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -307,10 +307,15 @@ impl super::stub::StorageTransferService for StorageTransferService {
     ) -> Result<gax::response::Response<crate::model::AgentPool>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
         let path = format!("/v1/{}", {
-            &req.agent_pool
+            let arg = &req
+                .agent_pool
                 .as_ref()
                 .ok_or_else(|| gaxi::path_parameter::missing("agent_pool"))?
-                .name
+                .name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("agent_pool.name"));
+            }
+            arg
         },);
         let builder = self
             .inner

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -46,12 +46,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::GoogleServiceAccount>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/googleServiceAccounts/{}", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/googleServiceAccounts/{}", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -68,9 +72,10 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = "/v1/transferJobs".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, "/v1/transferJobs".to_string())
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -87,9 +92,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferJob>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            let arg = &req.job_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::PATCH, format!("/v1/{}", req.job_name))
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -104,9 +116,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::TransferJob>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.job_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.job_name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -124,9 +143,10 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListTransferJobsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = "/v1/transferJobs".to_string();
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, "/v1/transferJobs".to_string())
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -146,9 +166,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:pause", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:pause", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -168,9 +195,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:resume", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:resume", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -190,9 +224,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:run", {
+            let arg = &req.job_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:run", req.job_name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -207,9 +248,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.job_name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("job_name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.job_name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -231,12 +279,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AgentPool>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/projects/{}/agentPools", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::POST,
-                format!("/v1/projects/{}/agentPools", req.project_id),
-            )
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -254,18 +306,15 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AgentPool>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}", {
+            &req.agent_pool
+                .as_ref()
+                .ok_or_else(|| gaxi::path_parameter::missing("agent_pool"))?
+                .name
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::PATCH,
-                format!(
-                    "/v1/{}",
-                    req.agent_pool
-                        .as_ref()
-                        .ok_or_else(|| gaxi::path_parameter::missing("agent_pool"))?
-                        .name
-                ),
-            )
+            .builder(reqwest::Method::PATCH, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -288,9 +337,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::AgentPool>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -307,12 +363,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListAgentPoolsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/projects/{}/agentPools", {
+            let arg = &req.project_id;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("project_id"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(
-                reqwest::Method::GET,
-                format!("/v1/projects/{}/agentPools", req.project_id),
-            )
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -332,9 +392,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::DELETE, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::DELETE, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -355,9 +422,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::ListOperationsResponse>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -377,9 +451,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<longrunning::model::Operation>> {
         let options = gax::options::internal::set_default_idempotency(options, true);
+        let path = format!("/v1/{}", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::GET, format!("/v1/{}", req.name))
+            .builder(reqwest::Method::GET, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",
@@ -396,9 +477,16 @@ impl super::stub::StorageTransferService for StorageTransferService {
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
         let options = gax::options::internal::set_default_idempotency(options, false);
+        let path = format!("/v1/{}:cancel", {
+            let arg = &req.name;
+            if arg.is_empty() {
+                return Err(gaxi::path_parameter::missing("name"));
+            }
+            arg
+        },);
         let builder = self
             .inner
-            .builder(reqwest::Method::POST, format!("/v1/{}:cancel", req.name))
+            .builder(reqwest::Method::POST, path)
             .query(&[("$alt", "json;enum-encoding=int")])
             .header(
                 "x-goog-api-client",

--- a/src/integration-tests/src/error_details.rs
+++ b/src/integration-tests/src/error_details.rs
@@ -34,7 +34,8 @@ pub async fn run(builder: ta::builder::telco_automation::ClientBuilder) -> Resul
     let client = builder.build().await?;
 
     let response = client
-        .list_orchestration_clusters(format!("projects/{project_id}/locations/{region_id}"))
+        .list_orchestration_clusters()
+        .set_parent(format!("projects/{project_id}/locations/{region_id}"))
         .send()
         .await;
     let err = response
@@ -70,7 +71,7 @@ pub async fn check_code_for_http(builder: wf::builder::workflows::ClientBuilder)
         format!("projects/{project_id}/locations/{location_id}/workflows/{workflow_id}");
     let client = builder.build().await?;
 
-    match client.get_workflow(&workflow_name).send().await {
+    match client.get_workflow().set_name(&workflow_name).send().await {
         Ok(g) => panic!("unexpected success {g:?}"),
         Err(e) => match e.as_inner::<gax::error::ServiceError>() {
             None => panic!("expected service error, got {e:?}"),

--- a/src/integration-tests/src/secret_manager/openapi.rs
+++ b/src/integration-tests/src/secret_manager/openapi.rs
@@ -41,7 +41,8 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
 
     println!("\nTesting create_secret()");
     let create = client
-        .create_secret(&project_id)
+        .create_secret()
+        .set_project(&project_id)
         .set_secret_id(&secret_id)
         .set_request_body(
             smo::model::Secret::new()
@@ -61,7 +62,12 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
     assert!(project_name.is_some());
 
     println!("\nTesting get_secret()");
-    let get = client.get_secret(&project_id, &secret_id).send().await?;
+    let get = client
+        .get_secret()
+        .set_project(&project_id)
+        .set_secret(&secret_id)
+        .send()
+        .await?;
     println!("GET = {get:?}");
     assert_eq!(get, create);
     assert!(get.name.is_some());
@@ -72,7 +78,9 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
     let mut new_labels = get.labels.clone();
     new_labels.insert("updated".to_string(), "true".to_string());
     let update = client
-        .update_secret(&project_id, &secret_id)
+        .update_secret()
+        .set_project(&project_id)
+        .set_secret(&secret_id)
         .set_update_mask(wkt::FieldMask::default().set_paths(["labels"]))
         .set_request_body(smo::model::Secret::new().set_labels(new_labels))
         .send()
@@ -92,14 +100,23 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
     run_locations(&client, &project_id).await?;
 
     println!("\nTesting delete_secret()");
-    let response = client.delete_secret(&project_id, &secret_id).send().await?;
+    let response = client
+        .delete_secret()
+        .set_project(&project_id)
+        .set_secret(&secret_id)
+        .send()
+        .await?;
     println!("DELETE = {response:?}");
     Ok(())
 }
 
 async fn run_locations(client: &smo::client::SecretManagerService, project_id: &str) -> Result<()> {
     println!("\nTesting list_locations()");
-    let locations = client.list_locations(project_id).send().await?;
+    let locations = client
+        .list_locations()
+        .set_project(project_id)
+        .send()
+        .await?;
     println!("LOCATIONS = {locations:?}");
 
     assert!(
@@ -114,7 +131,9 @@ async fn run_locations(client: &smo::client::SecretManagerService, project_id: &
 
     println!("\nTesting get_location()");
     let get = client
-        .get_location(project_id, first.location_id.clone().unwrap())
+        .get_location()
+        .set_project(project_id)
+        .set_location(first.location_id.clone().unwrap())
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -132,12 +151,19 @@ async fn run_iam(
     let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
-    let policy = client.get_iam_policy(project_id, secret_id).send().await?;
+    let policy = client
+        .get_iam_policy()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .send()
+        .await?;
     println!("POLICY = {policy:?}");
 
     println!("\nTesting test_iam_permissions()");
     let response = client
-        .test_iam_permissions(project_id, secret_id)
+        .test_iam_permissions()
+        .set_project(project_id)
+        .set_secret(secret_id)
         .set_permissions(["secretmanager.versions.access"])
         .send()
         .await?;
@@ -165,7 +191,9 @@ async fn run_iam(
         );
     }
     let response = client
-        .set_iam_policy(project_id, secret_id)
+        .set_iam_policy()
+        .set_project(project_id)
+        .set_secret(secret_id)
         .set_update_mask(wkt::FieldMask::default().set_paths(["bindings"]))
         .set_policy(new_policy)
         .send()
@@ -184,7 +212,9 @@ async fn run_secret_versions(
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
     let create = client
-        .add_secret_version(project_id, secret_id)
+        .add_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
         .set_payload(
             smo::model::SecretPayload::new()
                 .set_data(bytes::Bytes::from(data))
@@ -210,7 +240,10 @@ async fn run_secret_versions(
 
     println!("\nTesting get_secret_version()");
     let get = client
-        .get_secret_version(project_id, secret_id, version_id)
+        .get_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {get:?}");
@@ -228,7 +261,10 @@ async fn run_secret_versions(
 
     println!("\nTesting access_secret_version()");
     let access_secret_version = client
-        .access_secret_version(project_id, secret_id, version_id)
+        .access_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -239,21 +275,30 @@ async fn run_secret_versions(
 
     println!("\nTesting disable_secret_version()");
     let disable = client
-        .disable_secret_version(project_id, secret_id, version_id)
+        .disable_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
 
     println!("\nTesting enable_secret_version()");
     let enable = client
-        .enable_secret_version(project_id, secret_id, version_id)
+        .enable_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
 
     println!("\nTesting destroy_secret_version()");
     let delete = client
-        .destroy_secret_version(project_id, secret_id, version_id)
+        .destroy_secret_version()
+        .set_project(project_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -270,7 +315,9 @@ async fn get_all_secret_version_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secret_versions(project_id, secret_id)
+            .list_secret_versions()
+            .set_project(project_id)
+            .set_secret(secret_id)
             .set_page_token(page_token)
             .send()
             .await?;
@@ -292,7 +339,7 @@ async fn get_all_secret_names(
     project_id: &str,
 ) -> Result<Vec<String>> {
     let mut names = Vec::new();
-    let mut paginator = client.list_secrets(project_id).by_page();
+    let mut paginator = client.list_secrets().set_project(project_id).by_page();
     while let Some(response) = paginator.next().await {
         response?
             .secrets

--- a/src/integration-tests/src/secret_manager/openapi_locational.rs
+++ b/src/integration-tests/src/secret_manager/openapi_locational.rs
@@ -47,7 +47,9 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
 
     println!("\nTesting create_secret_by_project_and_location({project_id}, {location_id})");
     let create = client
-        .create_secret_by_project_and_location(&project_id, &location_id)
+        .create_secret_by_project_and_location()
+        .set_project(&project_id)
+        .set_location(&location_id)
         .set_secret_id(&secret_id)
         .set_request_body(smo::model::Secret::new().set_labels([("integration-test", "true")]))
         .send()
@@ -56,7 +58,10 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
 
     println!("\nTesting get_secret_by_project_and_location_and_secret()");
     let get = client
-        .get_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
+        .get_secret_by_project_and_location_and_secret()
+        .set_project(&project_id)
+        .set_location(&location_id)
+        .set_secret(&secret_id)
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -67,7 +72,10 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
     let mut new_labels = get.labels.clone();
     new_labels.insert("updated".to_string(), "true".to_string());
     let update = client
-        .update_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
+        .update_secret_by_project_and_location_and_secret()
+        .set_project(&project_id)
+        .set_location(&location_id)
+        .set_secret(&secret_id)
         .set_update_mask(wkt::FieldMask::default().set_paths(["labels"]))
         .set_request_body(smo::model::Secret::new().set_labels(new_labels))
         .send()
@@ -89,7 +97,10 @@ pub async fn run(builder: smo::builder::secret_manager_service::ClientBuilder) -
 
     println!("\nTesting delete_secret_by_project_and_location_and_secret()");
     let response = client
-        .delete_secret_by_project_and_location_and_secret(&project_id, &location_id, &secret_id)
+        .delete_secret_by_project_and_location_and_secret()
+        .set_project(&project_id)
+        .set_location(&location_id)
+        .set_secret(&secret_id)
         .send()
         .await?;
     println!("DELETE = {response:?}");
@@ -107,14 +118,20 @@ async fn run_iam(
 
     println!("\nTesting get_iam_policy_by_project_and_location_and_secret()");
     let policy = client
-        .get_iam_policy_by_project_and_location_and_secret(project_id, location_id, secret_id)
+        .get_iam_policy_by_project_and_location_and_secret()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
         .send()
         .await?;
     println!("POLICY = {policy:?}");
 
     println!("\nTesting test_iam_permissions_by_project_and_location_and_secret()");
     let response = client
-        .test_iam_permissions_by_project_and_location_and_secret(project_id, location_id, secret_id)
+        .test_iam_permissions_by_project_and_location_and_secret()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
         .set_permissions(["secretmanager.versions.access"])
         .send()
         .await?;
@@ -142,7 +159,10 @@ async fn run_iam(
         );
     }
     let response = client
-        .set_iam_policy_by_project_and_location_and_secret(project_id, location_id, secret_id)
+        .set_iam_policy_by_project_and_location_and_secret()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
         .set_update_mask(wkt::FieldMask::default().set_paths(["bindings"]))
         .set_policy(new_policy)
         .send()
@@ -162,7 +182,10 @@ async fn run_secret_versions(
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
     let create = client
-        .add_secret_version_by_project_and_location_and_secret(project_id, location_id, secret_id)
+        .add_secret_version_by_project_and_location_and_secret()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
         .set_payload(
             smo::model::SecretPayload::default()
                 .set_data(bytes::Bytes::from(data))
@@ -188,12 +211,11 @@ async fn run_secret_versions(
 
     println!("\nTesting get_secret_version_by_project_and_location_and_secret_and_version()");
     let get = client
-        .get_secret_version_by_project_and_location_and_secret_and_version(
-            project_id,
-            location_id,
-            secret_id,
-            version_id,
-        )
+        .get_secret_version_by_project_and_location_and_secret_and_version()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {get:?}");
@@ -212,12 +234,11 @@ async fn run_secret_versions(
 
     println!("\nTesting access_secret_version_by_project_and_location_and_secret_and_version()");
     let access_secret_version = client
-        .access_secret_version_by_project_and_location_and_secret_and_version(
-            project_id,
-            location_id,
-            secret_id,
-            version_id,
-        )
+        .access_secret_version_by_project_and_location_and_secret_and_version()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -228,36 +249,33 @@ async fn run_secret_versions(
 
     println!("\nTesting disable_secret_version_by_project_and_location_and_secret_and_version()");
     let disable = client
-        .disable_secret_version_by_project_and_location_and_secret_and_version(
-            project_id,
-            location_id,
-            secret_id,
-            version_id,
-        )
+        .disable_secret_version_by_project_and_location_and_secret_and_version()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
 
     println!("\nTesting enable_secret_version_by_project_and_location_and_secret_and_version()");
     let enable = client
-        .enable_secret_version_by_project_and_location_and_secret_and_version(
-            project_id,
-            location_id,
-            secret_id,
-            version_id,
-        )
+        .enable_secret_version_by_project_and_location_and_secret_and_version()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
 
     println!("\nTesting destroy_secret_version_by_project_and_location_and_secret_and_version()");
     let delete = client
-        .destroy_secret_version_by_project_and_location_and_secret_and_version(
-            project_id,
-            location_id,
-            secret_id,
-            version_id,
-        )
+        .destroy_secret_version_by_project_and_location_and_secret_and_version()
+        .set_project(project_id)
+        .set_location(location_id)
+        .set_secret(secret_id)
+        .set_version(version_id)
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -275,11 +293,10 @@ async fn get_all_secret_version_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secret_versions_by_project_and_location_and_secret(
-                project_id,
-                location_id,
-                secret_id,
-            )
+            .list_secret_versions_by_project_and_location_and_secret()
+            .set_project(project_id)
+            .set_location(location_id)
+            .set_secret(secret_id)
             .set_page_token(page_token)
             .send()
             .await?;
@@ -305,7 +322,9 @@ async fn get_all_secret_names(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secrets_by_project_and_location(project_id, location_id)
+            .list_secrets_by_project_and_location()
+            .set_project(project_id)
+            .set_location(location_id)
             .set_page_token(page_token)
             .send()
             .await?;
@@ -338,7 +357,9 @@ async fn cleanup_stale_secrets(
     let mut page_token = None::<String>;
     loop {
         let response = client
-            .list_secrets_by_project_and_location(project_id, location_id)
+            .list_secrets_by_project_and_location()
+            .set_project(project_id)
+            .set_location(location_id)
             .set_page_token(page_token.clone())
             .send()
             .await?;
@@ -365,9 +386,12 @@ async fn cleanup_stale_secrets(
 
     let pending = stale_secrets
         .iter()
-        .map(|v| {
+        .map(|secret_id| {
             client
-                .delete_secret_by_project_and_location_and_secret(project_id, location_id, v)
+                .delete_secret_by_project_and_location_and_secret()
+                .set_project(project_id)
+                .set_location(location_id)
+                .set_secret(secret_id)
                 .send()
         })
         .collect::<Vec<_>>();

--- a/src/integration-tests/src/sql.rs
+++ b/src/integration-tests/src/sql.rs
@@ -41,7 +41,8 @@ pub async fn run_sql_instances_service(
 
     println!("\nTesting insert sql instance");
     let insert = client
-        .insert(&project_id)
+        .insert()
+        .set_project(&project_id)
         .set_body(
             model::DatabaseInstance::new().set_name(&name).set_settings(
                 model::Settings::new()
@@ -55,7 +56,12 @@ pub async fn run_sql_instances_service(
     assert_eq!(insert.target_id, name);
 
     println!("Testing get sql instance");
-    let get = client.get(&project_id, &name).send().await?;
+    let get = client
+        .get()
+        .set_project(&project_id)
+        .set_instance(&name)
+        .send()
+        .await?;
     println!("SUCCESS on get sql instance: {get:?}");
     assert_eq!(get.name, name);
     let settings = get
@@ -65,7 +71,8 @@ pub async fn run_sql_instances_service(
 
     println!("Testing list sql instances");
     let list = client
-        .list(&project_id)
+        .list()
+        .set_project(&project_id)
         .set_filter(format!("name:{name}"))
         .send()
         .await?;
@@ -74,7 +81,12 @@ pub async fn run_sql_instances_service(
     assert!(list.items.into_iter().any(|v| v.name.eq(&name)));
 
     println!("Testing delete sql instance");
-    let delete = client.delete(&project_id, &name).send().await?;
+    let delete = client
+        .delete()
+        .set_project(&project_id)
+        .set_instance(&name)
+        .send()
+        .await?;
     println!("SUCCESS on delete sql instance: {delete:?}");
     assert_eq!(delete.target_id, name);
 
@@ -109,7 +121,8 @@ async fn cleanup_stale_sql_instances(
     let stale_deadline = wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
 
     let instances = client
-        .list(project_id)
+        .list()
+        .set_project(project_id)
         .set_filter(format!(
             "name:{PREFIX}* AND settings.userLabels.{INSTANCE_LABEL}:true"
         ))
@@ -121,7 +134,13 @@ async fn cleanup_stale_sql_instances(
         .into_iter()
         .filter_map(|instance| {
             if instance.create_time? < stale_deadline {
-                Some(client.delete(project_id, instance.name).send())
+                Some(
+                    client
+                        .delete()
+                        .set_project(project_id)
+                        .set_instance(instance.name)
+                        .send(),
+                )
             } else {
                 None
             }
@@ -160,7 +179,7 @@ pub async fn run_sql_tiers_service(
     let project_id = crate::project_id()?;
     let client: sql::client::SqlTiersService = builder.build().await?;
 
-    let list = client.list(&project_id).send().await?;
+    let list = client.list().set_project(&project_id).send().await?;
 
     assert_ne!(
         list.items

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -44,7 +44,8 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
 
     // Create an execution with a label. The label is not returned for the `BASIC` view.
     let start = client
-        .create_execution(&parent)
+        .create_execution()
+        .set_parent(&parent)
         .set_execution(wfe::model::Execution::new().set_labels([("test-label", "test-value")]))
         .send()
         .await?;
@@ -52,7 +53,8 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
 
     // The execution list using the `BASIC` view.
     let mut executions = client
-        .list_executions(&parent)
+        .list_executions()
+        .set_parent(&parent)
         .set_view(wfe::model::ExecutionView::Basic)
         .by_item();
 
@@ -64,7 +66,8 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
 
     // The execution list using the `FULL` view.
     let mut executions = client
-        .list_executions(&parent)
+        .list_executions()
+        .set_parent(&parent)
         .set_view(wfe::model::ExecutionView::Full)
         .by_item();
 
@@ -79,7 +82,12 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
 
 async fn delete_test_workflow(name: String) -> Result<()> {
     let client = workflow_client().await?;
-    client.delete_workflow(name).poller().until_done().await?;
+    client
+        .delete_workflow()
+        .set_name(name)
+        .poller()
+        .until_done()
+        .await?;
     Ok(())
 }
 
@@ -100,7 +108,8 @@ main:
 
     tracing::info!("Start create_workflow() LRO and poll it to completion");
     let response = client
-        .create_workflow(format!("projects/{project_id}/locations/{location_id}"))
+        .create_workflow()
+        .set_parent(format!("projects/{project_id}/locations/{location_id}"))
         .set_workflow_id(&workflow_id)
         .set_workflow(
             wf::model::Workflow::new()

--- a/src/integration-tests/tests/idempotency.rs
+++ b/src/integration-tests/tests/idempotency.rs
@@ -76,7 +76,8 @@ mod default_idempotency {
             // We are calling `GetSecret`, which is a `GET`. This request should
             // be idempotent.
             let _ = client
-                .get_secret("invalid")
+                .get_secret()
+                .set_name("invalid")
                 .with_retry_policy(expect_idempotent())
                 .send()
                 .await;
@@ -91,7 +92,8 @@ mod default_idempotency {
             // We are calling `AddSecretVersion`, which is a `POST`. This
             // request should not be idempotent.
             let _ = client
-                .add_secret_version("invalid")
+                .add_secret_version()
+                .set_parent("invalid")
                 .with_retry_policy(expect_non_idempotent())
                 .send()
                 .await;
@@ -111,7 +113,8 @@ mod default_idempotency {
             // We are calling `GetDocument`, which is a `GET`. This request
             // should be idempotent.
             let _ = client
-                .get_document("invalid")
+                .get_document()
+                .set_name("invalid")
                 .with_retry_policy(expect_idempotent())
                 .send()
                 .await;
@@ -126,7 +129,8 @@ mod default_idempotency {
             // We are calling `BeginTransaction`, which is a `POST`. This
             // request should not be idempotent.
             let _ = client
-                .begin_transaction("invalid")
+                .begin_transaction()
+                .set_database("invalid")
                 .with_retry_policy(expect_non_idempotent())
                 .send()
                 .await;

--- a/src/integration-tests/tests/mocking.rs
+++ b/src/integration-tests/tests/mocking.rs
@@ -32,7 +32,8 @@ mod mocking {
         id: &str,
     ) -> gax::Result<sm::model::Secret> {
         client
-            .create_secret(format!("projects/{project}/locations/{region}"))
+            .create_secret()
+            .set_parent(format!("projects/{project}/locations/{region}"))
             .set_secret_id(id)
             .send()
             .await

--- a/src/integration-tests/tests/pagination.rs
+++ b/src/integration-tests/tests/pagination.rs
@@ -43,7 +43,10 @@ mod mocking {
         async fn other_task(
             client: sm::client::SecretManagerService,
         ) -> gax::Result<Vec<ListSecretsResponse>> {
-            let mut pages = client.list_secrets("projects/test-project").by_page();
+            let mut pages = client
+                .list_secrets()
+                .set_parent("projects/test-project")
+                .by_page();
             let mut responses = Vec::new();
             while let Some(response) = pages.next().await {
                 responses.push(response?);
@@ -80,7 +83,10 @@ mod mocking {
         async fn other_task(
             client: sm::client::SecretManagerService,
         ) -> gax::Result<Vec<sm::model::Secret>> {
-            let mut paginator = client.list_secrets("projects/test-project").by_item();
+            let mut paginator = client
+                .list_secrets()
+                .set_parent("projects/test-project")
+                .by_item();
             let mut responses = Vec::new();
             while let Some(response) = paginator.next().await {
                 responses.push(response?);
@@ -133,7 +139,10 @@ mod mocking {
             });
 
         let client = sm::client::SecretManagerService::from_stub(mock);
-        let mut paginator = client.list_secrets("projects/test-project").by_page();
+        let mut paginator = client
+            .list_secrets()
+            .set_parent("projects/test-project")
+            .by_page();
         let mut responses = Vec::new();
         while let Some(response) = paginator.next().await {
             responses.push(response?);
@@ -195,7 +204,8 @@ mod mocking {
 
         let client = sm::client::SecretManagerService::from_stub(mock);
         let mut paginator = client
-            .list_secrets("projects/test-project")
+            .list_secrets()
+            .set_parent("projects/test-project")
             .by_page()
             .into_stream();
         let mut responses = Vec::new();
@@ -256,7 +266,10 @@ mod mocking {
             });
 
         let client = sm::client::SecretManagerService::from_stub(mock);
-        let mut paginator = client.list_secrets("projects/test-project").by_item();
+        let mut paginator = client
+            .list_secrets()
+            .set_parent("projects/test-project")
+            .by_item();
         let mut names = Vec::new();
         while let Some(secret) = paginator.next().await {
             names.push(secret?.name);
@@ -313,7 +326,8 @@ mod mocking {
 
         let client = sm::client::SecretManagerService::from_stub(mock);
         let mut stream = client
-            .list_secrets("projects/test-project")
+            .list_secrets()
+            .set_parent("projects/test-project")
             .by_item()
             .into_stream();
         let mut names = Vec::new();

--- a/src/integration-tests/tests/requests.rs
+++ b/src/integration-tests/tests/requests.rs
@@ -33,7 +33,8 @@ mod requests {
             .await?;
 
         client
-            .cancel_operation("operations/test-001")
+            .cancel_operation()
+            .set_name("operations/test-001")
             .send()
             .await?;
         Ok(())


### PR DESCRIPTION
Request may have multiple "bindings" for HTTP+JSON. The same RPC may be sent to
different URL paths based on what fields are set in the request, and even on
the format of these fields.

We believe that supporting multiple bindings is valuable, and the only way to
do so is to break the current client library surface. The request methods no
longer require the "path parameters" because, depending on the binding,
different sets of parameters may be chose for the path.

If these is any consolation, the new API will allow us to validate the format
of common request fields such as `name` and `parent`. That will be the subject
of future PRs though.

Fixes #2104
