### PR TITLE
cleanup(gaxi): tonic response conversion

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -131,24 +131,23 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         ].into_iter().fold(String::new(), |b, p| b + "&" + &p);
         {{/HasRouting}}
 
+        {{#ReturnsEmpty}}
+        type TR = ();
+        {{/ReturnsEmpty}}
+        {{^ReturnsEmpty}}
+        type TR = crate::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}};
+        {{/ReturnsEmpty}}
         self.inner
-          .execute(
-              extensions,
-              path,
-              req.to_proto().map_err(Error::other)?,
-              options,
-              &info::X_GOOG_API_CLIENT_HEADER,
-              &x_goog_request_params,
-          )
-          .await
-          .map(gaxi::grpc::to_gax_response::<
-          {{#ReturnsEmpty}}
-          (),
-          {{/ReturnsEmpty}}
-          {{^ReturnsEmpty}}
-          crate::{{OutputType.Codec.PackageModuleName}}::{{OutputType.Codec.Name}},
-          {{/ReturnsEmpty}}
-          {{Codec.ReturnType}}>)
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::other)?,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, {{Codec.ReturnType}}>)
     }
 
     {{/Codec.Methods}}

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -78,6 +78,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::Document;
         self.inner
             .execute(
                 extensions,
@@ -88,12 +89,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::Document,
-                    crate::model::Document,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Document>)
     }
 
     async fn list_documents(
@@ -120,6 +116,7 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::ListDocumentsResponse;
         self.inner
             .execute(
                 extensions,
@@ -130,12 +127,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::ListDocumentsResponse,
-                    crate::model::ListDocumentsResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListDocumentsResponse>)
     }
 
     async fn update_document(
@@ -165,6 +157,7 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::Document;
         self.inner
             .execute(
                 extensions,
@@ -175,12 +168,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::Document,
-                    crate::model::Document,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Document>)
     }
 
     async fn delete_document(
@@ -204,6 +192,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -214,7 +203,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn begin_transaction(
@@ -238,6 +227,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::BeginTransactionResponse;
         self.inner
             .execute(
                 extensions,
@@ -248,12 +238,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::BeginTransactionResponse,
-                    crate::model::BeginTransactionResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::BeginTransactionResponse>)
     }
 
     async fn commit(
@@ -276,6 +261,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::CommitResponse;
         self.inner
             .execute(
                 extensions,
@@ -286,12 +272,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::CommitResponse,
-                    crate::model::CommitResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::CommitResponse>)
     }
 
     async fn rollback(
@@ -314,6 +295,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -324,7 +306,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn partition_query(
@@ -348,6 +330,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::PartitionQueryResponse;
         self.inner
             .execute(
                 extensions,
@@ -358,12 +341,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::PartitionQueryResponse,
-                    crate::model::PartitionQueryResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::PartitionQueryResponse>)
     }
 
     async fn list_collection_ids(
@@ -388,6 +366,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::ListCollectionIdsResponse;
         self.inner
             .execute(
                 extensions,
@@ -398,12 +377,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::ListCollectionIdsResponse,
-                    crate::model::ListCollectionIdsResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListCollectionIdsResponse>)
     }
 
     async fn batch_write(
@@ -427,6 +401,7 @@ impl super::stub::Firestore for Firestore {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::BatchWriteResponse;
         self.inner
             .execute(
                 extensions,
@@ -437,12 +412,7 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::BatchWriteResponse,
-                    crate::model::BatchWriteResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::BatchWriteResponse>)
     }
 
     async fn create_document(
@@ -469,6 +439,7 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::firestore::v1::Document;
         self.inner
             .execute(
                 extensions,
@@ -479,11 +450,6 @@ impl super::stub::Firestore for Firestore {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::firestore::v1::Document,
-                    crate::model::Document,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Document>)
     }
 }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -241,14 +241,13 @@ impl Client {
 
 /// Convert a `tonic::Response` wrapping a prost message into a
 /// `gax::response::Response` wrapping our equivalent message
-pub fn to_gax_response<T, G>(response: tonic::Response<T>) -> gax::response::Response<G>
+pub fn to_gax_response<T, G>(response: tonic::Response<T>) -> Result<gax::response::Response<G>>
 where
     T: crate::prost::FromProto<G>,
 {
     let (metadata, body, _extensions) = response.into_parts();
-    gax::response::Response::from_parts(
+    Ok(gax::response::Response::from_parts(
         gax::response::Parts::new().set_headers(metadata.into_headers()),
-        // TODO(#2037) - handle conversion from proto errors.
-        body.cnv().unwrap(),
-    )
+        body.cnv().map_err(Error::other)?,
+    ))
 }

--- a/src/gax-internal/tests/grpc_convert.rs
+++ b/src/gax-internal/tests/grpc_convert.rs
@@ -20,7 +20,7 @@ mod test {
     use tonic::metadata::MetadataMap;
 
     #[test]
-    fn test_to_gax_response() {
+    fn test_to_gax_response() -> anyhow::Result<()> {
         let tonic_body = prost_types::Duration {
             seconds: 123,
             nanos: 456,
@@ -33,7 +33,7 @@ mod test {
             tonic::Extensions::new(),
         );
 
-        let gax_response = grpc::to_gax_response(tonic_response);
+        let gax_response = grpc::to_gax_response(tonic_response)?;
         assert_eq!(
             gax_response.body().to_owned(),
             wkt::Duration::clamp(123, 456)
@@ -42,5 +42,7 @@ mod test {
             gax_response.headers().to_owned(),
             tonic_headers.into_headers()
         );
+
+        Ok(())
     }
 }

--- a/src/storage-control/src/generated/gapic/transport.rs
+++ b/src/storage-control/src/generated/gapic/transport.rs
@@ -84,6 +84,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -94,7 +95,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn get_bucket(
@@ -124,6 +125,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Bucket;
         self.inner
             .execute(
                 extensions,
@@ -134,12 +136,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Bucket,
-                    crate::model::Bucket,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Bucket>)
     }
 
     async fn create_bucket(
@@ -179,6 +176,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("project", v))])
         };
 
+        type TR = crate::google::storage::v2::Bucket;
         self.inner
             .execute(
                 extensions,
@@ -189,12 +187,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Bucket,
-                    crate::model::Bucket,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Bucket>)
     }
 
     async fn list_buckets(
@@ -224,6 +217,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("project", v))])
         };
 
+        type TR = crate::google::storage::v2::ListBucketsResponse;
         self.inner
             .execute(
                 extensions,
@@ -234,12 +228,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::ListBucketsResponse,
-                    crate::model::ListBucketsResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListBucketsResponse>)
     }
 
     async fn lock_bucket_retention_policy(
@@ -271,6 +260,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Bucket;
         self.inner
             .execute(
                 extensions,
@@ -281,12 +271,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Bucket,
-                    crate::model::Bucket,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Bucket>)
     }
 
     async fn get_iam_policy(
@@ -316,19 +301,18 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::iam::v1::Policy;
         self.inner
-          .execute(
-              extensions,
-              path,
-              req.to_proto().map_err(Error::other)?,
-              options,
-              &info::X_GOOG_API_CLIENT_HEADER,
-              &x_goog_request_params,
-          )
-          .await
-          .map(gaxi::grpc::to_gax_response::<
-          crate::google::iam::v1::Policy,
-          iam_v1::model::Policy>)
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::other)?,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, iam_v1::model::Policy>)
     }
 
     async fn set_iam_policy(
@@ -358,19 +342,18 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::iam::v1::Policy;
         self.inner
-          .execute(
-              extensions,
-              path,
-              req.to_proto().map_err(Error::other)?,
-              options,
-              &info::X_GOOG_API_CLIENT_HEADER,
-              &x_goog_request_params,
-          )
-          .await
-          .map(gaxi::grpc::to_gax_response::<
-          crate::google::iam::v1::Policy,
-          iam_v1::model::Policy>)
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::other)?,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, iam_v1::model::Policy>)
     }
 
     async fn test_iam_permissions(
@@ -436,6 +419,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::iam::v1::TestIamPermissionsResponse;
         self.inner
             .execute(
                 extensions,
@@ -446,12 +430,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::iam::v1::TestIamPermissionsResponse,
-                    iam_v1::model::TestIamPermissionsResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, iam_v1::model::TestIamPermissionsResponse>)
     }
 
     async fn update_bucket(
@@ -483,6 +462,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Bucket;
         self.inner
             .execute(
                 extensions,
@@ -493,12 +473,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Bucket,
-                    crate::model::Bucket,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Bucket>)
     }
 
     async fn compose_object(
@@ -530,6 +505,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Object;
         self.inner
             .execute(
                 extensions,
@@ -540,12 +516,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Object,
-                    crate::model::Object,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Object>)
     }
 
     async fn delete_object(
@@ -575,6 +546,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -585,7 +557,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn restore_object(
@@ -615,6 +587,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Object;
         self.inner
             .execute(
                 extensions,
@@ -625,12 +598,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Object,
-                    crate::model::Object,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Object>)
     }
 
     async fn get_object(
@@ -660,6 +628,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Object;
         self.inner
             .execute(
                 extensions,
@@ -670,12 +639,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Object,
-                    crate::model::Object,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Object>)
     }
 
     async fn update_object(
@@ -707,6 +671,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Object;
         self.inner
             .execute(
                 extensions,
@@ -717,12 +682,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Object,
-                    crate::model::Object,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Object>)
     }
 
     async fn list_objects(
@@ -752,6 +712,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::ListObjectsResponse;
         self.inner
             .execute(
                 extensions,
@@ -762,12 +723,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::ListObjectsResponse,
-                    crate::model::ListObjectsResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListObjectsResponse>)
     }
 
     async fn rewrite_object(
@@ -806,6 +762,7 @@ impl super::stub::Storage for Storage {
             ])
         };
 
+        type TR = crate::google::storage::v2::RewriteResponse;
         self.inner
             .execute(
                 extensions,
@@ -816,12 +773,7 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::RewriteResponse,
-                    crate::model::RewriteResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::RewriteResponse>)
     }
 
     async fn move_object(
@@ -851,6 +803,7 @@ impl super::stub::Storage for Storage {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::v2::Object;
         self.inner
             .execute(
                 extensions,
@@ -861,11 +814,6 @@ impl super::stub::Storage for Storage {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::v2::Object,
-                    crate::model::Object,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Object>)
     }
 }

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -282,6 +282,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::longrunning::Operation;
         self.inner
             .execute(
                 extensions,
@@ -292,12 +293,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::longrunning::Operation,
-                    longrunning::model::Operation,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, longrunning::model::Operation>)
     }
 
     async fn get_storage_layout(
@@ -568,6 +564,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::longrunning::Operation;
         self.inner
             .execute(
                 extensions,
@@ -578,12 +575,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::longrunning::Operation,
-                    longrunning::model::Operation,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, longrunning::model::Operation>)
     }
 
     async fn update_anywhere_cache(
@@ -625,6 +617,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::longrunning::Operation;
         self.inner
             .execute(
                 extensions,
@@ -635,12 +628,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::longrunning::Operation,
-                    longrunning::model::Operation,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, longrunning::model::Operation>)
     }
 
     async fn disable_anywhere_cache(
@@ -912,6 +900,7 @@ impl super::stub::StorageControl for StorageControl {
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
+        type TR = crate::google::longrunning::Operation;
         self.inner
             .execute(
                 extensions,
@@ -922,11 +911,6 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::longrunning::Operation,
-                    longrunning::model::Operation,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, longrunning::model::Operation>)
     }
 }

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -86,6 +86,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::Folder;
         self.inner
             .execute(
                 extensions,
@@ -96,12 +97,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::Folder,
-                    crate::model::Folder,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Folder>)
     }
 
     async fn delete_folder(
@@ -141,6 +137,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -151,7 +148,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn get_folder(
@@ -191,6 +188,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::Folder;
         self.inner
             .execute(
                 extensions,
@@ -201,12 +199,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::Folder,
-                    crate::model::Folder,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::Folder>)
     }
 
     async fn list_folders(
@@ -238,6 +231,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::ListFoldersResponse;
         self.inner
             .execute(
                 extensions,
@@ -248,12 +242,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::ListFoldersResponse,
-                    crate::model::ListFoldersResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListFoldersResponse>)
     }
 
     async fn rename_folder(
@@ -348,6 +337,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::StorageLayout;
         self.inner
             .execute(
                 extensions,
@@ -358,12 +348,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::StorageLayout,
-                    crate::model::StorageLayout,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::StorageLayout>)
     }
 
     async fn create_managed_folder(
@@ -395,6 +380,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::ManagedFolder;
         self.inner
             .execute(
                 extensions,
@@ -405,12 +391,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::ManagedFolder,
-                    crate::model::ManagedFolder,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ManagedFolder>)
     }
 
     async fn delete_managed_folder(
@@ -450,6 +431,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = ();
         self.inner
             .execute(
                 extensions,
@@ -460,7 +442,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(gaxi::grpc::to_gax_response::<(), ()>)
+            .and_then(gaxi::grpc::to_gax_response::<TR, ()>)
     }
 
     async fn get_managed_folder(
@@ -500,6 +482,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::ManagedFolder;
         self.inner
             .execute(
                 extensions,
@@ -510,12 +493,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::ManagedFolder,
-                    crate::model::ManagedFolder,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ManagedFolder>)
     }
 
     async fn list_managed_folders(
@@ -547,6 +525,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::ListManagedFoldersResponse;
         self.inner
             .execute(
                 extensions,
@@ -557,12 +536,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::ListManagedFoldersResponse,
-                    crate::model::ListManagedFoldersResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListManagedFoldersResponse>)
     }
 
     async fn create_anywhere_cache(
@@ -706,6 +680,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::AnywhereCache;
         self.inner
             .execute(
                 extensions,
@@ -716,12 +691,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::AnywhereCache,
-                    crate::model::AnywhereCache,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::AnywhereCache>)
     }
 
     async fn pause_anywhere_cache(
@@ -761,6 +731,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::AnywhereCache;
         self.inner
             .execute(
                 extensions,
@@ -771,12 +742,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::AnywhereCache,
-                    crate::model::AnywhereCache,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::AnywhereCache>)
     }
 
     async fn resume_anywhere_cache(
@@ -816,6 +782,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::AnywhereCache;
         self.inner
             .execute(
                 extensions,
@@ -826,12 +793,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::AnywhereCache,
-                    crate::model::AnywhereCache,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::AnywhereCache>)
     }
 
     async fn get_anywhere_cache(
@@ -871,6 +833,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::AnywhereCache;
         self.inner
             .execute(
                 extensions,
@@ -881,12 +844,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::AnywhereCache,
-                    crate::model::AnywhereCache,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::AnywhereCache>)
     }
 
     async fn list_anywhere_caches(
@@ -918,6 +876,7 @@ impl super::stub::StorageControl for StorageControl {
             .map(|v| ("bucket", v))])
         };
 
+        type TR = crate::google::storage::control::v2::ListAnywhereCachesResponse;
         self.inner
             .execute(
                 extensions,
@@ -928,12 +887,7 @@ impl super::stub::StorageControl for StorageControl {
                 &x_goog_request_params,
             )
             .await
-            .map(
-                gaxi::grpc::to_gax_response::<
-                    crate::google::storage::control::v2::ListAnywhereCachesResponse,
-                    crate::model::ListAnywhereCachesResponse,
-                >,
-            )
+            .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ListAnywhereCachesResponse>)
     }
 
     async fn get_operation(


### PR DESCRIPTION
Part of the work for #2037 

`cnv()` can fail, so `to_gax_response()` can fail, as well.

I considered just unrolling the function, but it has a nice unit test, so let's keep it where it is.