### PR TITLE
ci(auth): deflake UC test

### DIFF
--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -694,6 +694,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn token_provider_full() -> TestResult {
+        let now = std::time::Instant::now();
         let response = Oauth2RefreshResponse {
             access_token: "test-access-token".to_string(),
             expires_in: Some(3600),
@@ -717,7 +718,6 @@ mod test {
             .with_scopes(vec!["scope1", "scope2"])
             .build()?;
 
-        let now = std::time::Instant::now();
         let token = cred.token(Extensions::new()).await?;
         assert_eq!(token.token, "test-access-token");
         assert_eq!(token.token_type, "test-token-type");


### PR DESCRIPTION
Fixes #2119 

When we switched to the builder pattern, we started including the token cache, which fetches a token upon credential creation, not just on calls for the `token()`.

We were comparing the expiration time to a time from between when the credentials are created and from when we ask for a token.

We want to compare the expiration time to a time from before the credentials are created.