### PR TITLE
refactor(gaxi): FromProto can error

### DIFF
--- a/generator/internal/rust/templates/convert-prost/message.mustache
+++ b/generator/internal/rust/templates/convert-prost/message.mustache
@@ -60,49 +60,55 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
 }
 
 impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} {
-    fn cnv(self) -> {{Codec.QualifiedName}} {
-        {{Codec.QualifiedName}}::new()
-            {{#Codec.BasicFields}}
-            {{#Singular}}
-            {{^Optional}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
-            {{/Optional}}
-            {{#Optional}}
-            {{^IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()))
-            {{/IsEnum}}
-            {{#IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.into()))
-            {{/IsEnum}}
-            {{/Optional}}
-            {{/Singular}}
-            {{#Repeated}}
-            {{^IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.cnv()))
-            {{/IsEnum}}
-            {{#IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.into()))
-            {{/IsEnum}}
-            {{/Repeated}}
-            {{#Map}}
-            {{!
-                Enums cannot appear in the key field.
+    fn cnv(self) -> std::result::Result<{{Codec.QualifiedName}}, gaxi::prost::ConvertError> {
+        Ok(
+            {{Codec.QualifiedName}}::new()
+                {{#Codec.BasicFields}}
+                {{#Singular}}
+                {{^Optional}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}})
+                {{/Optional}}
+                {{#Optional}}
+                {{^IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)
+                {{/IsEnum}}
+                {{#IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.into()))
+                {{/IsEnum}}
+                {{/Optional}}
+                {{/Singular}}
+                {{#Repeated}}
+                {{^IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                {{/IsEnum}}
+                {{#IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|v| v.into()))
+                {{/IsEnum}}
+                {{/Repeated}}
+                {{#Map}}
+                {{!
+                    Enums cannot appear in the key field.
 
-                "Note that neither enum nor proto messages are valid for `key_type`."
+                    "Note that neither enum nor proto messages are valid for `key_type`."
 
-                https://protobuf.dev/programming-guides/proto3/#maps
-            }}
-            {{#Codec.ValueType.IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), v.into())))
-            {{/Codec.ValueType.IsEnum}}
-            {{^Codec.ValueType.IsEnum}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            {{/Codec.ValueType.IsEnum}}
-            {{/Map}}
-            {{/Codec.BasicFields}}
-            {{#OneOfs}}
-            .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()))
-            {{/OneOfs}}
+                    https://protobuf.dev/programming-guides/proto3/#maps
+                }}
+                {{#Codec.ValueType.IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter().map(|(k, v)| (k.cnv(), v.into())))
+                {{/Codec.ValueType.IsEnum}}
+                {{^Codec.ValueType.IsEnum}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                {{/Codec.ValueType.IsEnum}}
+                {{/Map}}
+                {{/Codec.BasicFields}}
+                {{#OneOfs}}
+                .set_{{Codec.SetterName}}(self.{{Codec.FieldName}}.map(|v| v.cnv()).transpose()?)
+                {{/OneOfs}}
+        )
     }
 }
 {{/Codec.SkipConversion}}

--- a/generator/internal/rust/templates/convert-prost/oneof.mustache
+++ b/generator/internal/rust/templates/convert-prost/oneof.mustache
@@ -31,15 +31,15 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
 }
 
 impl gaxi::prost::FromProto<{{Codec.QualifiedName}}> for {{Codec.RelativeName}} {
-    fn cnv(self) -> {{Codec.QualifiedName}} {
+    fn cnv(self) -> std::result::Result<{{Codec.QualifiedName}}, gaxi::prost::ConvertError> {
         use {{Codec.QualifiedName}} as T;
         match self {
             {{#Fields}}
             {{^IsEnum}}
-            Self::{{Codec.BranchName}}(v) => T::from_{{Codec.SetterName}}(v.cnv()),
+            Self::{{Codec.BranchName}}(v) => Ok(T::from_{{Codec.SetterName}}(v.cnv()?)),
             {{/IsEnum}}
             {{#IsEnum}}
-            Self::{{Codec.BranchName}}(v) => T::from_{{Codec.SetterName}}(v),
+            Self::{{Codec.BranchName}}(v) => Ok(T::from_{{Codec.SetterName}}(v)),
             {{/IsEnum}}
             {{/Fields}}
         }

--- a/src/firestore/src/convert.rs
+++ b/src/firestore/src/convert.rs
@@ -56,7 +56,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.cnv();
+        let got = proto.cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -73,7 +73,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -99,7 +99,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -112,7 +112,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -125,7 +125,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -143,7 +143,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -180,7 +180,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }
@@ -228,7 +228,7 @@ mod test {
         let got = sidekick.clone().to_proto()?;
         assert_eq!(got, proto);
 
-        let got = proto.clone().cnv();
+        let got = proto.clone().cnv()?;
         assert_eq!(got, sidekick);
         Ok(())
     }

--- a/src/firestore/src/generated/convert/firestore/convert.rs
+++ b/src/firestore/src/generated/convert/firestore/convert.rs
@@ -28,9 +28,14 @@ impl gaxi::prost::ToProto<AggregationResult> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::AggregationResult> for AggregationResult {
-    fn cnv(self) -> crate::generated::gapic::model::AggregationResult {
-        crate::generated::gapic::model::AggregationResult::new()
-            .set_aggregate_fields(self.aggregate_fields.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::AggregationResult, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::AggregationResult::new()
+                .set_aggregate_fields(self.aggregate_fields.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+        )
     }
 }
 
@@ -45,10 +50,12 @@ impl gaxi::prost::ToProto<BitSequence> for crate::generated::gapic::model::BitSe
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BitSequence> for BitSequence {
-    fn cnv(self) -> crate::generated::gapic::model::BitSequence {
-        crate::generated::gapic::model::BitSequence::new()
-            .set_bitmap(self.bitmap)
-            .set_padding(self.padding)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BitSequence, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BitSequence::new()
+                .set_bitmap(self.bitmap)
+                .set_padding(self.padding)
+        )
     }
 }
 
@@ -63,10 +70,12 @@ impl gaxi::prost::ToProto<BloomFilter> for crate::generated::gapic::model::Bloom
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BloomFilter> for BloomFilter {
-    fn cnv(self) -> crate::generated::gapic::model::BloomFilter {
-        crate::generated::gapic::model::BloomFilter::new()
-            .set_bits(self.bits.map(|v| v.cnv()))
-            .set_hash_count(self.hash_count)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BloomFilter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BloomFilter::new()
+                .set_bits(self.bits.map(|v| v.cnv()).transpose()?)
+                .set_hash_count(self.hash_count)
+        )
     }
 }
 
@@ -83,9 +92,12 @@ impl gaxi::prost::ToProto<DocumentMask> for crate::generated::gapic::model::Docu
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DocumentMask> for DocumentMask {
-    fn cnv(self) -> crate::generated::gapic::model::DocumentMask {
-        crate::generated::gapic::model::DocumentMask::new()
-            .set_field_paths(self.field_paths.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DocumentMask, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DocumentMask::new()
+                .set_field_paths(self.field_paths.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -100,11 +112,11 @@ impl gaxi::prost::ToProto<precondition::ConditionType> for crate::generated::gap
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::precondition::ConditionType> for precondition::ConditionType {
-    fn cnv(self) -> crate::generated::gapic::model::precondition::ConditionType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::precondition::ConditionType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::precondition::ConditionType as T;
         match self {
-            Self::Exists(v) => T::from_exists(v.cnv()),
-            Self::UpdateTime(v) => T::from_update_time(v.cnv()),
+            Self::Exists(v) => Ok(T::from_exists(v.cnv()?)),
+            Self::UpdateTime(v) => Ok(T::from_update_time(v.cnv()?)),
         }
     }
 }
@@ -119,9 +131,11 @@ impl gaxi::prost::ToProto<Precondition> for crate::generated::gapic::model::Prec
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Precondition> for Precondition {
-    fn cnv(self) -> crate::generated::gapic::model::Precondition {
-        crate::generated::gapic::model::Precondition::new()
-            .set_condition_type(self.condition_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Precondition, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Precondition::new()
+                .set_condition_type(self.condition_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -135,9 +149,11 @@ impl gaxi::prost::ToProto<transaction_options::ReadWrite> for crate::generated::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options::ReadWrite> for transaction_options::ReadWrite {
-    fn cnv(self) -> crate::generated::gapic::model::transaction_options::ReadWrite {
-        crate::generated::gapic::model::transaction_options::ReadWrite::new()
-            .set_retry_transaction(self.retry_transaction)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::ReadWrite, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::transaction_options::ReadWrite::new()
+                .set_retry_transaction(self.retry_transaction)
+        )
     }
 }
 
@@ -151,10 +167,10 @@ impl gaxi::prost::ToProto<transaction_options::read_only::ConsistencySelector> f
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector> for transaction_options::read_only::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -169,9 +185,11 @@ impl gaxi::prost::ToProto<transaction_options::ReadOnly> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options::ReadOnly> for transaction_options::ReadOnly {
-    fn cnv(self) -> crate::generated::gapic::model::transaction_options::ReadOnly {
-        crate::generated::gapic::model::transaction_options::ReadOnly::new()
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::ReadOnly, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::transaction_options::ReadOnly::new()
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -186,11 +204,11 @@ impl gaxi::prost::ToProto<transaction_options::Mode> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options::Mode> for transaction_options::Mode {
-    fn cnv(self) -> crate::generated::gapic::model::transaction_options::Mode {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::Mode, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::transaction_options::Mode as T;
         match self {
-            Self::ReadOnly(v) => T::from_read_only(v.cnv()),
-            Self::ReadWrite(v) => T::from_read_write(v.cnv()),
+            Self::ReadOnly(v) => Ok(T::from_read_only(v.cnv()?)),
+            Self::ReadWrite(v) => Ok(T::from_read_write(v.cnv()?)),
         }
     }
 }
@@ -205,9 +223,11 @@ impl gaxi::prost::ToProto<TransactionOptions> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::TransactionOptions> for TransactionOptions {
-    fn cnv(self) -> crate::generated::gapic::model::TransactionOptions {
-        crate::generated::gapic::model::TransactionOptions::new()
-            .set_mode(self.mode.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::TransactionOptions, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::TransactionOptions::new()
+                .set_mode(self.mode.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -228,12 +248,17 @@ impl gaxi::prost::ToProto<Document> for crate::generated::gapic::model::Document
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Document> for Document {
-    fn cnv(self) -> crate::generated::gapic::model::Document {
-        crate::generated::gapic::model::Document::new()
-            .set_name(self.name)
-            .set_fields(self.fields.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Document, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Document::new()
+                .set_name(self.name)
+                .set_fields(self.fields.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -257,20 +282,20 @@ impl gaxi::prost::ToProto<value::ValueType> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::value::ValueType> for value::ValueType {
-    fn cnv(self) -> crate::generated::gapic::model::value::ValueType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::value::ValueType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::value::ValueType as T;
         match self {
-            Self::NullValue(v) => T::from_null_value(v.cnv()),
-            Self::BooleanValue(v) => T::from_boolean_value(v.cnv()),
-            Self::IntegerValue(v) => T::from_integer_value(v.cnv()),
-            Self::DoubleValue(v) => T::from_double_value(v.cnv()),
-            Self::TimestampValue(v) => T::from_timestamp_value(v.cnv()),
-            Self::StringValue(v) => T::from_string_value(v.cnv()),
-            Self::BytesValue(v) => T::from_bytes_value(v.cnv()),
-            Self::ReferenceValue(v) => T::from_reference_value(v.cnv()),
-            Self::GeoPointValue(v) => T::from_geo_point_value(v.cnv()),
-            Self::ArrayValue(v) => T::from_array_value(v.cnv()),
-            Self::MapValue(v) => T::from_map_value(v.cnv()),
+            Self::NullValue(v) => Ok(T::from_null_value(v.cnv()?)),
+            Self::BooleanValue(v) => Ok(T::from_boolean_value(v.cnv()?)),
+            Self::IntegerValue(v) => Ok(T::from_integer_value(v.cnv()?)),
+            Self::DoubleValue(v) => Ok(T::from_double_value(v.cnv()?)),
+            Self::TimestampValue(v) => Ok(T::from_timestamp_value(v.cnv()?)),
+            Self::StringValue(v) => Ok(T::from_string_value(v.cnv()?)),
+            Self::BytesValue(v) => Ok(T::from_bytes_value(v.cnv()?)),
+            Self::ReferenceValue(v) => Ok(T::from_reference_value(v.cnv()?)),
+            Self::GeoPointValue(v) => Ok(T::from_geo_point_value(v.cnv()?)),
+            Self::ArrayValue(v) => Ok(T::from_array_value(v.cnv()?)),
+            Self::MapValue(v) => Ok(T::from_map_value(v.cnv()?)),
         }
     }
 }
@@ -285,9 +310,11 @@ impl gaxi::prost::ToProto<Value> for crate::generated::gapic::model::Value {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Value> for Value {
-    fn cnv(self) -> crate::generated::gapic::model::Value {
-        crate::generated::gapic::model::Value::new()
-            .set_value_type(self.value_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Value, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Value::new()
+                .set_value_type(self.value_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -304,9 +331,12 @@ impl gaxi::prost::ToProto<ArrayValue> for crate::generated::gapic::model::ArrayV
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ArrayValue> for ArrayValue {
-    fn cnv(self) -> crate::generated::gapic::model::ArrayValue {
-        crate::generated::gapic::model::ArrayValue::new()
-            .set_values(self.values.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ArrayValue, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ArrayValue::new()
+                .set_values(self.values.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -324,9 +354,14 @@ impl gaxi::prost::ToProto<MapValue> for crate::generated::gapic::model::MapValue
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::MapValue> for MapValue {
-    fn cnv(self) -> crate::generated::gapic::model::MapValue {
-        crate::generated::gapic::model::MapValue::new()
-            .set_fields(self.fields.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::MapValue, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::MapValue::new()
+                .set_fields(self.fields.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+        )
     }
 }
 
@@ -341,11 +376,11 @@ impl gaxi::prost::ToProto<get_document_request::ConsistencySelector> for crate::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::get_document_request::ConsistencySelector> for get_document_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::get_document_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::get_document_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::get_document_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => T::from_transaction(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -362,11 +397,13 @@ impl gaxi::prost::ToProto<GetDocumentRequest> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::GetDocumentRequest> for GetDocumentRequest {
-    fn cnv(self) -> crate::generated::gapic::model::GetDocumentRequest {
-        crate::generated::gapic::model::GetDocumentRequest::new()
-            .set_name(self.name)
-            .set_mask(self.mask.map(|v| v.cnv()))
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::GetDocumentRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::GetDocumentRequest::new()
+                .set_name(self.name)
+                .set_mask(self.mask.map(|v| v.cnv()).transpose()?)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -381,11 +418,11 @@ impl gaxi::prost::ToProto<list_documents_request::ConsistencySelector> for crate
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::list_documents_request::ConsistencySelector> for list_documents_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::list_documents_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::list_documents_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::list_documents_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => T::from_transaction(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -407,16 +444,18 @@ impl gaxi::prost::ToProto<ListDocumentsRequest> for crate::generated::gapic::mod
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListDocumentsRequest> for ListDocumentsRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ListDocumentsRequest {
-        crate::generated::gapic::model::ListDocumentsRequest::new()
-            .set_parent(self.parent)
-            .set_collection_id(self.collection_id)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_order_by(self.order_by)
-            .set_mask(self.mask.map(|v| v.cnv()))
-            .set_show_missing(self.show_missing)
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListDocumentsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListDocumentsRequest::new()
+                .set_parent(self.parent)
+                .set_collection_id(self.collection_id)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_order_by(self.order_by)
+                .set_mask(self.mask.map(|v| v.cnv()).transpose()?)
+                .set_show_missing(self.show_missing)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -434,10 +473,13 @@ impl gaxi::prost::ToProto<ListDocumentsResponse> for crate::generated::gapic::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListDocumentsResponse> for ListDocumentsResponse {
-    fn cnv(self) -> crate::generated::gapic::model::ListDocumentsResponse {
-        crate::generated::gapic::model::ListDocumentsResponse::new()
-            .set_documents(self.documents.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListDocumentsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListDocumentsResponse::new()
+                .set_documents(self.documents.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -455,13 +497,15 @@ impl gaxi::prost::ToProto<CreateDocumentRequest> for crate::generated::gapic::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CreateDocumentRequest> for CreateDocumentRequest {
-    fn cnv(self) -> crate::generated::gapic::model::CreateDocumentRequest {
-        crate::generated::gapic::model::CreateDocumentRequest::new()
-            .set_parent(self.parent)
-            .set_collection_id(self.collection_id)
-            .set_document_id(self.document_id)
-            .set_document(self.document.map(|v| v.cnv()))
-            .set_mask(self.mask.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CreateDocumentRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CreateDocumentRequest::new()
+                .set_parent(self.parent)
+                .set_collection_id(self.collection_id)
+                .set_document_id(self.document_id)
+                .set_document(self.document.map(|v| v.cnv()).transpose()?)
+                .set_mask(self.mask.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -478,12 +522,14 @@ impl gaxi::prost::ToProto<UpdateDocumentRequest> for crate::generated::gapic::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::UpdateDocumentRequest> for UpdateDocumentRequest {
-    fn cnv(self) -> crate::generated::gapic::model::UpdateDocumentRequest {
-        crate::generated::gapic::model::UpdateDocumentRequest::new()
-            .set_document(self.document.map(|v| v.cnv()))
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
-            .set_mask(self.mask.map(|v| v.cnv()))
-            .set_current_document(self.current_document.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::UpdateDocumentRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::UpdateDocumentRequest::new()
+                .set_document(self.document.map(|v| v.cnv()).transpose()?)
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+                .set_mask(self.mask.map(|v| v.cnv()).transpose()?)
+                .set_current_document(self.current_document.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -498,10 +544,12 @@ impl gaxi::prost::ToProto<DeleteDocumentRequest> for crate::generated::gapic::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DeleteDocumentRequest> for DeleteDocumentRequest {
-    fn cnv(self) -> crate::generated::gapic::model::DeleteDocumentRequest {
-        crate::generated::gapic::model::DeleteDocumentRequest::new()
-            .set_name(self.name)
-            .set_current_document(self.current_document.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DeleteDocumentRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DeleteDocumentRequest::new()
+                .set_name(self.name)
+                .set_current_document(self.current_document.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -517,12 +565,12 @@ impl gaxi::prost::ToProto<batch_get_documents_request::ConsistencySelector> for 
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector> for batch_get_documents_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => T::from_transaction(v.cnv()),
-            Self::NewTransaction(v) => T::from_new_transaction(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -543,12 +591,15 @@ impl gaxi::prost::ToProto<BatchGetDocumentsRequest> for crate::generated::gapic:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BatchGetDocumentsRequest> for BatchGetDocumentsRequest {
-    fn cnv(self) -> crate::generated::gapic::model::BatchGetDocumentsRequest {
-        crate::generated::gapic::model::BatchGetDocumentsRequest::new()
-            .set_database(self.database)
-            .set_documents(self.documents.into_iter().map(|v| v.cnv()))
-            .set_mask(self.mask.map(|v| v.cnv()))
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BatchGetDocumentsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BatchGetDocumentsRequest::new()
+                .set_database(self.database)
+                .set_documents(self.documents.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_mask(self.mask.map(|v| v.cnv()).transpose()?)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -563,11 +614,11 @@ impl gaxi::prost::ToProto<batch_get_documents_response::Result> for crate::gener
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::batch_get_documents_response::Result> for batch_get_documents_response::Result {
-    fn cnv(self) -> crate::generated::gapic::model::batch_get_documents_response::Result {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::batch_get_documents_response::Result, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::batch_get_documents_response::Result as T;
         match self {
-            Self::Found(v) => T::from_found(v.cnv()),
-            Self::Missing(v) => T::from_missing(v.cnv()),
+            Self::Found(v) => Ok(T::from_found(v.cnv()?)),
+            Self::Missing(v) => Ok(T::from_missing(v.cnv()?)),
         }
     }
 }
@@ -584,11 +635,13 @@ impl gaxi::prost::ToProto<BatchGetDocumentsResponse> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BatchGetDocumentsResponse> for BatchGetDocumentsResponse {
-    fn cnv(self) -> crate::generated::gapic::model::BatchGetDocumentsResponse {
-        crate::generated::gapic::model::BatchGetDocumentsResponse::new()
-            .set_transaction(self.transaction)
-            .set_read_time(self.read_time.map(|v| v.cnv()))
-            .set_result(self.result.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BatchGetDocumentsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BatchGetDocumentsResponse::new()
+                .set_transaction(self.transaction)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+                .set_result(self.result.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -603,10 +656,12 @@ impl gaxi::prost::ToProto<BeginTransactionRequest> for crate::generated::gapic::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BeginTransactionRequest> for BeginTransactionRequest {
-    fn cnv(self) -> crate::generated::gapic::model::BeginTransactionRequest {
-        crate::generated::gapic::model::BeginTransactionRequest::new()
-            .set_database(self.database)
-            .set_options(self.options.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BeginTransactionRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BeginTransactionRequest::new()
+                .set_database(self.database)
+                .set_options(self.options.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -620,9 +675,11 @@ impl gaxi::prost::ToProto<BeginTransactionResponse> for crate::generated::gapic:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BeginTransactionResponse> for BeginTransactionResponse {
-    fn cnv(self) -> crate::generated::gapic::model::BeginTransactionResponse {
-        crate::generated::gapic::model::BeginTransactionResponse::new()
-            .set_transaction(self.transaction)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BeginTransactionResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BeginTransactionResponse::new()
+                .set_transaction(self.transaction)
+        )
     }
 }
 
@@ -641,11 +698,14 @@ impl gaxi::prost::ToProto<CommitRequest> for crate::generated::gapic::model::Com
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CommitRequest> for CommitRequest {
-    fn cnv(self) -> crate::generated::gapic::model::CommitRequest {
-        crate::generated::gapic::model::CommitRequest::new()
-            .set_database(self.database)
-            .set_writes(self.writes.into_iter().map(|v| v.cnv()))
-            .set_transaction(self.transaction)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CommitRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CommitRequest::new()
+                .set_database(self.database)
+                .set_writes(self.writes.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_transaction(self.transaction)
+        )
     }
 }
 
@@ -663,10 +723,13 @@ impl gaxi::prost::ToProto<CommitResponse> for crate::generated::gapic::model::Co
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CommitResponse> for CommitResponse {
-    fn cnv(self) -> crate::generated::gapic::model::CommitResponse {
-        crate::generated::gapic::model::CommitResponse::new()
-            .set_write_results(self.write_results.into_iter().map(|v| v.cnv()))
-            .set_commit_time(self.commit_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CommitResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CommitResponse::new()
+                .set_write_results(self.write_results.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_commit_time(self.commit_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -681,10 +744,12 @@ impl gaxi::prost::ToProto<RollbackRequest> for crate::generated::gapic::model::R
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RollbackRequest> for RollbackRequest {
-    fn cnv(self) -> crate::generated::gapic::model::RollbackRequest {
-        crate::generated::gapic::model::RollbackRequest::new()
-            .set_database(self.database)
-            .set_transaction(self.transaction)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RollbackRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RollbackRequest::new()
+                .set_database(self.database)
+                .set_transaction(self.transaction)
+        )
     }
 }
 
@@ -698,10 +763,10 @@ impl gaxi::prost::ToProto<run_query_request::QueryType> for crate::generated::ga
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_request::QueryType> for run_query_request::QueryType {
-    fn cnv(self) -> crate::generated::gapic::model::run_query_request::QueryType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_request::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => T::from_structured_query(v.cnv()),
+            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
         }
     }
 }
@@ -718,12 +783,12 @@ impl gaxi::prost::ToProto<run_query_request::ConsistencySelector> for crate::gen
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_request::ConsistencySelector> for run_query_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::run_query_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => T::from_transaction(v.cnv()),
-            Self::NewTransaction(v) => T::from_new_transaction(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -741,12 +806,14 @@ impl gaxi::prost::ToProto<RunQueryRequest> for crate::generated::gapic::model::R
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RunQueryRequest> for RunQueryRequest {
-    fn cnv(self) -> crate::generated::gapic::model::RunQueryRequest {
-        crate::generated::gapic::model::RunQueryRequest::new()
-            .set_parent(self.parent)
-            .set_explain_options(self.explain_options.map(|v| v.cnv()))
-            .set_query_type(self.query_type.map(|v| v.cnv()))
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RunQueryRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RunQueryRequest::new()
+                .set_parent(self.parent)
+                .set_explain_options(self.explain_options.map(|v| v.cnv()).transpose()?)
+                .set_query_type(self.query_type.map(|v| v.cnv()).transpose()?)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -760,10 +827,10 @@ impl gaxi::prost::ToProto<run_query_response::ContinuationSelector> for crate::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_response::ContinuationSelector> for run_query_response::ContinuationSelector {
-    fn cnv(self) -> crate::generated::gapic::model::run_query_response::ContinuationSelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_response::ContinuationSelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_response::ContinuationSelector as T;
         match self {
-            Self::Done(v) => T::from_done(v.cnv()),
+            Self::Done(v) => Ok(T::from_done(v.cnv()?)),
         }
     }
 }
@@ -783,14 +850,16 @@ impl gaxi::prost::ToProto<RunQueryResponse> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RunQueryResponse> for RunQueryResponse {
-    fn cnv(self) -> crate::generated::gapic::model::RunQueryResponse {
-        crate::generated::gapic::model::RunQueryResponse::new()
-            .set_transaction(self.transaction)
-            .set_document(self.document.map(|v| v.cnv()))
-            .set_read_time(self.read_time.map(|v| v.cnv()))
-            .set_skipped_results(self.skipped_results)
-            .set_explain_metrics(self.explain_metrics.map(|v| v.cnv()))
-            .set_continuation_selector(self.continuation_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RunQueryResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RunQueryResponse::new()
+                .set_transaction(self.transaction)
+                .set_document(self.document.map(|v| v.cnv()).transpose()?)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+                .set_skipped_results(self.skipped_results)
+                .set_explain_metrics(self.explain_metrics.map(|v| v.cnv()).transpose()?)
+                .set_continuation_selector(self.continuation_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -804,10 +873,10 @@ impl gaxi::prost::ToProto<run_aggregation_query_request::QueryType> for crate::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::run_aggregation_query_request::QueryType> for run_aggregation_query_request::QueryType {
-    fn cnv(self) -> crate::generated::gapic::model::run_aggregation_query_request::QueryType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_aggregation_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_aggregation_query_request::QueryType as T;
         match self {
-            Self::StructuredAggregationQuery(v) => T::from_structured_aggregation_query(v.cnv()),
+            Self::StructuredAggregationQuery(v) => Ok(T::from_structured_aggregation_query(v.cnv()?)),
         }
     }
 }
@@ -824,12 +893,12 @@ impl gaxi::prost::ToProto<run_aggregation_query_request::ConsistencySelector> fo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector> for run_aggregation_query_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => T::from_transaction(v.cnv()),
-            Self::NewTransaction(v) => T::from_new_transaction(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -847,12 +916,14 @@ impl gaxi::prost::ToProto<RunAggregationQueryRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RunAggregationQueryRequest> for RunAggregationQueryRequest {
-    fn cnv(self) -> crate::generated::gapic::model::RunAggregationQueryRequest {
-        crate::generated::gapic::model::RunAggregationQueryRequest::new()
-            .set_parent(self.parent)
-            .set_explain_options(self.explain_options.map(|v| v.cnv()))
-            .set_query_type(self.query_type.map(|v| v.cnv()))
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RunAggregationQueryRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RunAggregationQueryRequest::new()
+                .set_parent(self.parent)
+                .set_explain_options(self.explain_options.map(|v| v.cnv()).transpose()?)
+                .set_query_type(self.query_type.map(|v| v.cnv()).transpose()?)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -869,12 +940,14 @@ impl gaxi::prost::ToProto<RunAggregationQueryResponse> for crate::generated::gap
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RunAggregationQueryResponse> for RunAggregationQueryResponse {
-    fn cnv(self) -> crate::generated::gapic::model::RunAggregationQueryResponse {
-        crate::generated::gapic::model::RunAggregationQueryResponse::new()
-            .set_result(self.result.map(|v| v.cnv()))
-            .set_transaction(self.transaction)
-            .set_read_time(self.read_time.map(|v| v.cnv()))
-            .set_explain_metrics(self.explain_metrics.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RunAggregationQueryResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RunAggregationQueryResponse::new()
+                .set_result(self.result.map(|v| v.cnv()).transpose()?)
+                .set_transaction(self.transaction)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+                .set_explain_metrics(self.explain_metrics.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -888,10 +961,10 @@ impl gaxi::prost::ToProto<partition_query_request::QueryType> for crate::generat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::partition_query_request::QueryType> for partition_query_request::QueryType {
-    fn cnv(self) -> crate::generated::gapic::model::partition_query_request::QueryType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::partition_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::partition_query_request::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => T::from_structured_query(v.cnv()),
+            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
         }
     }
 }
@@ -906,10 +979,10 @@ impl gaxi::prost::ToProto<partition_query_request::ConsistencySelector> for crat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::partition_query_request::ConsistencySelector> for partition_query_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::partition_query_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::partition_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::partition_query_request::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -929,14 +1002,16 @@ impl gaxi::prost::ToProto<PartitionQueryRequest> for crate::generated::gapic::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::PartitionQueryRequest> for PartitionQueryRequest {
-    fn cnv(self) -> crate::generated::gapic::model::PartitionQueryRequest {
-        crate::generated::gapic::model::PartitionQueryRequest::new()
-            .set_parent(self.parent)
-            .set_partition_count(self.partition_count)
-            .set_page_token(self.page_token)
-            .set_page_size(self.page_size)
-            .set_query_type(self.query_type.map(|v| v.cnv()))
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::PartitionQueryRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::PartitionQueryRequest::new()
+                .set_parent(self.parent)
+                .set_partition_count(self.partition_count)
+                .set_page_token(self.page_token)
+                .set_page_size(self.page_size)
+                .set_query_type(self.query_type.map(|v| v.cnv()).transpose()?)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -954,10 +1029,13 @@ impl gaxi::prost::ToProto<PartitionQueryResponse> for crate::generated::gapic::m
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::PartitionQueryResponse> for PartitionQueryResponse {
-    fn cnv(self) -> crate::generated::gapic::model::PartitionQueryResponse {
-        crate::generated::gapic::model::PartitionQueryResponse::new()
-            .set_partitions(self.partitions.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::PartitionQueryResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::PartitionQueryResponse::new()
+                .set_partitions(self.partitions.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -982,13 +1060,19 @@ impl gaxi::prost::ToProto<WriteRequest> for crate::generated::gapic::model::Writ
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::WriteRequest> for WriteRequest {
-    fn cnv(self) -> crate::generated::gapic::model::WriteRequest {
-        crate::generated::gapic::model::WriteRequest::new()
-            .set_database(self.database)
-            .set_stream_id(self.stream_id)
-            .set_writes(self.writes.into_iter().map(|v| v.cnv()))
-            .set_stream_token(self.stream_token)
-            .set_labels(self.labels.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::WriteRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::WriteRequest::new()
+                .set_database(self.database)
+                .set_stream_id(self.stream_id)
+                .set_writes(self.writes.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_stream_token(self.stream_token)
+                .set_labels(self.labels.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+        )
     }
 }
 
@@ -1008,12 +1092,15 @@ impl gaxi::prost::ToProto<WriteResponse> for crate::generated::gapic::model::Wri
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::WriteResponse> for WriteResponse {
-    fn cnv(self) -> crate::generated::gapic::model::WriteResponse {
-        crate::generated::gapic::model::WriteResponse::new()
-            .set_stream_id(self.stream_id)
-            .set_stream_token(self.stream_token)
-            .set_write_results(self.write_results.into_iter().map(|v| v.cnv()))
-            .set_commit_time(self.commit_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::WriteResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::WriteResponse::new()
+                .set_stream_id(self.stream_id)
+                .set_stream_token(self.stream_token)
+                .set_write_results(self.write_results.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_commit_time(self.commit_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1028,11 +1115,11 @@ impl gaxi::prost::ToProto<listen_request::TargetChange> for crate::generated::ga
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::listen_request::TargetChange> for listen_request::TargetChange {
-    fn cnv(self) -> crate::generated::gapic::model::listen_request::TargetChange {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::listen_request::TargetChange, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::listen_request::TargetChange as T;
         match self {
-            Self::AddTarget(v) => T::from_add_target(v.cnv()),
-            Self::RemoveTarget(v) => T::from_remove_target(v.cnv()),
+            Self::AddTarget(v) => Ok(T::from_add_target(v.cnv()?)),
+            Self::RemoveTarget(v) => Ok(T::from_remove_target(v.cnv()?)),
         }
     }
 }
@@ -1053,11 +1140,16 @@ impl gaxi::prost::ToProto<ListenRequest> for crate::generated::gapic::model::Lis
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListenRequest> for ListenRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ListenRequest {
-        crate::generated::gapic::model::ListenRequest::new()
-            .set_database(self.database)
-            .set_labels(self.labels.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            .set_target_change(self.target_change.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListenRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListenRequest::new()
+                .set_database(self.database)
+                .set_labels(self.labels.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                .set_target_change(self.target_change.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1075,14 +1167,14 @@ impl gaxi::prost::ToProto<listen_response::ResponseType> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::listen_response::ResponseType> for listen_response::ResponseType {
-    fn cnv(self) -> crate::generated::gapic::model::listen_response::ResponseType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::listen_response::ResponseType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::listen_response::ResponseType as T;
         match self {
-            Self::TargetChange(v) => T::from_target_change(v.cnv()),
-            Self::DocumentChange(v) => T::from_document_change(v.cnv()),
-            Self::DocumentDelete(v) => T::from_document_delete(v.cnv()),
-            Self::DocumentRemove(v) => T::from_document_remove(v.cnv()),
-            Self::Filter(v) => T::from_filter(v.cnv()),
+            Self::TargetChange(v) => Ok(T::from_target_change(v.cnv()?)),
+            Self::DocumentChange(v) => Ok(T::from_document_change(v.cnv()?)),
+            Self::DocumentDelete(v) => Ok(T::from_document_delete(v.cnv()?)),
+            Self::DocumentRemove(v) => Ok(T::from_document_remove(v.cnv()?)),
+            Self::Filter(v) => Ok(T::from_filter(v.cnv()?)),
         }
     }
 }
@@ -1097,9 +1189,11 @@ impl gaxi::prost::ToProto<ListenResponse> for crate::generated::gapic::model::Li
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListenResponse> for ListenResponse {
-    fn cnv(self) -> crate::generated::gapic::model::ListenResponse {
-        crate::generated::gapic::model::ListenResponse::new()
-            .set_response_type(self.response_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListenResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListenResponse::new()
+                .set_response_type(self.response_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1116,9 +1210,12 @@ impl gaxi::prost::ToProto<target::DocumentsTarget> for crate::generated::gapic::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::target::DocumentsTarget> for target::DocumentsTarget {
-    fn cnv(self) -> crate::generated::gapic::model::target::DocumentsTarget {
-        crate::generated::gapic::model::target::DocumentsTarget::new()
-            .set_documents(self.documents.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::DocumentsTarget, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::target::DocumentsTarget::new()
+                .set_documents(self.documents.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -1132,10 +1229,10 @@ impl gaxi::prost::ToProto<target::query_target::QueryType> for crate::generated:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::target::query_target::QueryType> for target::query_target::QueryType {
-    fn cnv(self) -> crate::generated::gapic::model::target::query_target::QueryType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::query_target::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::query_target::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => T::from_structured_query(v.cnv()),
+            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
         }
     }
 }
@@ -1151,10 +1248,12 @@ impl gaxi::prost::ToProto<target::QueryTarget> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::target::QueryTarget> for target::QueryTarget {
-    fn cnv(self) -> crate::generated::gapic::model::target::QueryTarget {
-        crate::generated::gapic::model::target::QueryTarget::new()
-            .set_parent(self.parent)
-            .set_query_type(self.query_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::QueryTarget, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::target::QueryTarget::new()
+                .set_parent(self.parent)
+                .set_query_type(self.query_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1169,11 +1268,11 @@ impl gaxi::prost::ToProto<target::TargetType> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::target::TargetType> for target::TargetType {
-    fn cnv(self) -> crate::generated::gapic::model::target::TargetType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::TargetType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::TargetType as T;
         match self {
-            Self::Query(v) => T::from_query(v.cnv()),
-            Self::Documents(v) => T::from_documents(v.cnv()),
+            Self::Query(v) => Ok(T::from_query(v.cnv()?)),
+            Self::Documents(v) => Ok(T::from_documents(v.cnv()?)),
         }
     }
 }
@@ -1189,11 +1288,11 @@ impl gaxi::prost::ToProto<target::ResumeType> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::target::ResumeType> for target::ResumeType {
-    fn cnv(self) -> crate::generated::gapic::model::target::ResumeType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::ResumeType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::ResumeType as T;
         match self {
-            Self::ResumeToken(v) => T::from_resume_token(v.cnv()),
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::ResumeToken(v) => Ok(T::from_resume_token(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -1212,13 +1311,15 @@ impl gaxi::prost::ToProto<Target> for crate::generated::gapic::model::Target {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Target> for Target {
-    fn cnv(self) -> crate::generated::gapic::model::Target {
-        crate::generated::gapic::model::Target::new()
-            .set_target_id(self.target_id)
-            .set_once(self.once)
-            .set_expected_count(self.expected_count.map(|v| v.cnv()))
-            .set_target_type(self.target_type.map(|v| v.cnv()))
-            .set_resume_type(self.resume_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Target, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Target::new()
+                .set_target_id(self.target_id)
+                .set_once(self.once)
+                .set_expected_count(self.expected_count.map(|v| v.cnv()).transpose()?)
+                .set_target_type(self.target_type.map(|v| v.cnv()).transpose()?)
+                .set_resume_type(self.resume_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1246,13 +1347,16 @@ impl gaxi::prost::ToProto<TargetChange> for crate::generated::gapic::model::Targ
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::TargetChange> for TargetChange {
-    fn cnv(self) -> crate::generated::gapic::model::TargetChange {
-        crate::generated::gapic::model::TargetChange::new()
-            .set_target_change_type(self.target_change_type)
-            .set_target_ids(self.target_ids.into_iter().map(|v| v.cnv()))
-            .set_cause(self.cause.map(|v| v.cnv()))
-            .set_resume_token(self.resume_token)
-            .set_read_time(self.read_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::TargetChange, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::TargetChange::new()
+                .set_target_change_type(self.target_change_type)
+                .set_target_ids(self.target_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_cause(self.cause.map(|v| v.cnv()).transpose()?)
+                .set_resume_token(self.resume_token)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1266,10 +1370,10 @@ impl gaxi::prost::ToProto<list_collection_ids_request::ConsistencySelector> for 
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector> for list_collection_ids_request::ConsistencySelector {
-    fn cnv(self) -> crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => T::from_read_time(v.cnv()),
+            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
         }
     }
 }
@@ -1287,12 +1391,14 @@ impl gaxi::prost::ToProto<ListCollectionIdsRequest> for crate::generated::gapic:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListCollectionIdsRequest> for ListCollectionIdsRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ListCollectionIdsRequest {
-        crate::generated::gapic::model::ListCollectionIdsRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListCollectionIdsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListCollectionIdsRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_consistency_selector(self.consistency_selector.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1310,10 +1416,13 @@ impl gaxi::prost::ToProto<ListCollectionIdsResponse> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListCollectionIdsResponse> for ListCollectionIdsResponse {
-    fn cnv(self) -> crate::generated::gapic::model::ListCollectionIdsResponse {
-        crate::generated::gapic::model::ListCollectionIdsResponse::new()
-            .set_collection_ids(self.collection_ids.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListCollectionIdsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListCollectionIdsResponse::new()
+                .set_collection_ids(self.collection_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -1336,11 +1445,17 @@ impl gaxi::prost::ToProto<BatchWriteRequest> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BatchWriteRequest> for BatchWriteRequest {
-    fn cnv(self) -> crate::generated::gapic::model::BatchWriteRequest {
-        crate::generated::gapic::model::BatchWriteRequest::new()
-            .set_database(self.database)
-            .set_writes(self.writes.into_iter().map(|v| v.cnv()))
-            .set_labels(self.labels.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BatchWriteRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BatchWriteRequest::new()
+                .set_database(self.database)
+                .set_writes(self.writes.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_labels(self.labels.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+        )
     }
 }
 
@@ -1361,10 +1476,14 @@ impl gaxi::prost::ToProto<BatchWriteResponse> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BatchWriteResponse> for BatchWriteResponse {
-    fn cnv(self) -> crate::generated::gapic::model::BatchWriteResponse {
-        crate::generated::gapic::model::BatchWriteResponse::new()
-            .set_write_results(self.write_results.into_iter().map(|v| v.cnv()))
-            .set_status(self.status.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BatchWriteResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BatchWriteResponse::new()
+                .set_write_results(self.write_results.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_status(self.status.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -1379,10 +1498,12 @@ impl gaxi::prost::ToProto<structured_query::CollectionSelector> for crate::gener
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::CollectionSelector> for structured_query::CollectionSelector {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::CollectionSelector {
-        crate::generated::gapic::model::structured_query::CollectionSelector::new()
-            .set_collection_id(self.collection_id)
-            .set_all_descendants(self.all_descendants)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::CollectionSelector, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::CollectionSelector::new()
+                .set_collection_id(self.collection_id)
+                .set_all_descendants(self.all_descendants)
+        )
     }
 }
 
@@ -1398,12 +1519,12 @@ impl gaxi::prost::ToProto<structured_query::filter::FilterType> for crate::gener
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::filter::FilterType> for structured_query::filter::FilterType {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::filter::FilterType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::filter::FilterType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_query::filter::FilterType as T;
         match self {
-            Self::CompositeFilter(v) => T::from_composite_filter(v.cnv()),
-            Self::FieldFilter(v) => T::from_field_filter(v.cnv()),
-            Self::UnaryFilter(v) => T::from_unary_filter(v.cnv()),
+            Self::CompositeFilter(v) => Ok(T::from_composite_filter(v.cnv()?)),
+            Self::FieldFilter(v) => Ok(T::from_field_filter(v.cnv()?)),
+            Self::UnaryFilter(v) => Ok(T::from_unary_filter(v.cnv()?)),
         }
     }
 }
@@ -1418,9 +1539,11 @@ impl gaxi::prost::ToProto<structured_query::Filter> for crate::generated::gapic:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Filter> for structured_query::Filter {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::Filter {
-        crate::generated::gapic::model::structured_query::Filter::new()
-            .set_filter_type(self.filter_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::Filter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::Filter::new()
+                .set_filter_type(self.filter_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1445,10 +1568,13 @@ impl gaxi::prost::ToProto<structured_query::CompositeFilter> for crate::generate
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::CompositeFilter> for structured_query::CompositeFilter {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::CompositeFilter {
-        crate::generated::gapic::model::structured_query::CompositeFilter::new()
-            .set_op(self.op)
-            .set_filters(self.filters.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::CompositeFilter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::CompositeFilter::new()
+                .set_op(self.op)
+                .set_filters(self.filters.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -1471,11 +1597,13 @@ impl gaxi::prost::ToProto<structured_query::FieldFilter> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::FieldFilter> for structured_query::FieldFilter {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::FieldFilter {
-        crate::generated::gapic::model::structured_query::FieldFilter::new()
-            .set_field(self.field.map(|v| v.cnv()))
-            .set_op(self.op)
-            .set_value(self.value.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::FieldFilter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::FieldFilter::new()
+                .set_field(self.field.map(|v| v.cnv()).transpose()?)
+                .set_op(self.op)
+                .set_value(self.value.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1496,10 +1624,10 @@ impl gaxi::prost::ToProto<structured_query::unary_filter::OperandType> for crate
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::unary_filter::OperandType> for structured_query::unary_filter::OperandType {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::unary_filter::OperandType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::unary_filter::OperandType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_query::unary_filter::OperandType as T;
         match self {
-            Self::Field(v) => T::from_field(v.cnv()),
+            Self::Field(v) => Ok(T::from_field(v.cnv()?)),
         }
     }
 }
@@ -1515,10 +1643,12 @@ impl gaxi::prost::ToProto<structured_query::UnaryFilter> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::UnaryFilter> for structured_query::UnaryFilter {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::UnaryFilter {
-        crate::generated::gapic::model::structured_query::UnaryFilter::new()
-            .set_op(self.op)
-            .set_operand_type(self.operand_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::UnaryFilter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::UnaryFilter::new()
+                .set_op(self.op)
+                .set_operand_type(self.operand_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1533,10 +1663,12 @@ impl gaxi::prost::ToProto<structured_query::Order> for crate::generated::gapic::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Order> for structured_query::Order {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::Order {
-        crate::generated::gapic::model::structured_query::Order::new()
-            .set_field(self.field.map(|v| v.cnv()))
-            .set_direction(self.direction)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::Order, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::Order::new()
+                .set_field(self.field.map(|v| v.cnv()).transpose()?)
+                .set_direction(self.direction)
+        )
     }
 }
 
@@ -1550,9 +1682,11 @@ impl gaxi::prost::ToProto<structured_query::FieldReference> for crate::generated
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::FieldReference> for structured_query::FieldReference {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::FieldReference {
-        crate::generated::gapic::model::structured_query::FieldReference::new()
-            .set_field_path(self.field_path)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::FieldReference, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::FieldReference::new()
+                .set_field_path(self.field_path)
+        )
     }
 }
 
@@ -1569,9 +1703,12 @@ impl gaxi::prost::ToProto<structured_query::Projection> for crate::generated::ga
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Projection> for structured_query::Projection {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::Projection {
-        crate::generated::gapic::model::structured_query::Projection::new()
-            .set_fields(self.fields.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::Projection, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::Projection::new()
+                .set_fields(self.fields.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -1597,14 +1734,16 @@ impl gaxi::prost::ToProto<structured_query::FindNearest> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::FindNearest> for structured_query::FindNearest {
-    fn cnv(self) -> crate::generated::gapic::model::structured_query::FindNearest {
-        crate::generated::gapic::model::structured_query::FindNearest::new()
-            .set_vector_field(self.vector_field.map(|v| v.cnv()))
-            .set_query_vector(self.query_vector.map(|v| v.cnv()))
-            .set_distance_measure(self.distance_measure)
-            .set_limit(self.limit.map(|v| v.cnv()))
-            .set_distance_result_field(self.distance_result_field)
-            .set_distance_threshold(self.distance_threshold.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::FindNearest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_query::FindNearest::new()
+                .set_vector_field(self.vector_field.map(|v| v.cnv()).transpose()?)
+                .set_query_vector(self.query_vector.map(|v| v.cnv()).transpose()?)
+                .set_distance_measure(self.distance_measure)
+                .set_limit(self.limit.map(|v| v.cnv()).transpose()?)
+                .set_distance_result_field(self.distance_result_field)
+                .set_distance_threshold(self.distance_threshold.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1639,17 +1778,21 @@ impl gaxi::prost::ToProto<StructuredQuery> for crate::generated::gapic::model::S
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::StructuredQuery> for StructuredQuery {
-    fn cnv(self) -> crate::generated::gapic::model::StructuredQuery {
-        crate::generated::gapic::model::StructuredQuery::new()
-            .set_select(self.select.map(|v| v.cnv()))
-            .set_from(self.from.into_iter().map(|v| v.cnv()))
-            .set_where(self.r#where.map(|v| v.cnv()))
-            .set_order_by(self.order_by.into_iter().map(|v| v.cnv()))
-            .set_start_at(self.start_at.map(|v| v.cnv()))
-            .set_end_at(self.end_at.map(|v| v.cnv()))
-            .set_offset(self.offset)
-            .set_limit(self.limit.map(|v| v.cnv()))
-            .set_find_nearest(self.find_nearest.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::StructuredQuery, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::StructuredQuery::new()
+                .set_select(self.select.map(|v| v.cnv()).transpose()?)
+                .set_from(self.from.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_where(self.r#where.map(|v| v.cnv()).transpose()?)
+                .set_order_by(self.order_by.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_start_at(self.start_at.map(|v| v.cnv()).transpose()?)
+                .set_end_at(self.end_at.map(|v| v.cnv()).transpose()?)
+                .set_offset(self.offset)
+                .set_limit(self.limit.map(|v| v.cnv()).transpose()?)
+                .set_find_nearest(self.find_nearest.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1663,9 +1806,11 @@ impl gaxi::prost::ToProto<structured_aggregation_query::aggregation::Count> for 
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::aggregation::Count> for structured_aggregation_query::aggregation::Count {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::aggregation::Count {
-        crate::generated::gapic::model::structured_aggregation_query::aggregation::Count::new()
-            .set_up_to(self.up_to.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::aggregation::Count, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_aggregation_query::aggregation::Count::new()
+                .set_up_to(self.up_to.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1679,9 +1824,11 @@ impl gaxi::prost::ToProto<structured_aggregation_query::aggregation::Sum> for cr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::aggregation::Sum> for structured_aggregation_query::aggregation::Sum {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::aggregation::Sum {
-        crate::generated::gapic::model::structured_aggregation_query::aggregation::Sum::new()
-            .set_field(self.field.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::aggregation::Sum, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_aggregation_query::aggregation::Sum::new()
+                .set_field(self.field.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1695,9 +1842,11 @@ impl gaxi::prost::ToProto<structured_aggregation_query::aggregation::Avg> for cr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::aggregation::Avg> for structured_aggregation_query::aggregation::Avg {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::aggregation::Avg {
-        crate::generated::gapic::model::structured_aggregation_query::aggregation::Avg::new()
-            .set_field(self.field.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::aggregation::Avg, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_aggregation_query::aggregation::Avg::new()
+                .set_field(self.field.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1713,12 +1862,12 @@ impl gaxi::prost::ToProto<structured_aggregation_query::aggregation::Operator> f
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator> for structured_aggregation_query::aggregation::Operator {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator as T;
         match self {
-            Self::Count(v) => T::from_count(v.cnv()),
-            Self::Sum(v) => T::from_sum(v.cnv()),
-            Self::Avg(v) => T::from_avg(v.cnv()),
+            Self::Count(v) => Ok(T::from_count(v.cnv()?)),
+            Self::Sum(v) => Ok(T::from_sum(v.cnv()?)),
+            Self::Avg(v) => Ok(T::from_avg(v.cnv()?)),
         }
     }
 }
@@ -1734,10 +1883,12 @@ impl gaxi::prost::ToProto<structured_aggregation_query::Aggregation> for crate::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::Aggregation> for structured_aggregation_query::Aggregation {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::Aggregation {
-        crate::generated::gapic::model::structured_aggregation_query::Aggregation::new()
-            .set_alias(self.alias)
-            .set_operator(self.operator.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::Aggregation, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::structured_aggregation_query::Aggregation::new()
+                .set_alias(self.alias)
+                .set_operator(self.operator.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1751,10 +1902,10 @@ impl gaxi::prost::ToProto<structured_aggregation_query::QueryType> for crate::ge
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregation_query::QueryType> for structured_aggregation_query::QueryType {
-    fn cnv(self) -> crate::generated::gapic::model::structured_aggregation_query::QueryType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_aggregation_query::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => T::from_structured_query(v.cnv()),
+            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
         }
     }
 }
@@ -1773,10 +1924,13 @@ impl gaxi::prost::ToProto<StructuredAggregationQuery> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::StructuredAggregationQuery> for StructuredAggregationQuery {
-    fn cnv(self) -> crate::generated::gapic::model::StructuredAggregationQuery {
-        crate::generated::gapic::model::StructuredAggregationQuery::new()
-            .set_aggregations(self.aggregations.into_iter().map(|v| v.cnv()))
-            .set_query_type(self.query_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::StructuredAggregationQuery, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::StructuredAggregationQuery::new()
+                .set_aggregations(self.aggregations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_query_type(self.query_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1794,10 +1948,13 @@ impl gaxi::prost::ToProto<Cursor> for crate::generated::gapic::model::Cursor {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Cursor> for Cursor {
-    fn cnv(self) -> crate::generated::gapic::model::Cursor {
-        crate::generated::gapic::model::Cursor::new()
-            .set_values(self.values.into_iter().map(|v| v.cnv()))
-            .set_before(self.before)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Cursor, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Cursor::new()
+                .set_values(self.values.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_before(self.before)
+        )
     }
 }
 
@@ -1811,9 +1968,11 @@ impl gaxi::prost::ToProto<ExplainOptions> for crate::generated::gapic::model::Ex
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ExplainOptions> for ExplainOptions {
-    fn cnv(self) -> crate::generated::gapic::model::ExplainOptions {
-        crate::generated::gapic::model::ExplainOptions::new()
-            .set_analyze(self.analyze)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ExplainOptions, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ExplainOptions::new()
+                .set_analyze(self.analyze)
+        )
     }
 }
 
@@ -1828,10 +1987,12 @@ impl gaxi::prost::ToProto<ExplainMetrics> for crate::generated::gapic::model::Ex
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ExplainMetrics> for ExplainMetrics {
-    fn cnv(self) -> crate::generated::gapic::model::ExplainMetrics {
-        crate::generated::gapic::model::ExplainMetrics::new()
-            .set_plan_summary(self.plan_summary.map(|v| v.cnv()))
-            .set_execution_stats(self.execution_stats.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ExplainMetrics, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ExplainMetrics::new()
+                .set_plan_summary(self.plan_summary.map(|v| v.cnv()).transpose()?)
+                .set_execution_stats(self.execution_stats.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1848,9 +2009,12 @@ impl gaxi::prost::ToProto<PlanSummary> for crate::generated::gapic::model::PlanS
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::PlanSummary> for PlanSummary {
-    fn cnv(self) -> crate::generated::gapic::model::PlanSummary {
-        crate::generated::gapic::model::PlanSummary::new()
-            .set_indexes_used(self.indexes_used.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::PlanSummary, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::PlanSummary::new()
+                .set_indexes_used(self.indexes_used.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -1867,12 +2031,14 @@ impl gaxi::prost::ToProto<ExecutionStats> for crate::generated::gapic::model::Ex
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ExecutionStats> for ExecutionStats {
-    fn cnv(self) -> crate::generated::gapic::model::ExecutionStats {
-        crate::generated::gapic::model::ExecutionStats::new()
-            .set_results_returned(self.results_returned)
-            .set_execution_duration(self.execution_duration.map(|v| v.cnv()))
-            .set_read_operations(self.read_operations)
-            .set_debug_stats(self.debug_stats.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ExecutionStats, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ExecutionStats::new()
+                .set_results_returned(self.results_returned)
+                .set_execution_duration(self.execution_duration.map(|v| v.cnv()).transpose()?)
+                .set_read_operations(self.read_operations)
+                .set_debug_stats(self.debug_stats.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1888,12 +2054,12 @@ impl gaxi::prost::ToProto<write::Operation> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::write::Operation> for write::Operation {
-    fn cnv(self) -> crate::generated::gapic::model::write::Operation {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::write::Operation, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::write::Operation as T;
         match self {
-            Self::Update(v) => T::from_update(v.cnv()),
-            Self::Delete(v) => T::from_delete(v.cnv()),
-            Self::Transform(v) => T::from_transform(v.cnv()),
+            Self::Update(v) => Ok(T::from_update(v.cnv()?)),
+            Self::Delete(v) => Ok(T::from_delete(v.cnv()?)),
+            Self::Transform(v) => Ok(T::from_transform(v.cnv()?)),
         }
     }
 }
@@ -1914,12 +2080,15 @@ impl gaxi::prost::ToProto<Write> for crate::generated::gapic::model::Write {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Write> for Write {
-    fn cnv(self) -> crate::generated::gapic::model::Write {
-        crate::generated::gapic::model::Write::new()
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
-            .set_update_transforms(self.update_transforms.into_iter().map(|v| v.cnv()))
-            .set_current_document(self.current_document.map(|v| v.cnv()))
-            .set_operation(self.operation.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Write, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Write::new()
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+                .set_update_transforms(self.update_transforms.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_current_document(self.current_document.map(|v| v.cnv()).transpose()?)
+                .set_operation(self.operation.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1945,15 +2114,15 @@ impl gaxi::prost::ToProto<document_transform::field_transform::TransformType> fo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::document_transform::field_transform::TransformType> for document_transform::field_transform::TransformType {
-    fn cnv(self) -> crate::generated::gapic::model::document_transform::field_transform::TransformType {
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::document_transform::field_transform::TransformType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::document_transform::field_transform::TransformType as T;
         match self {
-            Self::SetToServerValue(v) => T::from_set_to_server_value(v.cnv()),
-            Self::Increment(v) => T::from_increment(v.cnv()),
-            Self::Maximum(v) => T::from_maximum(v.cnv()),
-            Self::Minimum(v) => T::from_minimum(v.cnv()),
-            Self::AppendMissingElements(v) => T::from_append_missing_elements(v.cnv()),
-            Self::RemoveAllFromArray(v) => T::from_remove_all_from_array(v.cnv()),
+            Self::SetToServerValue(v) => Ok(T::from_set_to_server_value(v.cnv()?)),
+            Self::Increment(v) => Ok(T::from_increment(v.cnv()?)),
+            Self::Maximum(v) => Ok(T::from_maximum(v.cnv()?)),
+            Self::Minimum(v) => Ok(T::from_minimum(v.cnv()?)),
+            Self::AppendMissingElements(v) => Ok(T::from_append_missing_elements(v.cnv()?)),
+            Self::RemoveAllFromArray(v) => Ok(T::from_remove_all_from_array(v.cnv()?)),
         }
     }
 }
@@ -1969,10 +2138,12 @@ impl gaxi::prost::ToProto<document_transform::FieldTransform> for crate::generat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::document_transform::FieldTransform> for document_transform::FieldTransform {
-    fn cnv(self) -> crate::generated::gapic::model::document_transform::FieldTransform {
-        crate::generated::gapic::model::document_transform::FieldTransform::new()
-            .set_field_path(self.field_path)
-            .set_transform_type(self.transform_type.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::document_transform::FieldTransform, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::document_transform::FieldTransform::new()
+                .set_field_path(self.field_path)
+                .set_transform_type(self.transform_type.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1990,10 +2161,13 @@ impl gaxi::prost::ToProto<DocumentTransform> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DocumentTransform> for DocumentTransform {
-    fn cnv(self) -> crate::generated::gapic::model::DocumentTransform {
-        crate::generated::gapic::model::DocumentTransform::new()
-            .set_document(self.document)
-            .set_field_transforms(self.field_transforms.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DocumentTransform, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DocumentTransform::new()
+                .set_document(self.document)
+                .set_field_transforms(self.field_transforms.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -2011,10 +2185,13 @@ impl gaxi::prost::ToProto<WriteResult> for crate::generated::gapic::model::Write
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::WriteResult> for WriteResult {
-    fn cnv(self) -> crate::generated::gapic::model::WriteResult {
-        crate::generated::gapic::model::WriteResult::new()
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_transform_results(self.transform_results.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::WriteResult, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::WriteResult::new()
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_transform_results(self.transform_results.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -2036,11 +2213,15 @@ impl gaxi::prost::ToProto<DocumentChange> for crate::generated::gapic::model::Do
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DocumentChange> for DocumentChange {
-    fn cnv(self) -> crate::generated::gapic::model::DocumentChange {
-        crate::generated::gapic::model::DocumentChange::new()
-            .set_document(self.document.map(|v| v.cnv()))
-            .set_target_ids(self.target_ids.into_iter().map(|v| v.cnv()))
-            .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DocumentChange, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DocumentChange::new()
+                .set_document(self.document.map(|v| v.cnv()).transpose()?)
+                .set_target_ids(self.target_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -2059,11 +2240,14 @@ impl gaxi::prost::ToProto<DocumentDelete> for crate::generated::gapic::model::Do
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DocumentDelete> for DocumentDelete {
-    fn cnv(self) -> crate::generated::gapic::model::DocumentDelete {
-        crate::generated::gapic::model::DocumentDelete::new()
-            .set_document(self.document)
-            .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv()))
-            .set_read_time(self.read_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DocumentDelete, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DocumentDelete::new()
+                .set_document(self.document)
+                .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -2082,11 +2266,14 @@ impl gaxi::prost::ToProto<DocumentRemove> for crate::generated::gapic::model::Do
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DocumentRemove> for DocumentRemove {
-    fn cnv(self) -> crate::generated::gapic::model::DocumentRemove {
-        crate::generated::gapic::model::DocumentRemove::new()
-            .set_document(self.document)
-            .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv()))
-            .set_read_time(self.read_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DocumentRemove, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DocumentRemove::new()
+                .set_document(self.document)
+                .set_removed_target_ids(self.removed_target_ids.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_read_time(self.read_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -2102,10 +2289,12 @@ impl gaxi::prost::ToProto<ExistenceFilter> for crate::generated::gapic::model::E
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ExistenceFilter> for ExistenceFilter {
-    fn cnv(self) -> crate::generated::gapic::model::ExistenceFilter {
-        crate::generated::gapic::model::ExistenceFilter::new()
-            .set_target_id(self.target_id)
-            .set_count(self.count)
-            .set_unchanged_names(self.unchanged_names.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ExistenceFilter, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ExistenceFilter::new()
+                .set_target_id(self.target_id)
+                .set_count(self.count)
+                .set_unchanged_names(self.unchanged_names.map(|v| v.cnv()).transpose()?)
+        )
     }
 }

--- a/src/firestore/src/generated/convert/rpc/convert.rs
+++ b/src/firestore/src/generated/convert/rpc/convert.rs
@@ -37,11 +37,16 @@ impl gaxi::prost::ToProto<ErrorInfo> for rpc::model::ErrorInfo {
 }
 
 impl gaxi::prost::FromProto<rpc::model::ErrorInfo> for ErrorInfo {
-    fn cnv(self) -> rpc::model::ErrorInfo {
-        rpc::model::ErrorInfo::new()
-            .set_reason(self.reason)
-            .set_domain(self.domain)
-            .set_metadata(self.metadata.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
+    fn cnv(self) -> std::result::Result<rpc::model::ErrorInfo, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::ErrorInfo::new()
+                .set_reason(self.reason)
+                .set_domain(self.domain)
+                .set_metadata(self.metadata.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+        )
     }
 }
 
@@ -55,9 +60,11 @@ impl gaxi::prost::ToProto<RetryInfo> for rpc::model::RetryInfo {
 }
 
 impl gaxi::prost::FromProto<rpc::model::RetryInfo> for RetryInfo {
-    fn cnv(self) -> rpc::model::RetryInfo {
-        rpc::model::RetryInfo::new()
-            .set_retry_delay(self.retry_delay.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::RetryInfo, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::RetryInfo::new()
+                .set_retry_delay(self.retry_delay.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -75,10 +82,13 @@ impl gaxi::prost::ToProto<DebugInfo> for rpc::model::DebugInfo {
 }
 
 impl gaxi::prost::FromProto<rpc::model::DebugInfo> for DebugInfo {
-    fn cnv(self) -> rpc::model::DebugInfo {
-        rpc::model::DebugInfo::new()
-            .set_stack_entries(self.stack_entries.into_iter().map(|v| v.cnv()))
-            .set_detail(self.detail)
+    fn cnv(self) -> std::result::Result<rpc::model::DebugInfo, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::DebugInfo::new()
+                .set_stack_entries(self.stack_entries.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_detail(self.detail)
+        )
     }
 }
 
@@ -103,16 +113,21 @@ impl gaxi::prost::ToProto<quota_failure::Violation> for rpc::model::quota_failur
 }
 
 impl gaxi::prost::FromProto<rpc::model::quota_failure::Violation> for quota_failure::Violation {
-    fn cnv(self) -> rpc::model::quota_failure::Violation {
-        rpc::model::quota_failure::Violation::new()
-            .set_subject(self.subject)
-            .set_description(self.description)
-            .set_api_service(self.api_service)
-            .set_quota_metric(self.quota_metric)
-            .set_quota_id(self.quota_id)
-            .set_quota_dimensions(self.quota_dimensions.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            .set_quota_value(self.quota_value)
-            .set_future_quota_value(self.future_quota_value.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::quota_failure::Violation, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::quota_failure::Violation::new()
+                .set_subject(self.subject)
+                .set_description(self.description)
+                .set_api_service(self.api_service)
+                .set_quota_metric(self.quota_metric)
+                .set_quota_id(self.quota_id)
+                .set_quota_dimensions(self.quota_dimensions.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                .set_quota_value(self.quota_value)
+                .set_future_quota_value(self.future_quota_value.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -129,9 +144,12 @@ impl gaxi::prost::ToProto<QuotaFailure> for rpc::model::QuotaFailure {
 }
 
 impl gaxi::prost::FromProto<rpc::model::QuotaFailure> for QuotaFailure {
-    fn cnv(self) -> rpc::model::QuotaFailure {
-        rpc::model::QuotaFailure::new()
-            .set_violations(self.violations.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::QuotaFailure, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::QuotaFailure::new()
+                .set_violations(self.violations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -147,11 +165,13 @@ impl gaxi::prost::ToProto<precondition_failure::Violation> for rpc::model::preco
 }
 
 impl gaxi::prost::FromProto<rpc::model::precondition_failure::Violation> for precondition_failure::Violation {
-    fn cnv(self) -> rpc::model::precondition_failure::Violation {
-        rpc::model::precondition_failure::Violation::new()
-            .set_type(self.r#type)
-            .set_subject(self.subject)
-            .set_description(self.description)
+    fn cnv(self) -> std::result::Result<rpc::model::precondition_failure::Violation, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::precondition_failure::Violation::new()
+                .set_type(self.r#type)
+                .set_subject(self.subject)
+                .set_description(self.description)
+        )
     }
 }
 
@@ -168,9 +188,12 @@ impl gaxi::prost::ToProto<PreconditionFailure> for rpc::model::PreconditionFailu
 }
 
 impl gaxi::prost::FromProto<rpc::model::PreconditionFailure> for PreconditionFailure {
-    fn cnv(self) -> rpc::model::PreconditionFailure {
-        rpc::model::PreconditionFailure::new()
-            .set_violations(self.violations.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::PreconditionFailure, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::PreconditionFailure::new()
+                .set_violations(self.violations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -187,12 +210,14 @@ impl gaxi::prost::ToProto<bad_request::FieldViolation> for rpc::model::bad_reque
 }
 
 impl gaxi::prost::FromProto<rpc::model::bad_request::FieldViolation> for bad_request::FieldViolation {
-    fn cnv(self) -> rpc::model::bad_request::FieldViolation {
-        rpc::model::bad_request::FieldViolation::new()
-            .set_field(self.field)
-            .set_description(self.description)
-            .set_reason(self.reason)
-            .set_localized_message(self.localized_message.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::bad_request::FieldViolation, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::bad_request::FieldViolation::new()
+                .set_field(self.field)
+                .set_description(self.description)
+                .set_reason(self.reason)
+                .set_localized_message(self.localized_message.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -209,9 +234,12 @@ impl gaxi::prost::ToProto<BadRequest> for rpc::model::BadRequest {
 }
 
 impl gaxi::prost::FromProto<rpc::model::BadRequest> for BadRequest {
-    fn cnv(self) -> rpc::model::BadRequest {
-        rpc::model::BadRequest::new()
-            .set_field_violations(self.field_violations.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::BadRequest, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::BadRequest::new()
+                .set_field_violations(self.field_violations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -226,10 +254,12 @@ impl gaxi::prost::ToProto<RequestInfo> for rpc::model::RequestInfo {
 }
 
 impl gaxi::prost::FromProto<rpc::model::RequestInfo> for RequestInfo {
-    fn cnv(self) -> rpc::model::RequestInfo {
-        rpc::model::RequestInfo::new()
-            .set_request_id(self.request_id)
-            .set_serving_data(self.serving_data)
+    fn cnv(self) -> std::result::Result<rpc::model::RequestInfo, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::RequestInfo::new()
+                .set_request_id(self.request_id)
+                .set_serving_data(self.serving_data)
+        )
     }
 }
 
@@ -246,12 +276,14 @@ impl gaxi::prost::ToProto<ResourceInfo> for rpc::model::ResourceInfo {
 }
 
 impl gaxi::prost::FromProto<rpc::model::ResourceInfo> for ResourceInfo {
-    fn cnv(self) -> rpc::model::ResourceInfo {
-        rpc::model::ResourceInfo::new()
-            .set_resource_type(self.resource_type)
-            .set_resource_name(self.resource_name)
-            .set_owner(self.owner)
-            .set_description(self.description)
+    fn cnv(self) -> std::result::Result<rpc::model::ResourceInfo, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::ResourceInfo::new()
+                .set_resource_type(self.resource_type)
+                .set_resource_name(self.resource_name)
+                .set_owner(self.owner)
+                .set_description(self.description)
+        )
     }
 }
 
@@ -266,10 +298,12 @@ impl gaxi::prost::ToProto<help::Link> for rpc::model::help::Link {
 }
 
 impl gaxi::prost::FromProto<rpc::model::help::Link> for help::Link {
-    fn cnv(self) -> rpc::model::help::Link {
-        rpc::model::help::Link::new()
-            .set_description(self.description)
-            .set_url(self.url)
+    fn cnv(self) -> std::result::Result<rpc::model::help::Link, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::help::Link::new()
+                .set_description(self.description)
+                .set_url(self.url)
+        )
     }
 }
 
@@ -286,9 +320,12 @@ impl gaxi::prost::ToProto<Help> for rpc::model::Help {
 }
 
 impl gaxi::prost::FromProto<rpc::model::Help> for Help {
-    fn cnv(self) -> rpc::model::Help {
-        rpc::model::Help::new()
-            .set_links(self.links.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<rpc::model::Help, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::Help::new()
+                .set_links(self.links.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -303,10 +340,12 @@ impl gaxi::prost::ToProto<LocalizedMessage> for rpc::model::LocalizedMessage {
 }
 
 impl gaxi::prost::FromProto<rpc::model::LocalizedMessage> for LocalizedMessage {
-    fn cnv(self) -> rpc::model::LocalizedMessage {
-        rpc::model::LocalizedMessage::new()
-            .set_locale(self.locale)
-            .set_message(self.message)
+    fn cnv(self) -> std::result::Result<rpc::model::LocalizedMessage, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::LocalizedMessage::new()
+                .set_locale(self.locale)
+                .set_message(self.message)
+        )
     }
 }
 
@@ -326,12 +365,15 @@ impl gaxi::prost::ToProto<HttpRequest> for rpc::model::HttpRequest {
 }
 
 impl gaxi::prost::FromProto<rpc::model::HttpRequest> for HttpRequest {
-    fn cnv(self) -> rpc::model::HttpRequest {
-        rpc::model::HttpRequest::new()
-            .set_method(self.method)
-            .set_uri(self.uri)
-            .set_headers(self.headers.into_iter().map(|v| v.cnv()))
-            .set_body(self.body)
+    fn cnv(self) -> std::result::Result<rpc::model::HttpRequest, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::HttpRequest::new()
+                .set_method(self.method)
+                .set_uri(self.uri)
+                .set_headers(self.headers.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_body(self.body)
+        )
     }
 }
 
@@ -351,12 +393,15 @@ impl gaxi::prost::ToProto<HttpResponse> for rpc::model::HttpResponse {
 }
 
 impl gaxi::prost::FromProto<rpc::model::HttpResponse> for HttpResponse {
-    fn cnv(self) -> rpc::model::HttpResponse {
-        rpc::model::HttpResponse::new()
-            .set_status(self.status)
-            .set_reason(self.reason)
-            .set_headers(self.headers.into_iter().map(|v| v.cnv()))
-            .set_body(self.body)
+    fn cnv(self) -> std::result::Result<rpc::model::HttpResponse, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::HttpResponse::new()
+                .set_status(self.status)
+                .set_reason(self.reason)
+                .set_headers(self.headers.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_body(self.body)
+        )
     }
 }
 
@@ -371,9 +416,11 @@ impl gaxi::prost::ToProto<HttpHeader> for rpc::model::HttpHeader {
 }
 
 impl gaxi::prost::FromProto<rpc::model::HttpHeader> for HttpHeader {
-    fn cnv(self) -> rpc::model::HttpHeader {
-        rpc::model::HttpHeader::new()
-            .set_key(self.key)
-            .set_value(self.value)
+    fn cnv(self) -> std::result::Result<rpc::model::HttpHeader, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::HttpHeader::new()
+                .set_key(self.key)
+                .set_value(self.value)
+        )
     }
 }

--- a/src/firestore/src/generated/convert/type/convert.rs
+++ b/src/firestore/src/generated/convert/type/convert.rs
@@ -25,9 +25,11 @@ impl gaxi::prost::ToProto<LatLng> for gtype::model::LatLng {
 }
 
 impl gaxi::prost::FromProto<gtype::model::LatLng> for LatLng {
-    fn cnv(self) -> gtype::model::LatLng {
-        gtype::model::LatLng::new()
-            .set_latitude(self.latitude)
-            .set_longitude(self.longitude)
+    fn cnv(self) -> std::result::Result<gtype::model::LatLng, gaxi::prost::ConvertError> {
+        Ok(
+            gtype::model::LatLng::new()
+                .set_latitude(self.latitude)
+                .set_longitude(self.longitude)
+        )
     }
 }

--- a/src/firestore/src/status.rs
+++ b/src/firestore/src/status.rs
@@ -26,11 +26,11 @@ impl gaxi::prost::ToProto<google::rpc::Status> for rpc::model::Status {
 }
 
 impl gaxi::prost::FromProto<rpc::model::Status> for google::rpc::Status {
-    fn cnv(self) -> rpc::model::Status {
-        rpc::model::Status::new()
+    fn cnv(self) -> Result<rpc::model::Status, gaxi::prost::ConvertError> {
+        Ok(rpc::model::Status::new()
             .set_code(self.code)
             .set_message(self.message)
-            .set_details(self.details.into_iter().filter_map(any_from_prost))
+            .set_details(self.details.into_iter().filter_map(any_from_prost)))
     }
 }
 
@@ -98,43 +98,53 @@ fn any_from_prost(value: prost_types::Any) -> Option<wkt::Any> {
         "type.googleapis.com/google.rpc.BadRequest" => value
             .to_msg::<google::rpc::BadRequest>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.DebugInfo" => value
             .to_msg::<google::rpc::DebugInfo>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.ErrorInfo" => value
             .to_msg::<google::rpc::ErrorInfo>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.Help" => value
             .to_msg::<google::rpc::Help>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.LocalizedMessage" => value
             .to_msg::<google::rpc::LocalizedMessage>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.PreconditionFailure" => value
             .to_msg::<google::rpc::PreconditionFailure>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.QuotaFailure" => value
             .to_msg::<google::rpc::QuotaFailure>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.RequestInfo" => value
             .to_msg::<google::rpc::RequestInfo>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.ResourceInfo" => value
             .to_msg::<google::rpc::ResourceInfo>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         "type.googleapis.com/google.rpc.RetryInfo" => value
             .to_msg::<google::rpc::RetryInfo>()
             .ok()
-            .map(|v| wkt::Any::try_from(&v.cnv())),
+            .and_then(|v| v.cnv().ok())
+            .map(|v| wkt::Any::try_from(&v)),
         _ => None,
     };
     mapped.transpose().ok().flatten()
@@ -147,18 +157,19 @@ mod test {
     use gaxi::prost::ToProto;
 
     #[test]
-    fn from_protok() {
+    fn from_proto() -> anyhow::Result<()> {
         let input = google::rpc::Status {
             code: 12,
             message: "test-message".into(),
             details: prost_details(),
         };
-        let got: rpc::model::Status = input.cnv();
+        let got = input.cnv()?;
         let want = rpc::model::Status::new()
             .set_code(12)
             .set_message("test-message")
             .set_details(wkt_details());
         assert_eq!(got, want);
+        Ok(())
     }
 
     #[test]

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -248,6 +248,7 @@ where
     let (metadata, body, _extensions) = response.into_parts();
     gax::response::Response::from_parts(
         gax::response::Parts::new().set_headers(metadata.into_headers()),
-        body.cnv(),
+        // TODO(#2037) - handle conversion from proto errors.
+        body.cnv().unwrap(),
     )
 }

--- a/src/gax-internal/src/prost.rs
+++ b/src/gax-internal/src/prost.rs
@@ -33,7 +33,7 @@ pub trait ToProto<T>: Sized {
 
 /// Converts from `Self` into `T`, where `Self` is expected to be a Protobuf-generated type.
 pub trait FromProto<T>: Sized {
-    fn cnv(self) -> T;
+    fn cnv(self) -> Result<T>;
 }
 
 /// A helper for map conversions.
@@ -55,8 +55,8 @@ macro_rules! impl_primitive {
         }
 
         impl FromProto<$t> for $t {
-            fn cnv(self) -> $t {
-                self
+            fn cnv(self) -> Result<$t> {
+                Ok(self)
             }
         }
     };
@@ -74,8 +74,8 @@ impl_primitive!(String);
 impl_primitive!(bytes::Bytes);
 
 impl FromProto<wkt::Duration> for prost_types::Duration {
-    fn cnv(self) -> wkt::Duration {
-        wkt::Duration::clamp(self.seconds, self.nanos)
+    fn cnv(self) -> Result<wkt::Duration> {
+        Ok(wkt::Duration::clamp(self.seconds, self.nanos))
     }
 }
 
@@ -90,8 +90,8 @@ impl ToProto<prost_types::Duration> for wkt::Duration {
 }
 
 impl FromProto<wkt::FieldMask> for prost_types::FieldMask {
-    fn cnv(self) -> wkt::FieldMask {
-        wkt::FieldMask::default().set_paths(self.paths)
+    fn cnv(self) -> Result<wkt::FieldMask> {
+        Ok(wkt::FieldMask::default().set_paths(self.paths))
     }
 }
 
@@ -103,8 +103,8 @@ impl ToProto<prost_types::FieldMask> for wkt::FieldMask {
 }
 
 impl FromProto<wkt::Timestamp> for prost_types::Timestamp {
-    fn cnv(self) -> wkt::Timestamp {
-        wkt::Timestamp::clamp(self.seconds, self.nanos)
+    fn cnv(self) -> Result<wkt::Timestamp> {
+        Ok(wkt::Timestamp::clamp(self.seconds, self.nanos))
     }
 }
 
@@ -119,11 +119,12 @@ impl ToProto<prost_types::Timestamp> for wkt::Timestamp {
 }
 
 impl FromProto<wkt::Struct> for prost_types::Struct {
-    fn cnv(self) -> wkt::Struct {
-        self.fields
+    fn cnv(self) -> Result<wkt::Struct> {
+        Ok(self
+            .fields
             .into_iter()
-            .map(|(k, v)| (k.cnv(), v.cnv()))
-            .collect()
+            .map(|(k, v)| pair_transpose(k.cnv(), v.cnv()))
+            .collect::<Result<serde_json::Map<_, _>>>()?)
     }
 }
 
@@ -133,18 +134,16 @@ impl ToProto<prost_types::Struct> for wkt::Struct {
         Ok(prost_types::Struct {
             fields: self
                 .into_iter()
-                .map(|(k, v)| -> Result<(String, prost_types::Value)> {
-                    Ok((k.to_proto()?, v.to_proto()?))
-                })
+                .map(|(k, v)| pair_transpose(k.to_proto(), v.to_proto()))
                 .collect::<Result<BTreeMap<_, _>>>()?,
         })
     }
 }
 
 impl FromProto<wkt::Value> for prost_types::Value {
-    fn cnv(self) -> wkt::Value {
+    fn cnv(self) -> Result<wkt::Value> {
         use prost_types::value::Kind;
-        match self.kind {
+        let kind = match self.kind {
             None => wkt::Value::Null,
             Some(kind) => match kind {
                 Kind::NullValue(_) => wkt::Value::Null,
@@ -155,10 +154,11 @@ impl FromProto<wkt::Value> for prost_types::Value {
                 }
                 Kind::StringValue(v) => wkt::Value::String(v),
                 Kind::BoolValue(v) => wkt::Value::Bool(v),
-                Kind::StructValue(v) => wkt::Value::Object(v.cnv()),
-                Kind::ListValue(v) => wkt::Value::Array(v.cnv()),
+                Kind::StructValue(v) => wkt::Value::Object(v.cnv()?),
+                Kind::ListValue(v) => wkt::Value::Array(v.cnv()?),
             },
-        }
+        };
+        Ok(kind)
     }
 }
 
@@ -179,8 +179,11 @@ impl ToProto<prost_types::Value> for wkt::Value {
 }
 
 impl FromProto<wkt::ListValue> for prost_types::ListValue {
-    fn cnv(self) -> wkt::ListValue {
-        self.values.into_iter().map(|v| v.cnv()).collect()
+    fn cnv(self) -> Result<wkt::ListValue> {
+        self.values
+            .into_iter()
+            .map(|v| v.cnv())
+            .collect::<Result<Vec<_>>>()
     }
 }
 
@@ -206,8 +209,8 @@ impl ToProto<prost_types::NullValue> for wkt::NullValue {
 impl FromProto<wkt::NullValue> for prost_types::NullValue {
     // By convention `from_*` functions do not consume a `self`. And we need
     // `self` so we can write generic code for repeated fields, maps, etc.
-    fn cnv(self) -> wkt::NullValue {
-        wkt::NullValue
+    fn cnv(self) -> Result<wkt::NullValue> {
+        Ok(wkt::NullValue)
     }
 }
 
@@ -239,14 +242,14 @@ mod test {
 
     #[test]
     fn primitive_unit() {
-        let _: () = ().cnv();
+        assert_eq!(().cnv(), Ok(()));
     }
 
     #[test]
     fn primitive_bool() {
         let input: bool = true;
-        let got: bool = input.cnv();
-        assert_eq!(got, input);
+        let got = input.cnv();
+        assert_eq!(got, Ok(input));
     }
 
     #[test_case(0 as f32)]
@@ -259,8 +262,8 @@ mod test {
     where
         T: std::fmt::Debug + Copy + PartialEq + FromProto<T>,
     {
-        let got: T = input.cnv();
-        assert_eq!(got, input);
+        let got = input.cnv();
+        assert_eq!(got, Ok(input));
     }
 
     #[test_case(0 as f32)]
@@ -281,7 +284,7 @@ mod test {
     fn primitive_string() {
         let input = "abc".to_string();
         let got = input.cnv();
-        assert_eq!(&got, "abc");
+        assert_eq!(got, Ok("abc".into()));
         let input = "abc".to_string();
         let got = input.to_proto();
         assert_eq!(got, Ok("abc".into()));
@@ -291,7 +294,7 @@ mod test {
     fn primitive_bytes() {
         let input = bytes::Bytes::from_static(b"abc");
         let got = input.clone().cnv();
-        assert_eq!(got, input);
+        assert_eq!(got, Ok(input));
         let input = bytes::Bytes::from_static(b"abc");
         let got = input.clone().to_proto();
         assert_eq!(got, Ok(input));
@@ -303,8 +306,8 @@ mod test {
             seconds: 123,
             nanos: 456,
         };
-        let got: wkt::Duration = input.cnv();
-        assert_eq!(got, wkt::Duration::clamp(123, 456));
+        let got = input.cnv();
+        assert_eq!(got, Ok(wkt::Duration::clamp(123, 456)));
     }
 
     #[test]
@@ -326,7 +329,10 @@ mod test {
             paths: ["a", "b", "c"].map(str::to_string).to_vec(),
         };
         let got = input.cnv();
-        assert_eq!(got, wkt::FieldMask::default().set_paths(["a", "b", "c"]));
+        assert_eq!(
+            got,
+            Ok(wkt::FieldMask::default().set_paths(["a", "b", "c"]))
+        );
     }
 
     #[test]
@@ -348,7 +354,7 @@ mod test {
             nanos: 456,
         };
         let got = input.cnv();
-        assert_eq!(got, wkt::Timestamp::clamp(123, 456));
+        assert_eq!(got, Ok(wkt::Timestamp::clamp(123, 456)));
     }
 
     #[test]
@@ -371,7 +377,7 @@ mod test {
     #[test_case(json!({"a": true, "b": "xyz"}))]
     fn wkt_value_roundtrip(input: wkt::Value) -> anyhow::Result<()> {
         let convert = input.clone().to_proto()?;
-        let got = convert.cnv();
+        let got = convert.cnv()?;
         assert_eq!(got, input);
         Ok(())
     }
@@ -388,6 +394,6 @@ mod test {
     fn from_prost_null_value() {
         let input = prost_types::NullValue::NullValue;
         let got = input.cnv();
-        assert_eq!(got, wkt::NullValue);
+        assert_eq!(got, Ok(wkt::NullValue));
     }
 }

--- a/src/gax-internal/src/prost.rs
+++ b/src/gax-internal/src/prost.rs
@@ -120,11 +120,10 @@ impl ToProto<prost_types::Timestamp> for wkt::Timestamp {
 
 impl FromProto<wkt::Struct> for prost_types::Struct {
     fn cnv(self) -> Result<wkt::Struct> {
-        Ok(self
-            .fields
+        self.fields
             .into_iter()
             .map(|(k, v)| pair_transpose(k.cnv(), v.cnv()))
-            .collect::<Result<serde_json::Map<_, _>>>()?)
+            .collect::<Result<serde_json::Map<_, _>>>()
     }
 }
 

--- a/src/storage-control/src/generated/convert/control/convert.rs
+++ b/src/storage-control/src/generated/convert/control/convert.rs
@@ -24,9 +24,11 @@ impl gaxi::prost::ToProto<PendingRenameInfo> for crate::generated::gapic_control
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::PendingRenameInfo> for PendingRenameInfo {
-    fn cnv(self) -> crate::generated::gapic_control::model::PendingRenameInfo {
-        crate::generated::gapic_control::model::PendingRenameInfo::new()
-            .set_operation(self.operation)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::PendingRenameInfo, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::PendingRenameInfo::new()
+                .set_operation(self.operation)
+        )
     }
 }
 
@@ -44,13 +46,15 @@ impl gaxi::prost::ToProto<Folder> for crate::generated::gapic_control::model::Fo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::Folder> for Folder {
-    fn cnv(self) -> crate::generated::gapic_control::model::Folder {
-        crate::generated::gapic_control::model::Folder::new()
-            .set_name(self.name)
-            .set_metageneration(self.metageneration)
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_pending_rename_info(self.pending_rename_info.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::Folder, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::Folder::new()
+                .set_name(self.name)
+                .set_metageneration(self.metageneration)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_pending_rename_info(self.pending_rename_info.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -67,12 +71,14 @@ impl gaxi::prost::ToProto<GetFolderRequest> for crate::generated::gapic_control:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::GetFolderRequest> for GetFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::GetFolderRequest {
-        crate::generated::gapic_control::model::GetFolderRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::GetFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::GetFolderRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -90,13 +96,15 @@ impl gaxi::prost::ToProto<CreateFolderRequest> for crate::generated::gapic_contr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::CreateFolderRequest> for CreateFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::CreateFolderRequest {
-        crate::generated::gapic_control::model::CreateFolderRequest::new()
-            .set_parent(self.parent)
-            .set_folder(self.folder.map(|v| v.cnv()))
-            .set_folder_id(self.folder_id)
-            .set_recursive(self.recursive)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::CreateFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::CreateFolderRequest::new()
+                .set_parent(self.parent)
+                .set_folder(self.folder.map(|v| v.cnv()).transpose()?)
+                .set_folder_id(self.folder_id)
+                .set_recursive(self.recursive)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -113,12 +121,14 @@ impl gaxi::prost::ToProto<DeleteFolderRequest> for crate::generated::gapic_contr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::DeleteFolderRequest> for DeleteFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::DeleteFolderRequest {
-        crate::generated::gapic_control::model::DeleteFolderRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::DeleteFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::DeleteFolderRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -139,16 +149,18 @@ impl gaxi::prost::ToProto<ListFoldersRequest> for crate::generated::gapic_contro
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListFoldersRequest> for ListFoldersRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListFoldersRequest {
-        crate::generated::gapic_control::model::ListFoldersRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_prefix(self.prefix)
-            .set_delimiter(self.delimiter)
-            .set_lexicographic_start(self.lexicographic_start)
-            .set_lexicographic_end(self.lexicographic_end)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListFoldersRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListFoldersRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_prefix(self.prefix)
+                .set_delimiter(self.delimiter)
+                .set_lexicographic_start(self.lexicographic_start)
+                .set_lexicographic_end(self.lexicographic_end)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -166,10 +178,13 @@ impl gaxi::prost::ToProto<ListFoldersResponse> for crate::generated::gapic_contr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListFoldersResponse> for ListFoldersResponse {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListFoldersResponse {
-        crate::generated::gapic_control::model::ListFoldersResponse::new()
-            .set_folders(self.folders.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListFoldersResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListFoldersResponse::new()
+                .set_folders(self.folders.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -187,13 +202,15 @@ impl gaxi::prost::ToProto<RenameFolderRequest> for crate::generated::gapic_contr
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::RenameFolderRequest> for RenameFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::RenameFolderRequest {
-        crate::generated::gapic_control::model::RenameFolderRequest::new()
-            .set_name(self.name)
-            .set_destination_folder_id(self.destination_folder_id)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::RenameFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::RenameFolderRequest::new()
+                .set_name(self.name)
+                .set_destination_folder_id(self.destination_folder_id)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -212,14 +229,16 @@ impl gaxi::prost::ToProto<CommonLongRunningOperationMetadata> for crate::generat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::CommonLongRunningOperationMetadata> for CommonLongRunningOperationMetadata {
-    fn cnv(self) -> crate::generated::gapic_control::model::CommonLongRunningOperationMetadata {
-        crate::generated::gapic_control::model::CommonLongRunningOperationMetadata::new()
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_end_time(self.end_time.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_type(self.r#type)
-            .set_requested_cancellation(self.requested_cancellation)
-            .set_progress_percent(self.progress_percent)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::CommonLongRunningOperationMetadata, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::CommonLongRunningOperationMetadata::new()
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_end_time(self.end_time.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_type(self.r#type)
+                .set_requested_cancellation(self.requested_cancellation)
+                .set_progress_percent(self.progress_percent)
+        )
     }
 }
 
@@ -235,11 +254,13 @@ impl gaxi::prost::ToProto<RenameFolderMetadata> for crate::generated::gapic_cont
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::RenameFolderMetadata> for RenameFolderMetadata {
-    fn cnv(self) -> crate::generated::gapic_control::model::RenameFolderMetadata {
-        crate::generated::gapic_control::model::RenameFolderMetadata::new()
-            .set_common_metadata(self.common_metadata.map(|v| v.cnv()))
-            .set_source_folder_id(self.source_folder_id)
-            .set_destination_folder_id(self.destination_folder_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::RenameFolderMetadata, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::RenameFolderMetadata::new()
+                .set_common_metadata(self.common_metadata.map(|v| v.cnv()).transpose()?)
+                .set_source_folder_id(self.source_folder_id)
+                .set_destination_folder_id(self.destination_folder_id)
+        )
     }
 }
 
@@ -256,9 +277,12 @@ impl gaxi::prost::ToProto<storage_layout::CustomPlacementConfig> for crate::gene
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::storage_layout::CustomPlacementConfig> for storage_layout::CustomPlacementConfig {
-    fn cnv(self) -> crate::generated::gapic_control::model::storage_layout::CustomPlacementConfig {
-        crate::generated::gapic_control::model::storage_layout::CustomPlacementConfig::new()
-            .set_data_locations(self.data_locations.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::storage_layout::CustomPlacementConfig, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::storage_layout::CustomPlacementConfig::new()
+                .set_data_locations(self.data_locations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -272,9 +296,11 @@ impl gaxi::prost::ToProto<storage_layout::HierarchicalNamespace> for crate::gene
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::storage_layout::HierarchicalNamespace> for storage_layout::HierarchicalNamespace {
-    fn cnv(self) -> crate::generated::gapic_control::model::storage_layout::HierarchicalNamespace {
-        crate::generated::gapic_control::model::storage_layout::HierarchicalNamespace::new()
-            .set_enabled(self.enabled)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::storage_layout::HierarchicalNamespace, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::storage_layout::HierarchicalNamespace::new()
+                .set_enabled(self.enabled)
+        )
     }
 }
 
@@ -292,13 +318,15 @@ impl gaxi::prost::ToProto<StorageLayout> for crate::generated::gapic_control::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::StorageLayout> for StorageLayout {
-    fn cnv(self) -> crate::generated::gapic_control::model::StorageLayout {
-        crate::generated::gapic_control::model::StorageLayout::new()
-            .set_name(self.name)
-            .set_location(self.location)
-            .set_location_type(self.location_type)
-            .set_custom_placement_config(self.custom_placement_config.map(|v| v.cnv()))
-            .set_hierarchical_namespace(self.hierarchical_namespace.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::StorageLayout, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::StorageLayout::new()
+                .set_name(self.name)
+                .set_location(self.location)
+                .set_location_type(self.location_type)
+                .set_custom_placement_config(self.custom_placement_config.map(|v| v.cnv()).transpose()?)
+                .set_hierarchical_namespace(self.hierarchical_namespace.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -314,11 +342,13 @@ impl gaxi::prost::ToProto<GetStorageLayoutRequest> for crate::generated::gapic_c
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::GetStorageLayoutRequest> for GetStorageLayoutRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::GetStorageLayoutRequest {
-        crate::generated::gapic_control::model::GetStorageLayoutRequest::new()
-            .set_name(self.name)
-            .set_prefix(self.prefix)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::GetStorageLayoutRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::GetStorageLayoutRequest::new()
+                .set_name(self.name)
+                .set_prefix(self.prefix)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -335,12 +365,14 @@ impl gaxi::prost::ToProto<ManagedFolder> for crate::generated::gapic_control::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ManagedFolder> for ManagedFolder {
-    fn cnv(self) -> crate::generated::gapic_control::model::ManagedFolder {
-        crate::generated::gapic_control::model::ManagedFolder::new()
-            .set_name(self.name)
-            .set_metageneration(self.metageneration)
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ManagedFolder, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ManagedFolder::new()
+                .set_name(self.name)
+                .set_metageneration(self.metageneration)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -357,12 +389,14 @@ impl gaxi::prost::ToProto<GetManagedFolderRequest> for crate::generated::gapic_c
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::GetManagedFolderRequest> for GetManagedFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::GetManagedFolderRequest {
-        crate::generated::gapic_control::model::GetManagedFolderRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::GetManagedFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::GetManagedFolderRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -379,12 +413,14 @@ impl gaxi::prost::ToProto<CreateManagedFolderRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::CreateManagedFolderRequest> for CreateManagedFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::CreateManagedFolderRequest {
-        crate::generated::gapic_control::model::CreateManagedFolderRequest::new()
-            .set_parent(self.parent)
-            .set_managed_folder(self.managed_folder.map(|v| v.cnv()))
-            .set_managed_folder_id(self.managed_folder_id)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::CreateManagedFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::CreateManagedFolderRequest::new()
+                .set_parent(self.parent)
+                .set_managed_folder(self.managed_folder.map(|v| v.cnv()).transpose()?)
+                .set_managed_folder_id(self.managed_folder_id)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -402,13 +438,15 @@ impl gaxi::prost::ToProto<DeleteManagedFolderRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::DeleteManagedFolderRequest> for DeleteManagedFolderRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::DeleteManagedFolderRequest {
-        crate::generated::gapic_control::model::DeleteManagedFolderRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_allow_non_empty(self.allow_non_empty)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::DeleteManagedFolderRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::DeleteManagedFolderRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_allow_non_empty(self.allow_non_empty)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -426,13 +464,15 @@ impl gaxi::prost::ToProto<ListManagedFoldersRequest> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListManagedFoldersRequest> for ListManagedFoldersRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListManagedFoldersRequest {
-        crate::generated::gapic_control::model::ListManagedFoldersRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_prefix(self.prefix)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListManagedFoldersRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListManagedFoldersRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_prefix(self.prefix)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -450,10 +490,13 @@ impl gaxi::prost::ToProto<ListManagedFoldersResponse> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListManagedFoldersResponse> for ListManagedFoldersResponse {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListManagedFoldersResponse {
-        crate::generated::gapic_control::model::ListManagedFoldersResponse::new()
-            .set_managed_folders(self.managed_folders.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListManagedFoldersResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListManagedFoldersResponse::new()
+                .set_managed_folders(self.managed_folders.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -471,13 +514,15 @@ impl gaxi::prost::ToProto<CreateAnywhereCacheMetadata> for crate::generated::gap
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::CreateAnywhereCacheMetadata> for CreateAnywhereCacheMetadata {
-    fn cnv(self) -> crate::generated::gapic_control::model::CreateAnywhereCacheMetadata {
-        crate::generated::gapic_control::model::CreateAnywhereCacheMetadata::new()
-            .set_common_metadata(self.common_metadata.map(|v| v.cnv()))
-            .set_anywhere_cache_id(self.anywhere_cache_id.map(|v| v.cnv()))
-            .set_zone(self.zone.map(|v| v.cnv()))
-            .set_ttl(self.ttl.map(|v| v.cnv()))
-            .set_admission_policy(self.admission_policy.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::CreateAnywhereCacheMetadata, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::CreateAnywhereCacheMetadata::new()
+                .set_common_metadata(self.common_metadata.map(|v| v.cnv()).transpose()?)
+                .set_anywhere_cache_id(self.anywhere_cache_id.map(|v| v.cnv()).transpose()?)
+                .set_zone(self.zone.map(|v| v.cnv()).transpose()?)
+                .set_ttl(self.ttl.map(|v| v.cnv()).transpose()?)
+                .set_admission_policy(self.admission_policy.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -495,13 +540,15 @@ impl gaxi::prost::ToProto<UpdateAnywhereCacheMetadata> for crate::generated::gap
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::UpdateAnywhereCacheMetadata> for UpdateAnywhereCacheMetadata {
-    fn cnv(self) -> crate::generated::gapic_control::model::UpdateAnywhereCacheMetadata {
-        crate::generated::gapic_control::model::UpdateAnywhereCacheMetadata::new()
-            .set_common_metadata(self.common_metadata.map(|v| v.cnv()))
-            .set_anywhere_cache_id(self.anywhere_cache_id.map(|v| v.cnv()))
-            .set_zone(self.zone.map(|v| v.cnv()))
-            .set_ttl(self.ttl.map(|v| v.cnv()))
-            .set_admission_policy(self.admission_policy.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::UpdateAnywhereCacheMetadata, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::UpdateAnywhereCacheMetadata::new()
+                .set_common_metadata(self.common_metadata.map(|v| v.cnv()).transpose()?)
+                .set_anywhere_cache_id(self.anywhere_cache_id.map(|v| v.cnv()).transpose()?)
+                .set_zone(self.zone.map(|v| v.cnv()).transpose()?)
+                .set_ttl(self.ttl.map(|v| v.cnv()).transpose()?)
+                .set_admission_policy(self.admission_policy.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -522,16 +569,18 @@ impl gaxi::prost::ToProto<AnywhereCache> for crate::generated::gapic_control::mo
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::AnywhereCache> for AnywhereCache {
-    fn cnv(self) -> crate::generated::gapic_control::model::AnywhereCache {
-        crate::generated::gapic_control::model::AnywhereCache::new()
-            .set_name(self.name)
-            .set_zone(self.zone)
-            .set_ttl(self.ttl.map(|v| v.cnv()))
-            .set_admission_policy(self.admission_policy)
-            .set_state(self.state)
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_pending_update(self.pending_update)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::AnywhereCache, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::AnywhereCache::new()
+                .set_name(self.name)
+                .set_zone(self.zone)
+                .set_ttl(self.ttl.map(|v| v.cnv()).transpose()?)
+                .set_admission_policy(self.admission_policy)
+                .set_state(self.state)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_pending_update(self.pending_update)
+        )
     }
 }
 
@@ -547,11 +596,13 @@ impl gaxi::prost::ToProto<CreateAnywhereCacheRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::CreateAnywhereCacheRequest> for CreateAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::CreateAnywhereCacheRequest {
-        crate::generated::gapic_control::model::CreateAnywhereCacheRequest::new()
-            .set_parent(self.parent)
-            .set_anywhere_cache(self.anywhere_cache.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::CreateAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::CreateAnywhereCacheRequest::new()
+                .set_parent(self.parent)
+                .set_anywhere_cache(self.anywhere_cache.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -567,11 +618,13 @@ impl gaxi::prost::ToProto<UpdateAnywhereCacheRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::UpdateAnywhereCacheRequest> for UpdateAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::UpdateAnywhereCacheRequest {
-        crate::generated::gapic_control::model::UpdateAnywhereCacheRequest::new()
-            .set_anywhere_cache(self.anywhere_cache.map(|v| v.cnv()))
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::UpdateAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::UpdateAnywhereCacheRequest::new()
+                .set_anywhere_cache(self.anywhere_cache.map(|v| v.cnv()).transpose()?)
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -586,10 +639,12 @@ impl gaxi::prost::ToProto<DisableAnywhereCacheRequest> for crate::generated::gap
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::DisableAnywhereCacheRequest> for DisableAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::DisableAnywhereCacheRequest {
-        crate::generated::gapic_control::model::DisableAnywhereCacheRequest::new()
-            .set_name(self.name)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::DisableAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::DisableAnywhereCacheRequest::new()
+                .set_name(self.name)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -604,10 +659,12 @@ impl gaxi::prost::ToProto<PauseAnywhereCacheRequest> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::PauseAnywhereCacheRequest> for PauseAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::PauseAnywhereCacheRequest {
-        crate::generated::gapic_control::model::PauseAnywhereCacheRequest::new()
-            .set_name(self.name)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::PauseAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::PauseAnywhereCacheRequest::new()
+                .set_name(self.name)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -622,10 +679,12 @@ impl gaxi::prost::ToProto<ResumeAnywhereCacheRequest> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ResumeAnywhereCacheRequest> for ResumeAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::ResumeAnywhereCacheRequest {
-        crate::generated::gapic_control::model::ResumeAnywhereCacheRequest::new()
-            .set_name(self.name)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ResumeAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ResumeAnywhereCacheRequest::new()
+                .set_name(self.name)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -640,10 +699,12 @@ impl gaxi::prost::ToProto<GetAnywhereCacheRequest> for crate::generated::gapic_c
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::GetAnywhereCacheRequest> for GetAnywhereCacheRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::GetAnywhereCacheRequest {
-        crate::generated::gapic_control::model::GetAnywhereCacheRequest::new()
-            .set_name(self.name)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::GetAnywhereCacheRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::GetAnywhereCacheRequest::new()
+                .set_name(self.name)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -660,12 +721,14 @@ impl gaxi::prost::ToProto<ListAnywhereCachesRequest> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListAnywhereCachesRequest> for ListAnywhereCachesRequest {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListAnywhereCachesRequest {
-        crate::generated::gapic_control::model::ListAnywhereCachesRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_request_id(self.request_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListAnywhereCachesRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListAnywhereCachesRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_request_id(self.request_id)
+        )
     }
 }
 
@@ -683,9 +746,12 @@ impl gaxi::prost::ToProto<ListAnywhereCachesResponse> for crate::generated::gapi
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic_control::model::ListAnywhereCachesResponse> for ListAnywhereCachesResponse {
-    fn cnv(self) -> crate::generated::gapic_control::model::ListAnywhereCachesResponse {
-        crate::generated::gapic_control::model::ListAnywhereCachesResponse::new()
-            .set_anywhere_caches(self.anywhere_caches.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::ListAnywhereCachesResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic_control::model::ListAnywhereCachesResponse::new()
+                .set_anywhere_caches(self.anywhere_caches.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }

--- a/src/storage-control/src/generated/convert/iam/convert.rs
+++ b/src/storage-control/src/generated/convert/iam/convert.rs
@@ -26,11 +26,13 @@ impl gaxi::prost::ToProto<SetIamPolicyRequest> for iam_v1::model::SetIamPolicyRe
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::SetIamPolicyRequest> for SetIamPolicyRequest {
-    fn cnv(self) -> iam_v1::model::SetIamPolicyRequest {
-        iam_v1::model::SetIamPolicyRequest::new()
-            .set_resource(self.resource)
-            .set_policy(self.policy.map(|v| v.cnv()))
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::SetIamPolicyRequest, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::SetIamPolicyRequest::new()
+                .set_resource(self.resource)
+                .set_policy(self.policy.map(|v| v.cnv()).transpose()?)
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -45,10 +47,12 @@ impl gaxi::prost::ToProto<GetIamPolicyRequest> for iam_v1::model::GetIamPolicyRe
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::GetIamPolicyRequest> for GetIamPolicyRequest {
-    fn cnv(self) -> iam_v1::model::GetIamPolicyRequest {
-        iam_v1::model::GetIamPolicyRequest::new()
-            .set_resource(self.resource)
-            .set_options(self.options.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::GetIamPolicyRequest, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::GetIamPolicyRequest::new()
+                .set_resource(self.resource)
+                .set_options(self.options.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -66,10 +70,13 @@ impl gaxi::prost::ToProto<TestIamPermissionsRequest> for iam_v1::model::TestIamP
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::TestIamPermissionsRequest> for TestIamPermissionsRequest {
-    fn cnv(self) -> iam_v1::model::TestIamPermissionsRequest {
-        iam_v1::model::TestIamPermissionsRequest::new()
-            .set_resource(self.resource)
-            .set_permissions(self.permissions.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::TestIamPermissionsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::TestIamPermissionsRequest::new()
+                .set_resource(self.resource)
+                .set_permissions(self.permissions.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -86,9 +93,12 @@ impl gaxi::prost::ToProto<TestIamPermissionsResponse> for iam_v1::model::TestIam
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::TestIamPermissionsResponse> for TestIamPermissionsResponse {
-    fn cnv(self) -> iam_v1::model::TestIamPermissionsResponse {
-        iam_v1::model::TestIamPermissionsResponse::new()
-            .set_permissions(self.permissions.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::TestIamPermissionsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::TestIamPermissionsResponse::new()
+                .set_permissions(self.permissions.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -102,9 +112,11 @@ impl gaxi::prost::ToProto<GetPolicyOptions> for iam_v1::model::GetPolicyOptions 
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::GetPolicyOptions> for GetPolicyOptions {
-    fn cnv(self) -> iam_v1::model::GetPolicyOptions {
-        iam_v1::model::GetPolicyOptions::new()
-            .set_requested_policy_version(self.requested_policy_version)
+    fn cnv(self) -> std::result::Result<iam_v1::model::GetPolicyOptions, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::GetPolicyOptions::new()
+                .set_requested_policy_version(self.requested_policy_version)
+        )
     }
 }
 
@@ -127,12 +139,16 @@ impl gaxi::prost::ToProto<Policy> for iam_v1::model::Policy {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::Policy> for Policy {
-    fn cnv(self) -> iam_v1::model::Policy {
-        iam_v1::model::Policy::new()
-            .set_version(self.version)
-            .set_bindings(self.bindings.into_iter().map(|v| v.cnv()))
-            .set_audit_configs(self.audit_configs.into_iter().map(|v| v.cnv()))
-            .set_etag(self.etag)
+    fn cnv(self) -> std::result::Result<iam_v1::model::Policy, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::Policy::new()
+                .set_version(self.version)
+                .set_bindings(self.bindings.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_audit_configs(self.audit_configs.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_etag(self.etag)
+        )
     }
 }
 
@@ -151,11 +167,14 @@ impl gaxi::prost::ToProto<Binding> for iam_v1::model::Binding {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::Binding> for Binding {
-    fn cnv(self) -> iam_v1::model::Binding {
-        iam_v1::model::Binding::new()
-            .set_role(self.role)
-            .set_members(self.members.into_iter().map(|v| v.cnv()))
-            .set_condition(self.condition.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::Binding, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::Binding::new()
+                .set_role(self.role)
+                .set_members(self.members.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_condition(self.condition.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -173,10 +192,13 @@ impl gaxi::prost::ToProto<AuditConfig> for iam_v1::model::AuditConfig {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::AuditConfig> for AuditConfig {
-    fn cnv(self) -> iam_v1::model::AuditConfig {
-        iam_v1::model::AuditConfig::new()
-            .set_service(self.service)
-            .set_audit_log_configs(self.audit_log_configs.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::AuditConfig, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::AuditConfig::new()
+                .set_service(self.service)
+                .set_audit_log_configs(self.audit_log_configs.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -201,10 +223,13 @@ impl gaxi::prost::ToProto<AuditLogConfig> for iam_v1::model::AuditLogConfig {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::AuditLogConfig> for AuditLogConfig {
-    fn cnv(self) -> iam_v1::model::AuditLogConfig {
-        iam_v1::model::AuditLogConfig::new()
-            .set_log_type(self.log_type)
-            .set_exempted_members(self.exempted_members.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::AuditLogConfig, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::AuditLogConfig::new()
+                .set_log_type(self.log_type)
+                .set_exempted_members(self.exempted_members.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -225,10 +250,14 @@ impl gaxi::prost::ToProto<PolicyDelta> for iam_v1::model::PolicyDelta {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::PolicyDelta> for PolicyDelta {
-    fn cnv(self) -> iam_v1::model::PolicyDelta {
-        iam_v1::model::PolicyDelta::new()
-            .set_binding_deltas(self.binding_deltas.into_iter().map(|v| v.cnv()))
-            .set_audit_config_deltas(self.audit_config_deltas.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::PolicyDelta, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::PolicyDelta::new()
+                .set_binding_deltas(self.binding_deltas.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_audit_config_deltas(self.audit_config_deltas.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -252,12 +281,14 @@ impl gaxi::prost::ToProto<BindingDelta> for iam_v1::model::BindingDelta {
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::BindingDelta> for BindingDelta {
-    fn cnv(self) -> iam_v1::model::BindingDelta {
-        iam_v1::model::BindingDelta::new()
-            .set_action(self.action)
-            .set_role(self.role)
-            .set_member(self.member)
-            .set_condition(self.condition.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<iam_v1::model::BindingDelta, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::BindingDelta::new()
+                .set_action(self.action)
+                .set_role(self.role)
+                .set_member(self.member)
+                .set_condition(self.condition.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -281,11 +312,13 @@ impl gaxi::prost::ToProto<AuditConfigDelta> for iam_v1::model::AuditConfigDelta 
 }
 
 impl gaxi::prost::FromProto<iam_v1::model::AuditConfigDelta> for AuditConfigDelta {
-    fn cnv(self) -> iam_v1::model::AuditConfigDelta {
-        iam_v1::model::AuditConfigDelta::new()
-            .set_action(self.action)
-            .set_service(self.service)
-            .set_exempted_member(self.exempted_member)
-            .set_log_type(self.log_type)
+    fn cnv(self) -> std::result::Result<iam_v1::model::AuditConfigDelta, gaxi::prost::ConvertError> {
+        Ok(
+            iam_v1::model::AuditConfigDelta::new()
+                .set_action(self.action)
+                .set_service(self.service)
+                .set_exempted_member(self.exempted_member)
+                .set_log_type(self.log_type)
+        )
     }
 }

--- a/src/storage-control/src/generated/convert/storage/convert.rs
+++ b/src/storage-control/src/generated/convert/storage/convert.rs
@@ -26,11 +26,13 @@ impl gaxi::prost::ToProto<DeleteBucketRequest> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DeleteBucketRequest> for DeleteBucketRequest {
-    fn cnv(self) -> crate::generated::gapic::model::DeleteBucketRequest {
-        crate::generated::gapic::model::DeleteBucketRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DeleteBucketRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DeleteBucketRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -47,12 +49,14 @@ impl gaxi::prost::ToProto<GetBucketRequest> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::GetBucketRequest> for GetBucketRequest {
-    fn cnv(self) -> crate::generated::gapic::model::GetBucketRequest {
-        crate::generated::gapic::model::GetBucketRequest::new()
-            .set_name(self.name)
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_read_mask(self.read_mask.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::GetBucketRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::GetBucketRequest::new()
+                .set_name(self.name)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_read_mask(self.read_mask.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -70,13 +74,15 @@ impl gaxi::prost::ToProto<CreateBucketRequest> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CreateBucketRequest> for CreateBucketRequest {
-    fn cnv(self) -> crate::generated::gapic::model::CreateBucketRequest {
-        crate::generated::gapic::model::CreateBucketRequest::new()
-            .set_parent(self.parent)
-            .set_bucket(self.bucket.map(|v| v.cnv()))
-            .set_bucket_id(self.bucket_id)
-            .set_predefined_acl(self.predefined_acl)
-            .set_predefined_default_object_acl(self.predefined_default_object_acl)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CreateBucketRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CreateBucketRequest::new()
+                .set_parent(self.parent)
+                .set_bucket(self.bucket.map(|v| v.cnv()).transpose()?)
+                .set_bucket_id(self.bucket_id)
+                .set_predefined_acl(self.predefined_acl)
+                .set_predefined_default_object_acl(self.predefined_default_object_acl)
+        )
     }
 }
 
@@ -94,13 +100,15 @@ impl gaxi::prost::ToProto<ListBucketsRequest> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListBucketsRequest> for ListBucketsRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ListBucketsRequest {
-        crate::generated::gapic::model::ListBucketsRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_prefix(self.prefix)
-            .set_read_mask(self.read_mask.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListBucketsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListBucketsRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_prefix(self.prefix)
+                .set_read_mask(self.read_mask.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -118,10 +126,13 @@ impl gaxi::prost::ToProto<ListBucketsResponse> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListBucketsResponse> for ListBucketsResponse {
-    fn cnv(self) -> crate::generated::gapic::model::ListBucketsResponse {
-        crate::generated::gapic::model::ListBucketsResponse::new()
-            .set_buckets(self.buckets.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListBucketsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListBucketsResponse::new()
+                .set_buckets(self.buckets.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -136,10 +147,12 @@ impl gaxi::prost::ToProto<LockBucketRetentionPolicyRequest> for crate::generated
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::LockBucketRetentionPolicyRequest> for LockBucketRetentionPolicyRequest {
-    fn cnv(self) -> crate::generated::gapic::model::LockBucketRetentionPolicyRequest {
-        crate::generated::gapic::model::LockBucketRetentionPolicyRequest::new()
-            .set_bucket(self.bucket)
-            .set_if_metageneration_match(self.if_metageneration_match)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::LockBucketRetentionPolicyRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::LockBucketRetentionPolicyRequest::new()
+                .set_bucket(self.bucket)
+                .set_if_metageneration_match(self.if_metageneration_match)
+        )
     }
 }
 
@@ -158,14 +171,16 @@ impl gaxi::prost::ToProto<UpdateBucketRequest> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::UpdateBucketRequest> for UpdateBucketRequest {
-    fn cnv(self) -> crate::generated::gapic::model::UpdateBucketRequest {
-        crate::generated::gapic::model::UpdateBucketRequest::new()
-            .set_bucket(self.bucket.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_predefined_acl(self.predefined_acl)
-            .set_predefined_default_object_acl(self.predefined_default_object_acl)
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::UpdateBucketRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::UpdateBucketRequest::new()
+                .set_bucket(self.bucket.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_predefined_acl(self.predefined_acl)
+                .set_predefined_default_object_acl(self.predefined_default_object_acl)
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -179,9 +194,11 @@ impl gaxi::prost::ToProto<compose_object_request::source_object::ObjectPrecondit
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::compose_object_request::source_object::ObjectPreconditions> for compose_object_request::source_object::ObjectPreconditions {
-    fn cnv(self) -> crate::generated::gapic::model::compose_object_request::source_object::ObjectPreconditions {
-        crate::generated::gapic::model::compose_object_request::source_object::ObjectPreconditions::new()
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::compose_object_request::source_object::ObjectPreconditions, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::compose_object_request::source_object::ObjectPreconditions::new()
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -197,11 +214,13 @@ impl gaxi::prost::ToProto<compose_object_request::SourceObject> for crate::gener
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::compose_object_request::SourceObject> for compose_object_request::SourceObject {
-    fn cnv(self) -> crate::generated::gapic::model::compose_object_request::SourceObject {
-        crate::generated::gapic::model::compose_object_request::SourceObject::new()
-            .set_name(self.name)
-            .set_generation(self.generation)
-            .set_object_preconditions(self.object_preconditions.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::compose_object_request::SourceObject, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::compose_object_request::SourceObject::new()
+                .set_name(self.name)
+                .set_generation(self.generation)
+                .set_object_preconditions(self.object_preconditions.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -225,16 +244,19 @@ impl gaxi::prost::ToProto<ComposeObjectRequest> for crate::generated::gapic::mod
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ComposeObjectRequest> for ComposeObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ComposeObjectRequest {
-        crate::generated::gapic::model::ComposeObjectRequest::new()
-            .set_destination(self.destination.map(|v| v.cnv()))
-            .set_source_objects(self.source_objects.into_iter().map(|v| v.cnv()))
-            .set_destination_predefined_acl(self.destination_predefined_acl)
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_kms_key(self.kms_key)
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
-            .set_object_checksums(self.object_checksums.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ComposeObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ComposeObjectRequest::new()
+                .set_destination(self.destination.map(|v| v.cnv()).transpose()?)
+                .set_source_objects(self.source_objects.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_destination_predefined_acl(self.destination_predefined_acl)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_kms_key(self.kms_key)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+                .set_object_checksums(self.object_checksums.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -255,16 +277,18 @@ impl gaxi::prost::ToProto<DeleteObjectRequest> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::DeleteObjectRequest> for DeleteObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::DeleteObjectRequest {
-        crate::generated::gapic::model::DeleteObjectRequest::new()
-            .set_bucket(self.bucket)
-            .set_object(self.object)
-            .set_generation(self.generation)
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::DeleteObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::DeleteObjectRequest::new()
+                .set_bucket(self.bucket)
+                .set_object(self.object)
+                .set_generation(self.generation)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -287,18 +311,20 @@ impl gaxi::prost::ToProto<RestoreObjectRequest> for crate::generated::gapic::mod
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RestoreObjectRequest> for RestoreObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::RestoreObjectRequest {
-        crate::generated::gapic::model::RestoreObjectRequest::new()
-            .set_bucket(self.bucket)
-            .set_object(self.object)
-            .set_generation(self.generation)
-            .set_restore_token(self.restore_token)
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_copy_source_acl(self.copy_source_acl.map(|v| v.cnv()))
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RestoreObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RestoreObjectRequest::new()
+                .set_bucket(self.bucket)
+                .set_object(self.object)
+                .set_generation(self.generation)
+                .set_restore_token(self.restore_token)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_copy_source_acl(self.copy_source_acl.map(|v| v.cnv()).transpose()?)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -322,19 +348,21 @@ impl gaxi::prost::ToProto<GetObjectRequest> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::GetObjectRequest> for GetObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::GetObjectRequest {
-        crate::generated::gapic::model::GetObjectRequest::new()
-            .set_bucket(self.bucket)
-            .set_object(self.object)
-            .set_generation(self.generation)
-            .set_soft_deleted(self.soft_deleted.map(|v| v.cnv()))
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
-            .set_read_mask(self.read_mask.map(|v| v.cnv()))
-            .set_restore_token(self.restore_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::GetObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::GetObjectRequest::new()
+                .set_bucket(self.bucket)
+                .set_object(self.object)
+                .set_generation(self.generation)
+                .set_soft_deleted(self.soft_deleted.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+                .set_read_mask(self.read_mask.map(|v| v.cnv()).transpose()?)
+                .set_restore_token(self.restore_token)
+        )
     }
 }
 
@@ -360,21 +388,23 @@ impl gaxi::prost::ToProto<ListObjectsRequest> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListObjectsRequest> for ListObjectsRequest {
-    fn cnv(self) -> crate::generated::gapic::model::ListObjectsRequest {
-        crate::generated::gapic::model::ListObjectsRequest::new()
-            .set_parent(self.parent)
-            .set_page_size(self.page_size)
-            .set_page_token(self.page_token)
-            .set_delimiter(self.delimiter)
-            .set_include_trailing_delimiter(self.include_trailing_delimiter)
-            .set_prefix(self.prefix)
-            .set_versions(self.versions)
-            .set_read_mask(self.read_mask.map(|v| v.cnv()))
-            .set_lexicographic_start(self.lexicographic_start)
-            .set_lexicographic_end(self.lexicographic_end)
-            .set_soft_deleted(self.soft_deleted)
-            .set_include_folders_as_prefixes(self.include_folders_as_prefixes)
-            .set_match_glob(self.match_glob)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListObjectsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListObjectsRequest::new()
+                .set_parent(self.parent)
+                .set_page_size(self.page_size)
+                .set_page_token(self.page_token)
+                .set_delimiter(self.delimiter)
+                .set_include_trailing_delimiter(self.include_trailing_delimiter)
+                .set_prefix(self.prefix)
+                .set_versions(self.versions)
+                .set_read_mask(self.read_mask.map(|v| v.cnv()).transpose()?)
+                .set_lexicographic_start(self.lexicographic_start)
+                .set_lexicographic_end(self.lexicographic_end)
+                .set_soft_deleted(self.soft_deleted)
+                .set_include_folders_as_prefixes(self.include_folders_as_prefixes)
+                .set_match_glob(self.match_glob)
+        )
     }
 }
 
@@ -410,31 +440,33 @@ impl gaxi::prost::ToProto<RewriteObjectRequest> for crate::generated::gapic::mod
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RewriteObjectRequest> for RewriteObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::RewriteObjectRequest {
-        crate::generated::gapic::model::RewriteObjectRequest::new()
-            .set_destination_name(self.destination_name)
-            .set_destination_bucket(self.destination_bucket)
-            .set_destination_kms_key(self.destination_kms_key)
-            .set_destination(self.destination.map(|v| v.cnv()))
-            .set_source_bucket(self.source_bucket)
-            .set_source_object(self.source_object)
-            .set_source_generation(self.source_generation)
-            .set_rewrite_token(self.rewrite_token)
-            .set_destination_predefined_acl(self.destination_predefined_acl)
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_if_source_generation_match(self.if_source_generation_match.map(|v| v.cnv()))
-            .set_if_source_generation_not_match(self.if_source_generation_not_match.map(|v| v.cnv()))
-            .set_if_source_metageneration_match(self.if_source_metageneration_match.map(|v| v.cnv()))
-            .set_if_source_metageneration_not_match(self.if_source_metageneration_not_match.map(|v| v.cnv()))
-            .set_max_bytes_rewritten_per_call(self.max_bytes_rewritten_per_call)
-            .set_copy_source_encryption_algorithm(self.copy_source_encryption_algorithm)
-            .set_copy_source_encryption_key_bytes(self.copy_source_encryption_key_bytes)
-            .set_copy_source_encryption_key_sha256_bytes(self.copy_source_encryption_key_sha256_bytes)
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
-            .set_object_checksums(self.object_checksums.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RewriteObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RewriteObjectRequest::new()
+                .set_destination_name(self.destination_name)
+                .set_destination_bucket(self.destination_bucket)
+                .set_destination_kms_key(self.destination_kms_key)
+                .set_destination(self.destination.map(|v| v.cnv()).transpose()?)
+                .set_source_bucket(self.source_bucket)
+                .set_source_object(self.source_object)
+                .set_source_generation(self.source_generation)
+                .set_rewrite_token(self.rewrite_token)
+                .set_destination_predefined_acl(self.destination_predefined_acl)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_generation_match(self.if_source_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_generation_not_match(self.if_source_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_metageneration_match(self.if_source_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_metageneration_not_match(self.if_source_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_max_bytes_rewritten_per_call(self.max_bytes_rewritten_per_call)
+                .set_copy_source_encryption_algorithm(self.copy_source_encryption_algorithm)
+                .set_copy_source_encryption_key_bytes(self.copy_source_encryption_key_bytes)
+                .set_copy_source_encryption_key_sha256_bytes(self.copy_source_encryption_key_sha256_bytes)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+                .set_object_checksums(self.object_checksums.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -452,13 +484,15 @@ impl gaxi::prost::ToProto<RewriteResponse> for crate::generated::gapic::model::R
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::RewriteResponse> for RewriteResponse {
-    fn cnv(self) -> crate::generated::gapic::model::RewriteResponse {
-        crate::generated::gapic::model::RewriteResponse::new()
-            .set_total_bytes_rewritten(self.total_bytes_rewritten)
-            .set_object_size(self.object_size)
-            .set_done(self.done)
-            .set_rewrite_token(self.rewrite_token)
-            .set_resource(self.resource.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::RewriteResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::RewriteResponse::new()
+                .set_total_bytes_rewritten(self.total_bytes_rewritten)
+                .set_object_size(self.object_size)
+                .set_done(self.done)
+                .set_rewrite_token(self.rewrite_token)
+                .set_resource(self.resource.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -482,19 +516,21 @@ impl gaxi::prost::ToProto<MoveObjectRequest> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::MoveObjectRequest> for MoveObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::MoveObjectRequest {
-        crate::generated::gapic::model::MoveObjectRequest::new()
-            .set_bucket(self.bucket)
-            .set_source_object(self.source_object)
-            .set_destination_object(self.destination_object)
-            .set_if_source_generation_match(self.if_source_generation_match.map(|v| v.cnv()))
-            .set_if_source_generation_not_match(self.if_source_generation_not_match.map(|v| v.cnv()))
-            .set_if_source_metageneration_match(self.if_source_metageneration_match.map(|v| v.cnv()))
-            .set_if_source_metageneration_not_match(self.if_source_metageneration_not_match.map(|v| v.cnv()))
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::MoveObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::MoveObjectRequest::new()
+                .set_bucket(self.bucket)
+                .set_source_object(self.source_object)
+                .set_destination_object(self.destination_object)
+                .set_if_source_generation_match(self.if_source_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_generation_not_match(self.if_source_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_metageneration_match(self.if_source_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_source_metageneration_not_match(self.if_source_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -515,16 +551,18 @@ impl gaxi::prost::ToProto<UpdateObjectRequest> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::UpdateObjectRequest> for UpdateObjectRequest {
-    fn cnv(self) -> crate::generated::gapic::model::UpdateObjectRequest {
-        crate::generated::gapic::model::UpdateObjectRequest::new()
-            .set_object(self.object.map(|v| v.cnv()))
-            .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()))
-            .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()))
-            .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()))
-            .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()))
-            .set_predefined_acl(self.predefined_acl)
-            .set_update_mask(self.update_mask.map(|v| v.cnv()))
-            .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::UpdateObjectRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::UpdateObjectRequest::new()
+                .set_object(self.object.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_match(self.if_generation_match.map(|v| v.cnv()).transpose()?)
+                .set_if_generation_not_match(self.if_generation_not_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_match(self.if_metageneration_match.map(|v| v.cnv()).transpose()?)
+                .set_if_metageneration_not_match(self.if_metageneration_not_match.map(|v| v.cnv()).transpose()?)
+                .set_predefined_acl(self.predefined_acl)
+                .set_update_mask(self.update_mask.map(|v| v.cnv()).transpose()?)
+                .set_common_object_request_params(self.common_object_request_params.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -540,11 +578,13 @@ impl gaxi::prost::ToProto<CommonObjectRequestParams> for crate::generated::gapic
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CommonObjectRequestParams> for CommonObjectRequestParams {
-    fn cnv(self) -> crate::generated::gapic::model::CommonObjectRequestParams {
-        crate::generated::gapic::model::CommonObjectRequestParams::new()
-            .set_encryption_algorithm(self.encryption_algorithm)
-            .set_encryption_key_bytes(self.encryption_key_bytes)
-            .set_encryption_key_sha256_bytes(self.encryption_key_sha256_bytes)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CommonObjectRequestParams, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CommonObjectRequestParams::new()
+                .set_encryption_algorithm(self.encryption_algorithm)
+                .set_encryption_key_bytes(self.encryption_key_bytes)
+                .set_encryption_key_sha256_bytes(self.encryption_key_sha256_bytes)
+        )
     }
 }
 
@@ -564,8 +604,10 @@ impl gaxi::prost::ToProto<ServiceConstants> for crate::generated::gapic::model::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ServiceConstants> for ServiceConstants {
-    fn cnv(self) -> crate::generated::gapic::model::ServiceConstants {
-        crate::generated::gapic::model::ServiceConstants::new()
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ServiceConstants, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ServiceConstants::new()
+        )
     }
 }
 
@@ -579,9 +621,11 @@ impl gaxi::prost::ToProto<bucket::Billing> for crate::generated::gapic::model::b
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Billing> for bucket::Billing {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Billing {
-        crate::generated::gapic::model::bucket::Billing::new()
-            .set_requester_pays(self.requester_pays)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Billing, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Billing::new()
+                .set_requester_pays(self.requester_pays)
+        )
     }
 }
 
@@ -607,12 +651,17 @@ impl gaxi::prost::ToProto<bucket::Cors> for crate::generated::gapic::model::buck
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Cors> for bucket::Cors {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Cors {
-        crate::generated::gapic::model::bucket::Cors::new()
-            .set_origin(self.origin.into_iter().map(|v| v.cnv()))
-            .set_method(self.method.into_iter().map(|v| v.cnv()))
-            .set_response_header(self.response_header.into_iter().map(|v| v.cnv()))
-            .set_max_age_seconds(self.max_age_seconds)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Cors, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Cors::new()
+                .set_origin(self.origin.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_method(self.method.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_response_header(self.response_header.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_max_age_seconds(self.max_age_seconds)
+        )
     }
 }
 
@@ -626,9 +675,11 @@ impl gaxi::prost::ToProto<bucket::Encryption> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Encryption> for bucket::Encryption {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Encryption {
-        crate::generated::gapic::model::bucket::Encryption::new()
-            .set_default_kms_key(self.default_kms_key)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Encryption, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Encryption::new()
+                .set_default_kms_key(self.default_kms_key)
+        )
     }
 }
 
@@ -643,10 +694,12 @@ impl gaxi::prost::ToProto<bucket::iam_config::UniformBucketLevelAccess> for crat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::iam_config::UniformBucketLevelAccess> for bucket::iam_config::UniformBucketLevelAccess {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::iam_config::UniformBucketLevelAccess {
-        crate::generated::gapic::model::bucket::iam_config::UniformBucketLevelAccess::new()
-            .set_enabled(self.enabled)
-            .set_lock_time(self.lock_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::iam_config::UniformBucketLevelAccess, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::iam_config::UniformBucketLevelAccess::new()
+                .set_enabled(self.enabled)
+                .set_lock_time(self.lock_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -661,10 +714,12 @@ impl gaxi::prost::ToProto<bucket::IamConfig> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::IamConfig> for bucket::IamConfig {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::IamConfig {
-        crate::generated::gapic::model::bucket::IamConfig::new()
-            .set_uniform_bucket_level_access(self.uniform_bucket_level_access.map(|v| v.cnv()))
-            .set_public_access_prevention(self.public_access_prevention)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::IamConfig, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::IamConfig::new()
+                .set_uniform_bucket_level_access(self.uniform_bucket_level_access.map(|v| v.cnv()).transpose()?)
+                .set_public_access_prevention(self.public_access_prevention)
+        )
     }
 }
 
@@ -679,10 +734,12 @@ impl gaxi::prost::ToProto<bucket::lifecycle::rule::Action> for crate::generated:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::lifecycle::rule::Action> for bucket::lifecycle::rule::Action {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::lifecycle::rule::Action {
-        crate::generated::gapic::model::bucket::lifecycle::rule::Action::new()
-            .set_type(self.r#type)
-            .set_storage_class(self.storage_class)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::lifecycle::rule::Action, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::lifecycle::rule::Action::new()
+                .set_type(self.r#type)
+                .set_storage_class(self.storage_class)
+        )
     }
 }
 
@@ -715,19 +772,24 @@ impl gaxi::prost::ToProto<bucket::lifecycle::rule::Condition> for crate::generat
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::lifecycle::rule::Condition> for bucket::lifecycle::rule::Condition {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::lifecycle::rule::Condition {
-        crate::generated::gapic::model::bucket::lifecycle::rule::Condition::new()
-            .set_age_days(self.age_days.map(|v| v.cnv()))
-            .set_created_before(self.created_before.map(|v| v.cnv()))
-            .set_is_live(self.is_live.map(|v| v.cnv()))
-            .set_num_newer_versions(self.num_newer_versions.map(|v| v.cnv()))
-            .set_matches_storage_class(self.matches_storage_class.into_iter().map(|v| v.cnv()))
-            .set_days_since_custom_time(self.days_since_custom_time.map(|v| v.cnv()))
-            .set_custom_time_before(self.custom_time_before.map(|v| v.cnv()))
-            .set_days_since_noncurrent_time(self.days_since_noncurrent_time.map(|v| v.cnv()))
-            .set_noncurrent_time_before(self.noncurrent_time_before.map(|v| v.cnv()))
-            .set_matches_prefix(self.matches_prefix.into_iter().map(|v| v.cnv()))
-            .set_matches_suffix(self.matches_suffix.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::lifecycle::rule::Condition, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::lifecycle::rule::Condition::new()
+                .set_age_days(self.age_days.map(|v| v.cnv()).transpose()?)
+                .set_created_before(self.created_before.map(|v| v.cnv()).transpose()?)
+                .set_is_live(self.is_live.map(|v| v.cnv()).transpose()?)
+                .set_num_newer_versions(self.num_newer_versions.map(|v| v.cnv()).transpose()?)
+                .set_matches_storage_class(self.matches_storage_class.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_days_since_custom_time(self.days_since_custom_time.map(|v| v.cnv()).transpose()?)
+                .set_custom_time_before(self.custom_time_before.map(|v| v.cnv()).transpose()?)
+                .set_days_since_noncurrent_time(self.days_since_noncurrent_time.map(|v| v.cnv()).transpose()?)
+                .set_noncurrent_time_before(self.noncurrent_time_before.map(|v| v.cnv()).transpose()?)
+                .set_matches_prefix(self.matches_prefix.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_matches_suffix(self.matches_suffix.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -742,10 +804,12 @@ impl gaxi::prost::ToProto<bucket::lifecycle::Rule> for crate::generated::gapic::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::lifecycle::Rule> for bucket::lifecycle::Rule {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::lifecycle::Rule {
-        crate::generated::gapic::model::bucket::lifecycle::Rule::new()
-            .set_action(self.action.map(|v| v.cnv()))
-            .set_condition(self.condition.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::lifecycle::Rule, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::lifecycle::Rule::new()
+                .set_action(self.action.map(|v| v.cnv()).transpose()?)
+                .set_condition(self.condition.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -762,9 +826,12 @@ impl gaxi::prost::ToProto<bucket::Lifecycle> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Lifecycle> for bucket::Lifecycle {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Lifecycle {
-        crate::generated::gapic::model::bucket::Lifecycle::new()
-            .set_rule(self.rule.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Lifecycle, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Lifecycle::new()
+                .set_rule(self.rule.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -779,10 +846,12 @@ impl gaxi::prost::ToProto<bucket::Logging> for crate::generated::gapic::model::b
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Logging> for bucket::Logging {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Logging {
-        crate::generated::gapic::model::bucket::Logging::new()
-            .set_log_bucket(self.log_bucket)
-            .set_log_object_prefix(self.log_object_prefix)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Logging, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Logging::new()
+                .set_log_bucket(self.log_bucket)
+                .set_log_object_prefix(self.log_object_prefix)
+        )
     }
 }
 
@@ -798,11 +867,13 @@ impl gaxi::prost::ToProto<bucket::RetentionPolicy> for crate::generated::gapic::
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::RetentionPolicy> for bucket::RetentionPolicy {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::RetentionPolicy {
-        crate::generated::gapic::model::bucket::RetentionPolicy::new()
-            .set_effective_time(self.effective_time.map(|v| v.cnv()))
-            .set_is_locked(self.is_locked)
-            .set_retention_duration(self.retention_duration.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::RetentionPolicy, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::RetentionPolicy::new()
+                .set_effective_time(self.effective_time.map(|v| v.cnv()).transpose()?)
+                .set_is_locked(self.is_locked)
+                .set_retention_duration(self.retention_duration.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -817,10 +888,12 @@ impl gaxi::prost::ToProto<bucket::SoftDeletePolicy> for crate::generated::gapic:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::SoftDeletePolicy> for bucket::SoftDeletePolicy {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::SoftDeletePolicy {
-        crate::generated::gapic::model::bucket::SoftDeletePolicy::new()
-            .set_retention_duration(self.retention_duration.map(|v| v.cnv()))
-            .set_effective_time(self.effective_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::SoftDeletePolicy, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::SoftDeletePolicy::new()
+                .set_retention_duration(self.retention_duration.map(|v| v.cnv()).transpose()?)
+                .set_effective_time(self.effective_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -834,9 +907,11 @@ impl gaxi::prost::ToProto<bucket::Versioning> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Versioning> for bucket::Versioning {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Versioning {
-        crate::generated::gapic::model::bucket::Versioning::new()
-            .set_enabled(self.enabled)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Versioning, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Versioning::new()
+                .set_enabled(self.enabled)
+        )
     }
 }
 
@@ -851,10 +926,12 @@ impl gaxi::prost::ToProto<bucket::Website> for crate::generated::gapic::model::b
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Website> for bucket::Website {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Website {
-        crate::generated::gapic::model::bucket::Website::new()
-            .set_main_page_suffix(self.main_page_suffix)
-            .set_not_found_page(self.not_found_page)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Website, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Website::new()
+                .set_main_page_suffix(self.main_page_suffix)
+                .set_not_found_page(self.not_found_page)
+        )
     }
 }
 
@@ -871,9 +948,12 @@ impl gaxi::prost::ToProto<bucket::CustomPlacementConfig> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::CustomPlacementConfig> for bucket::CustomPlacementConfig {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::CustomPlacementConfig {
-        crate::generated::gapic::model::bucket::CustomPlacementConfig::new()
-            .set_data_locations(self.data_locations.into_iter().map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::CustomPlacementConfig, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::CustomPlacementConfig::new()
+                .set_data_locations(self.data_locations.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+        )
     }
 }
 
@@ -890,12 +970,14 @@ impl gaxi::prost::ToProto<bucket::Autoclass> for crate::generated::gapic::model:
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::Autoclass> for bucket::Autoclass {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::Autoclass {
-        crate::generated::gapic::model::bucket::Autoclass::new()
-            .set_enabled(self.enabled)
-            .set_toggle_time(self.toggle_time.map(|v| v.cnv()))
-            .set_terminal_storage_class(self.terminal_storage_class.map(|v| v.cnv()))
-            .set_terminal_storage_class_update_time(self.terminal_storage_class_update_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::Autoclass, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::Autoclass::new()
+                .set_enabled(self.enabled)
+                .set_toggle_time(self.toggle_time.map(|v| v.cnv()).transpose()?)
+                .set_terminal_storage_class(self.terminal_storage_class.map(|v| v.cnv()).transpose()?)
+                .set_terminal_storage_class_update_time(self.terminal_storage_class_update_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -909,9 +991,11 @@ impl gaxi::prost::ToProto<bucket::HierarchicalNamespace> for crate::generated::g
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::bucket::HierarchicalNamespace> for bucket::HierarchicalNamespace {
-    fn cnv(self) -> crate::generated::gapic::model::bucket::HierarchicalNamespace {
-        crate::generated::gapic::model::bucket::HierarchicalNamespace::new()
-            .set_enabled(self.enabled)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::bucket::HierarchicalNamespace, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::bucket::HierarchicalNamespace::new()
+                .set_enabled(self.enabled)
+        )
     }
 }
 
@@ -967,38 +1051,46 @@ impl gaxi::prost::ToProto<Bucket> for crate::generated::gapic::model::Bucket {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Bucket> for Bucket {
-    fn cnv(self) -> crate::generated::gapic::model::Bucket {
-        crate::generated::gapic::model::Bucket::new()
-            .set_name(self.name)
-            .set_bucket_id(self.bucket_id)
-            .set_etag(self.etag)
-            .set_project(self.project)
-            .set_metageneration(self.metageneration)
-            .set_location(self.location)
-            .set_location_type(self.location_type)
-            .set_storage_class(self.storage_class)
-            .set_rpo(self.rpo)
-            .set_acl(self.acl.into_iter().map(|v| v.cnv()))
-            .set_default_object_acl(self.default_object_acl.into_iter().map(|v| v.cnv()))
-            .set_lifecycle(self.lifecycle.map(|v| v.cnv()))
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_cors(self.cors.into_iter().map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_default_event_based_hold(self.default_event_based_hold)
-            .set_labels(self.labels.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            .set_website(self.website.map(|v| v.cnv()))
-            .set_versioning(self.versioning.map(|v| v.cnv()))
-            .set_logging(self.logging.map(|v| v.cnv()))
-            .set_owner(self.owner.map(|v| v.cnv()))
-            .set_encryption(self.encryption.map(|v| v.cnv()))
-            .set_billing(self.billing.map(|v| v.cnv()))
-            .set_retention_policy(self.retention_policy.map(|v| v.cnv()))
-            .set_iam_config(self.iam_config.map(|v| v.cnv()))
-            .set_satisfies_pzs(self.satisfies_pzs)
-            .set_custom_placement_config(self.custom_placement_config.map(|v| v.cnv()))
-            .set_autoclass(self.autoclass.map(|v| v.cnv()))
-            .set_hierarchical_namespace(self.hierarchical_namespace.map(|v| v.cnv()))
-            .set_soft_delete_policy(self.soft_delete_policy.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Bucket, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Bucket::new()
+                .set_name(self.name)
+                .set_bucket_id(self.bucket_id)
+                .set_etag(self.etag)
+                .set_project(self.project)
+                .set_metageneration(self.metageneration)
+                .set_location(self.location)
+                .set_location_type(self.location_type)
+                .set_storage_class(self.storage_class)
+                .set_rpo(self.rpo)
+                .set_acl(self.acl.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_default_object_acl(self.default_object_acl.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_lifecycle(self.lifecycle.map(|v| v.cnv()).transpose()?)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_cors(self.cors.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_default_event_based_hold(self.default_event_based_hold)
+                .set_labels(self.labels.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                .set_website(self.website.map(|v| v.cnv()).transpose()?)
+                .set_versioning(self.versioning.map(|v| v.cnv()).transpose()?)
+                .set_logging(self.logging.map(|v| v.cnv()).transpose()?)
+                .set_owner(self.owner.map(|v| v.cnv()).transpose()?)
+                .set_encryption(self.encryption.map(|v| v.cnv()).transpose()?)
+                .set_billing(self.billing.map(|v| v.cnv()).transpose()?)
+                .set_retention_policy(self.retention_policy.map(|v| v.cnv()).transpose()?)
+                .set_iam_config(self.iam_config.map(|v| v.cnv()).transpose()?)
+                .set_satisfies_pzs(self.satisfies_pzs)
+                .set_custom_placement_config(self.custom_placement_config.map(|v| v.cnv()).transpose()?)
+                .set_autoclass(self.autoclass.map(|v| v.cnv()).transpose()?)
+                .set_hierarchical_namespace(self.hierarchical_namespace.map(|v| v.cnv()).transpose()?)
+                .set_soft_delete_policy(self.soft_delete_policy.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1020,17 +1112,19 @@ impl gaxi::prost::ToProto<BucketAccessControl> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::BucketAccessControl> for BucketAccessControl {
-    fn cnv(self) -> crate::generated::gapic::model::BucketAccessControl {
-        crate::generated::gapic::model::BucketAccessControl::new()
-            .set_role(self.role)
-            .set_id(self.id)
-            .set_entity(self.entity)
-            .set_entity_alt(self.entity_alt)
-            .set_entity_id(self.entity_id)
-            .set_etag(self.etag)
-            .set_email(self.email)
-            .set_domain(self.domain)
-            .set_project_team(self.project_team.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::BucketAccessControl, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::BucketAccessControl::new()
+                .set_role(self.role)
+                .set_id(self.id)
+                .set_entity(self.entity)
+                .set_entity_alt(self.entity_alt)
+                .set_entity_id(self.entity_id)
+                .set_etag(self.etag)
+                .set_email(self.email)
+                .set_domain(self.domain)
+                .set_project_team(self.project_team.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1045,10 +1139,12 @@ impl gaxi::prost::ToProto<ObjectChecksums> for crate::generated::gapic::model::O
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ObjectChecksums> for ObjectChecksums {
-    fn cnv(self) -> crate::generated::gapic::model::ObjectChecksums {
-        crate::generated::gapic::model::ObjectChecksums::new()
-            .set_crc32c(self.crc32c.map(|v| v.cnv()))
-            .set_md5_hash(self.md5_hash)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ObjectChecksums, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ObjectChecksums::new()
+                .set_crc32c(self.crc32c.map(|v| v.cnv()).transpose()?)
+                .set_md5_hash(self.md5_hash)
+        )
     }
 }
 
@@ -1063,10 +1159,12 @@ impl gaxi::prost::ToProto<CustomerEncryption> for crate::generated::gapic::model
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::CustomerEncryption> for CustomerEncryption {
-    fn cnv(self) -> crate::generated::gapic::model::CustomerEncryption {
-        crate::generated::gapic::model::CustomerEncryption::new()
-            .set_encryption_algorithm(self.encryption_algorithm)
-            .set_key_sha256_bytes(self.key_sha256_bytes)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::CustomerEncryption, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::CustomerEncryption::new()
+                .set_encryption_algorithm(self.encryption_algorithm)
+                .set_key_sha256_bytes(self.key_sha256_bytes)
+        )
     }
 }
 
@@ -1117,39 +1215,45 @@ impl gaxi::prost::ToProto<Object> for crate::generated::gapic::model::Object {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Object> for Object {
-    fn cnv(self) -> crate::generated::gapic::model::Object {
-        crate::generated::gapic::model::Object::new()
-            .set_name(self.name)
-            .set_bucket(self.bucket)
-            .set_etag(self.etag)
-            .set_generation(self.generation)
-            .set_restore_token(self.restore_token.map(|v| v.cnv()))
-            .set_metageneration(self.metageneration)
-            .set_storage_class(self.storage_class)
-            .set_size(self.size)
-            .set_content_encoding(self.content_encoding)
-            .set_content_disposition(self.content_disposition)
-            .set_cache_control(self.cache_control)
-            .set_acl(self.acl.into_iter().map(|v| v.cnv()))
-            .set_content_language(self.content_language)
-            .set_delete_time(self.delete_time.map(|v| v.cnv()))
-            .set_finalize_time(self.finalize_time.map(|v| v.cnv()))
-            .set_content_type(self.content_type)
-            .set_create_time(self.create_time.map(|v| v.cnv()))
-            .set_component_count(self.component_count)
-            .set_checksums(self.checksums.map(|v| v.cnv()))
-            .set_update_time(self.update_time.map(|v| v.cnv()))
-            .set_kms_key(self.kms_key)
-            .set_update_storage_class_time(self.update_storage_class_time.map(|v| v.cnv()))
-            .set_temporary_hold(self.temporary_hold)
-            .set_retention_expire_time(self.retention_expire_time.map(|v| v.cnv()))
-            .set_metadata(self.metadata.into_iter().map(|(k, v)| (k.cnv(), v.cnv())))
-            .set_event_based_hold(self.event_based_hold.map(|v| v.cnv()))
-            .set_owner(self.owner.map(|v| v.cnv()))
-            .set_customer_encryption(self.customer_encryption.map(|v| v.cnv()))
-            .set_custom_time(self.custom_time.map(|v| v.cnv()))
-            .set_soft_delete_time(self.soft_delete_time.map(|v| v.cnv()))
-            .set_hard_delete_time(self.hard_delete_time.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Object, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Object::new()
+                .set_name(self.name)
+                .set_bucket(self.bucket)
+                .set_etag(self.etag)
+                .set_generation(self.generation)
+                .set_restore_token(self.restore_token.map(|v| v.cnv()).transpose()?)
+                .set_metageneration(self.metageneration)
+                .set_storage_class(self.storage_class)
+                .set_size(self.size)
+                .set_content_encoding(self.content_encoding)
+                .set_content_disposition(self.content_disposition)
+                .set_cache_control(self.cache_control)
+                .set_acl(self.acl.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_content_language(self.content_language)
+                .set_delete_time(self.delete_time.map(|v| v.cnv()).transpose()?)
+                .set_finalize_time(self.finalize_time.map(|v| v.cnv()).transpose()?)
+                .set_content_type(self.content_type)
+                .set_create_time(self.create_time.map(|v| v.cnv()).transpose()?)
+                .set_component_count(self.component_count)
+                .set_checksums(self.checksums.map(|v| v.cnv()).transpose()?)
+                .set_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
+                .set_kms_key(self.kms_key)
+                .set_update_storage_class_time(self.update_storage_class_time.map(|v| v.cnv()).transpose()?)
+                .set_temporary_hold(self.temporary_hold)
+                .set_retention_expire_time(self.retention_expire_time.map(|v| v.cnv()).transpose()?)
+                .set_metadata(self.metadata.into_iter()
+                    .map(|(k, v)| {
+                        gaxi::prost::pair_transpose(k.cnv(), v.cnv())
+                    }).collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()?)
+                .set_event_based_hold(self.event_based_hold.map(|v| v.cnv()).transpose()?)
+                .set_owner(self.owner.map(|v| v.cnv()).transpose()?)
+                .set_customer_encryption(self.customer_encryption.map(|v| v.cnv()).transpose()?)
+                .set_custom_time(self.custom_time.map(|v| v.cnv()).transpose()?)
+                .set_soft_delete_time(self.soft_delete_time.map(|v| v.cnv()).transpose()?)
+                .set_hard_delete_time(self.hard_delete_time.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1171,17 +1275,19 @@ impl gaxi::prost::ToProto<ObjectAccessControl> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ObjectAccessControl> for ObjectAccessControl {
-    fn cnv(self) -> crate::generated::gapic::model::ObjectAccessControl {
-        crate::generated::gapic::model::ObjectAccessControl::new()
-            .set_role(self.role)
-            .set_id(self.id)
-            .set_entity(self.entity)
-            .set_entity_alt(self.entity_alt)
-            .set_entity_id(self.entity_id)
-            .set_etag(self.etag)
-            .set_email(self.email)
-            .set_domain(self.domain)
-            .set_project_team(self.project_team.map(|v| v.cnv()))
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ObjectAccessControl, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ObjectAccessControl::new()
+                .set_role(self.role)
+                .set_id(self.id)
+                .set_entity(self.entity)
+                .set_entity_alt(self.entity_alt)
+                .set_entity_id(self.entity_id)
+                .set_etag(self.etag)
+                .set_email(self.email)
+                .set_domain(self.domain)
+                .set_project_team(self.project_team.map(|v| v.cnv()).transpose()?)
+        )
     }
 }
 
@@ -1203,11 +1309,15 @@ impl gaxi::prost::ToProto<ListObjectsResponse> for crate::generated::gapic::mode
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ListObjectsResponse> for ListObjectsResponse {
-    fn cnv(self) -> crate::generated::gapic::model::ListObjectsResponse {
-        crate::generated::gapic::model::ListObjectsResponse::new()
-            .set_objects(self.objects.into_iter().map(|v| v.cnv()))
-            .set_prefixes(self.prefixes.into_iter().map(|v| v.cnv()))
-            .set_next_page_token(self.next_page_token)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ListObjectsResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ListObjectsResponse::new()
+                .set_objects(self.objects.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_prefixes(self.prefixes.into_iter().map(|v| v.cnv())
+                    .collect::<std::result::Result<std::vec::Vec<_>, _>>()?)
+                .set_next_page_token(self.next_page_token)
+        )
     }
 }
 
@@ -1222,10 +1332,12 @@ impl gaxi::prost::ToProto<ProjectTeam> for crate::generated::gapic::model::Proje
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ProjectTeam> for ProjectTeam {
-    fn cnv(self) -> crate::generated::gapic::model::ProjectTeam {
-        crate::generated::gapic::model::ProjectTeam::new()
-            .set_project_number(self.project_number)
-            .set_team(self.team)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ProjectTeam, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ProjectTeam::new()
+                .set_project_number(self.project_number)
+                .set_team(self.team)
+        )
     }
 }
 
@@ -1240,10 +1352,12 @@ impl gaxi::prost::ToProto<Owner> for crate::generated::gapic::model::Owner {
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::Owner> for Owner {
-    fn cnv(self) -> crate::generated::gapic::model::Owner {
-        crate::generated::gapic::model::Owner::new()
-            .set_entity(self.entity)
-            .set_entity_id(self.entity_id)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::Owner, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::Owner::new()
+                .set_entity(self.entity)
+                .set_entity_id(self.entity_id)
+        )
     }
 }
 
@@ -1259,10 +1373,12 @@ impl gaxi::prost::ToProto<ContentRange> for crate::generated::gapic::model::Cont
 }
 
 impl gaxi::prost::FromProto<crate::generated::gapic::model::ContentRange> for ContentRange {
-    fn cnv(self) -> crate::generated::gapic::model::ContentRange {
-        crate::generated::gapic::model::ContentRange::new()
-            .set_start(self.start)
-            .set_end(self.end)
-            .set_complete_length(self.complete_length)
+    fn cnv(self) -> std::result::Result<crate::generated::gapic::model::ContentRange, gaxi::prost::ConvertError> {
+        Ok(
+            crate::generated::gapic::model::ContentRange::new()
+                .set_start(self.start)
+                .set_end(self.end)
+                .set_complete_length(self.complete_length)
+        )
     }
 }

--- a/src/storage-control/src/generated/convert/type/convert.rs
+++ b/src/storage-control/src/generated/convert/type/convert.rs
@@ -26,11 +26,13 @@ impl gaxi::prost::ToProto<Date> for gtype::model::Date {
 }
 
 impl gaxi::prost::FromProto<gtype::model::Date> for Date {
-    fn cnv(self) -> gtype::model::Date {
-        gtype::model::Date::new()
-            .set_year(self.year)
-            .set_month(self.month)
-            .set_day(self.day)
+    fn cnv(self) -> std::result::Result<gtype::model::Date, gaxi::prost::ConvertError> {
+        Ok(
+            gtype::model::Date::new()
+                .set_year(self.year)
+                .set_month(self.month)
+                .set_day(self.day)
+        )
     }
 }
 
@@ -47,11 +49,13 @@ impl gaxi::prost::ToProto<Expr> for gtype::model::Expr {
 }
 
 impl gaxi::prost::FromProto<gtype::model::Expr> for Expr {
-    fn cnv(self) -> gtype::model::Expr {
-        gtype::model::Expr::new()
-            .set_expression(self.expression)
-            .set_title(self.title)
-            .set_description(self.description)
-            .set_location(self.location)
+    fn cnv(self) -> std::result::Result<gtype::model::Expr, gaxi::prost::ConvertError> {
+        Ok(
+            gtype::model::Expr::new()
+                .set_expression(self.expression)
+                .set_title(self.title)
+                .set_description(self.description)
+                .set_location(self.location)
+        )
     }
 }

--- a/src/storage-control/src/lib.rs
+++ b/src/storage-control/src/lib.rs
@@ -88,11 +88,13 @@ impl gaxi::prost::ToProto<google::rpc::Status> for rpc::model::Status {
 }
 
 impl gaxi::prost::FromProto<rpc::model::Status> for google::rpc::Status {
-    fn cnv(self) -> rpc::model::Status {
-        rpc::model::Status::new()
-            .set_code(self.code)
-            .set_message(self.message)
-        // TODO(#1699) - detail with the error details
-        // .set_details(self.details.into_iter().filter_map(any_from_prost))
+    fn cnv(self) -> std::result::Result<rpc::model::Status, gaxi::prost::ConvertError> {
+        Ok(
+            rpc::model::Status::new()
+                .set_code(self.code)
+                .set_message(self.message),
+            // TODO(#1699) - detail with the error details
+            // .set_details(self.details.into_iter().filter_map(any_from_prost))
+        )
     }
 }


### PR DESCRIPTION
Part of the work for #2037 

We want to use the existing to/from proto traits when converting LROs.

In order to convert from a `prost_types::Any` -> `wkt::Any`, we need to match on type IDs, deserialize a prost message, convert it to our of our types, then pack it into our `Any`.

Many of these steps can fail. So we need our convert from proto function to potentially return an error.

I left myself one TODO (in `to_gax_response`) related to the refactor to break down this already unruly PR. `unwrap()`ing is currently fine, because we only return `Ok()`. I will fix in a follow up.

The diff for `convert.rs` is fairly poor. Sorry.