### PR TITLE
ci(auth): reuse PKs in test

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -652,11 +652,12 @@ mod test {
     use rsa::pkcs8::{EncodePrivateKey, LineEnding};
     use scoped_env::ScopedEnv;
     use std::error::Error;
+    use std::sync::LazyLock;
     use test_case::test_case;
 
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-    pub fn generate_pkcs8_private_key() -> String {
+    pub static PKCS8_PK: LazyLock<String> = LazyLock::new(|| {
         let mut rng = rand::thread_rng();
         let bits = 2048;
         let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
@@ -664,7 +665,7 @@ mod test {
             .to_pkcs8_pem(LineEnding::LF)
             .expect("Failed to encode key to PKCS#8 PEM")
             .to_string()
-    }
+    });
 
     pub fn b64_decode_to_json(s: String) -> serde_json::Value {
         let decoded = String::from_utf8(
@@ -838,7 +839,7 @@ mod test {
         let scopes =
             ["https://www.googleapis.com/auth/pubsub, https://www.googleapis.com/auth/translate"];
 
-        service_account_key["private_key"] = Value::from(generate_pkcs8_private_key());
+        service_account_key["private_key"] = Value::from(PKCS8_PK.clone());
 
         let sac = Builder::new(service_account_key)
             .with_quota_project_id("test-quota-project")


### PR DESCRIPTION
Motivated by #2121 

Only generate private keys for test once.

This doesn't fix the flake, as generating the initial keys could take > 60s, which is our test timeout.

Anecdotally, this does make `cargo test -p google-cloud-auth` run significantly faster. My last run was 21s vs. 52s at HEAD. All 20s go to generating the key.